### PR TITLE
Fix pipeline failures due to executor resources exhausted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
         executor:
             name: node/default
             tag: 20.18-browsers
+            resource_class: xlarge
         environment:
             TURBO_UI: "false"
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,4 +21,4 @@ jobs:
             - run:
                   command: pnpm build
             - run:
-                  command: pnpm test
+                  command: pnpm test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,25 @@
 version: 2.1
+
 orbs:
     node: circleci/node@6.3.0
     browser-tools: circleci/browser-tools@1.4.8
+
 workflows:
     test:
         jobs:
-            - test
+            - test-all:
+                  filters:
+                      branches:
+                          only:
+                              - main
+            - test-affected:
+                  filters:
+                      branches:
+                          ignore:
+                              - main
+
 jobs:
-    test:
+    test-all:
         executor:
             name: node/default
             tag: 20.18-browsers
@@ -22,3 +34,18 @@ jobs:
                   command: pnpm build
             - run:
                   command: pnpm test:ci
+    test-affected:
+        executor:
+            name: node/default
+            tag: 20.18-browsers
+        environment:
+            TURBO_UI: "false"
+        steps:
+            - browser-tools/install-chrome
+            - checkout
+            - node/install-packages:
+                  pkg-manager: pnpm
+            - run:
+                  command: pnpm build
+            - run:
+                  command: pnpm test:ci:affected

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,6 @@ jobs:
             - node/install-packages:
                   pkg-manager: pnpm
             - run:
-                  command: pnpm build
-            - run:
                   command: pnpm test:ci
     test-affected:
         executor:
@@ -45,7 +43,5 @@ jobs:
             - checkout
             - node/install-packages:
                   pkg-manager: pnpm
-            - run:
-                  command: pnpm build
             - run:
                   command: pnpm test:ci:affected

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
         executor:
             name: node/default
             tag: 20.18-browsers
-            resource_class: xlarge
         environment:
             TURBO_UI: "false"
         steps:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "turbo build",
     "test": "turbo test",
+    "test:ci": "turbo test --concurrency=5",
     "doc": "turbo doc"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee",
   "scripts": {
     "build": "turbo build",
-    "test": "turbo test",
+    "test": "pnpm test:affected",
+    "test:affected": "turbo test --affected --output-logs=new-only",
+    "test:all": "turbo test",
+    "test:all:force": "turbo test --force",
     "test:ci": "turbo test --concurrency=5",
+    "test:ci:affected": "pnpm test:ci --affected",
     "doc": "turbo doc"
   },
   "devDependencies": {


### PR DESCRIPTION
- Halved turborepo concurrency in CI runs
- Running only affected tests on the PR, kept running everything on the main branch

This is to fix red CI due to `node[5874]: pthread_create: Resource temporarily unavailable`