### PR TITLE
Fix a bug where the formatter was not being used correctly

### DIFF
--- a/packages/ilib-lint/docs/ReleaseNotes.md
+++ b/packages/ilib-lint/docs/ReleaseNotes.md
@@ -3,6 +3,7 @@ Release Notes
 
 ### v2.6.0
 
+- fixed a bug where the results were not formatted properly when using the ansi-console-formatter
 - added XliffSerializer, LineSerializer, and StringSerializer classes generate the
   text of modified files
     - not used yet -- this is in preparation for the implementation of autofixing

--- a/packages/ilib-lint/package.json
+++ b/packages/ilib-lint/package.json
@@ -73,8 +73,8 @@
     },
     "dependencies": {
         "@formatjs/intl": "^2.10.4",
-        "ilib-common": "workspace:*",
-        "ilib-lint-common": "workspace:*",
+        "ilib-common": "^1.1.3",
+        "ilib-lint-common": "^3.1.0",
         "ilib-locale": "^1.2.2",
         "ilib-localeinfo": "^1.1.0",
         "ilib-tools-common": "^1.11.0",

--- a/packages/ilib-lint/src/Project.js
+++ b/packages/ilib-lint/src/Project.js
@@ -56,6 +56,20 @@ const unknownFileTypeDefinition = {
 };
 
 /**
+ * Return true if the given method name is a method that is
+ * defined in the class itself and not inherited from a parent
+ * class.
+ *
+ * @private
+ * @param {Object} instance the instance to check
+ * @param {String} methodName the name of the method to check
+ * @returns {boolean} true if the method is defined in the class itself
+ */
+function isOwnMethod(instance, methodName) {
+    return typeof(instance[methodName]) === 'function' && instance[methodName].prototype === instance;
+}
+
+/**
  * @class Represent an ilin-lint project.
  *
  * A project is defined as a root directory and a configuration that
@@ -596,7 +610,7 @@ class Project extends DirItem {
             maxFractionDigits: 2
         });
         const score = this.getScore();
-        if (typeof (this.formatter.formatOutput) === "function") {
+        if (isOwnMethod(this.formatter, "formatOutput")) {
             resultAll = this.formatter.formatOutput({
                 name: this.options.opt.name || this.project.name,
                 fileStats: this.fileStats,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,11 +118,11 @@ importers:
         specifier: ^2.10.4
         version: 2.10.11(typescript@5.6.3)
       ilib-common:
-        specifier: workspace:*
-        version: link:../ilib-common
+        specifier: ^1.1.3
+        version: 1.1.3
       ilib-lint-common:
-        specifier: workspace:*
-        version: link:../ilib-lint-common
+        specifier: ^3.1.0
+        version: 3.1.0
       ilib-locale:
         specifier: ^1.2.2
         version: 1.2.2
@@ -2552,8 +2552,8 @@ packages:
   ilib-env@1.4.0:
     resolution: {integrity: sha512-zDpTmrGMvg9P40TtelR3k+eIFPd1VZA9TmB/5dXKEona6TQBObe6/D9zgmoLf17mI0kBg8ho+q1T42EJGvB5mg==}
 
-  ilib-lint-common@3.0.0:
-    resolution: {integrity: sha512-IfnSrxQWEB02cZwFldrHHM/nMKV+tpwLP2zDWy91QvBXLpSMQHcHmBICx9dsiooOFMLG4gpCDRFOm5F3YgBOqw==}
+  ilib-lint-common@3.1.0:
+    resolution: {integrity: sha512-e02KHTG/MPi+4Qp/VHali0oH7kTVk0kT1q+busjBVKRUNG/fep1b1Fu6otUodgMK+aJfDTX8MYPe5iI8cpbF4Q==}
     engines: {node: '>=14.0.0'}
 
   ilib-lint-plugin-obsolete@file:packages/ilib-lint/test/ilib-lint-plugin-obsolete:
@@ -7839,7 +7839,7 @@ snapshots:
 
   ilib-env@1.4.0: {}
 
-  ilib-lint-common@3.0.0: {}
+  ilib-lint-common@3.1.0: {}
 
   ilib-lint-plugin-obsolete@file:packages/ilib-lint/test/ilib-lint-plugin-obsolete:
     dependencies:
@@ -7850,7 +7850,7 @@ snapshots:
 
   ilib-lint-plugin-test@file:packages/ilib-lint/test/ilib-lint-plugin-test:
     dependencies:
-      ilib-lint-common: 3.0.0
+      ilib-lint-common: 3.1.0
       ilib-locale: 1.2.2
       ilib-tools-common: 1.11.0
       json5: 2.2.3


### PR DESCRIPTION
- did not correctly detect whether or not the formatter defined its own formatOutput() method or just inherited it from its parent, causing it not to give any output at all
- this merges into the update-ilib-lint branch first and then that should get merged to main