### PR TITLE
loctool: Add support for converting string target with tag nodes to plural

### DIFF
--- a/packages/loctool/lib/ResourceConvert.js
+++ b/packages/loctool/lib/ResourceConvert.js
@@ -65,33 +65,31 @@ function reconstructString(node) {
         case NodeType.literal:
             return node.value;
         case NodeType.argument:
-            return `{${node.value}}`;
+            return "{" + node.value + "}";
         case NodeType.number:
-            return `{${node.value}, number}`;
+            return "{" + node.value + ", number}";
         case NodeType.date:
-            return `{${node.value}, date}`;
+            return "{" + node.value + ", date}";
         case NodeType.time:
-            return `{${node.value}, time}`;
+            return "{" + node.value + ", time}";
         case NodeType.select: {
-            const options = Object.entries(node.options).map(entry => `${entry[0]} {${reconstructString(entry[1].value)}}`).join(' ');
+            const options = Object.entries(node.options).map(function (entry) {
+                return entry[0] + " {" + reconstructString(entry[1].value) + "}";
+            }).join(' ');
 
-            return `{${node.value}, select, ${options}}`;
+            return "{" + node.value + ", select, " + options + "}";
         }
         case NodeType.plural: {
             const options = Object.entries(node.options).map(entry => `${entry[0]} {${reconstructString(entry[1].value)}}`).join(' ');
 
-            return `{${node.value}, plural, ${options}}`;
+            return "{" + node.value + ", plural, " + options + "}";
         }
         case NodeType.tag:
             const children = reconstructString(node.children);
 
-            return `<${node.value}>${children}</${node.value}>`;
+            return "<" + node.value + ">" + children + "</" + node.value + ">";
         default:
-            throw new Error(`
-                Unsupported AST node type:
-                    * node type: ${node.type} (${Object.keys(NodeType).find(key => NodeType[key] === node.type)});
-                    * node value: ${node.value}
-            `);
+            throw new Error('Unsupported AST node type: ' + node.type);
     }
 }
 

--- a/packages/loctool/test/ResourceConvert.test.js
+++ b/packages/loctool/test/ResourceConvert.test.js
@@ -22,8 +22,8 @@ const ResourceString = require("../lib/ResourceString.js");
 const ResourceArray = require("../lib/ResourceArray.js");
 const convert = require("../lib/ResourceConvert.js");
 
-describe("convertPluralResToICU", function() {
-    test("converts plural source to string", function() {
+describe("convertPluralResToICU", function () {
+    test("converts plural source to string", function () {
         const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
@@ -44,7 +44,7 @@ describe("convertPluralResToICU", function() {
         expect(string.getSource()).toBe(expected);
     });
 
-    test("converts plural source to string in a source-only resource", function() {
+    test("converts plural source to string in a source-only resource", function () {
         const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
@@ -63,7 +63,7 @@ describe("convertPluralResToICU", function() {
         expect(string.getTargetLocale()).toBeUndefined();
     });
 
-    test("converts plural target to string", function() {
+    test("converts plural target to string", function () {
         const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
@@ -84,7 +84,7 @@ describe("convertPluralResToICU", function() {
         expect(string.getTarget()).toBe(expected);
     });
 
-    test("converts plural source to string when the target has more plural categories than the source", function() {
+    test("converts plural source to string when the target has more plural categories than the source", function () {
         const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
@@ -106,7 +106,7 @@ describe("convertPluralResToICU", function() {
         expect(string.getSource()).toBe(expected);
     });
 
-    test("converts plural target to string when the target has more plural categories than the source", function() {
+    test("converts plural target to string when the target has more plural categories than the source", function () {
         const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
@@ -128,7 +128,7 @@ describe("convertPluralResToICU", function() {
         expect(string.getTarget()).toBe(expected);
     });
 
-    test("converts plural source to string when the target has less plural categories than the source", function() {
+    test("converts plural source to string when the target has less plural categories than the source", function () {
         const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
@@ -148,7 +148,7 @@ describe("convertPluralResToICU", function() {
         expect(string.getSource()).toBe(expected);
     });
 
-    test("converts plural target to string when the target has less plural categories than the source", function() {
+    test("converts plural target to string when the target has less plural categories than the source", function () {
         const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
@@ -168,7 +168,7 @@ describe("convertPluralResToICU", function() {
         expect(string.getTarget()).toBe(expected);
     });
 
-    test("don't convert array resources to a string", function() {
+    test("don't convert array resources to a string", function () {
         const plural = new ResourceArray({
             sourceLocale: "en-US",
             sourceArray: [
@@ -187,7 +187,7 @@ describe("convertPluralResToICU", function() {
         expect(string).toBeUndefined(); // no conversion
     });
 
-    test("don't convert string resources to a different string", function() {
+    test("don't convert string resources to a different string", function () {
         const plural = new ResourceString({
             sourceLocale: "en-US",
             source: "There is 1 string.",
@@ -200,7 +200,7 @@ describe("convertPluralResToICU", function() {
         expect(string).toBeUndefined(); // no conversion
     });
 
-    test("converts string source to plural", function() {
+    test("converts string source to plural", function () {
         const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
@@ -218,7 +218,7 @@ describe("convertPluralResToICU", function() {
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
     });
 
-    test("converts string source to plural in a source-only resource", function() {
+    test("converts string source to plural in a source-only resource", function () {
         const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}"
@@ -237,7 +237,7 @@ describe("convertPluralResToICU", function() {
         expect(plural.getTargetLocale()).toBeUndefined();
     });
 
-    test("converts plural source to string preserves all other fields", function() {
+    test("converts plural source to string preserves all other fields", function () {
         const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
@@ -274,7 +274,7 @@ describe("convertPluralResToICU", function() {
 });
 
 describe("convertICUToPluralRes", () => {
-    test("converts string target to plural", function() {
+    test("converts string target to plural", function () {
         const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
@@ -286,41 +286,56 @@ describe("convertICUToPluralRes", () => {
             other: "Es gibt {n} Zeichenfolgen.",
         };
 
-        const  plural = convert.convertICUToPluralRes(string);
+        const plural = convert.convertICUToPluralRes(string);
 
         expect(plural.getType()).toBe("plural");
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
     });
 
-    test("converts string target to plural when it contains HTML tags", function() {
-        const string = new ResourceString({
-            sourceLocale: "en-US",
+    test.each([
+        {
+q            name: "flat tags",
             source: "{count, plural, one {There is {n} <b>string</b>.} other {There are {n} <b>strings</b>.}}",
-            targetLocale: "de-DE",
             target: "{count, plural,  one {Es gibt {n} <b>Zeichenfolge</b>.} other {Es gibt {n} <b>Zeichenfolgen</b>.}}",
-        });
-        const expected = {
-            one: "Es gibt {n} <b>Zeichenfolge</b>.",
-            other: "Es gibt {n} <b>Zeichenfolgen</b>.",
-        };
-
-        const plural = convert.convertICUToPluralRes(string);
-
-        expect(plural.getType()).toBe("plural");
-        expect(plural.getTargetPlurals()).toStrictEqual(expected);
-    });
-
-    test("converts string target to plural when it contains nested HTML tags", function() {
+            expected: {
+                one: "Es gibt {n} <b>Zeichenfolge</b>.",
+                other: "Es gibt {n} <b>Zeichenfolgen</b>.",
+            }
+        },
+        {
+            name: "self-closing tags",
+            source: "{count, plural, one {There is {n} <img/>string.} other {There are {n} <img/>strings.}}",
+            target: "{count, plural,  one {Es gibt {n} <img/>Zeichenfolge.} other {Es gibt {n} <img/>Zeichenfolgen.}}",
+            expected: {
+                one: "Es gibt {n} <img/>Zeichenfolge.",
+                other: "Es gibt {n} <img/>Zeichenfolgen.",
+            }
+        },
+        {
+            name: "open-close tags with no child node",
+            source: "{count, plural, one {There is {n} <b></b>string.} other {There are {n} <b></b>strings.}}",
+            target: "{count, plural,  one {Es gibt {n} <b></b>Zeichenfolge.} other {Es gibt {n} <b></b>Zeichenfolgen.}}",
+            expected: {
+                one: "Es gibt {n} <b></b>Zeichenfolge.",
+                other: "Es gibt {n} <b></b>Zeichenfolgen.",
+            }
+        },
+        {
+            name: "nested tags",
+            source: "{count, plural, one {There is {n} <span><b>string</b></span>.} other {There are {n} <span><b>strings</b></span>.}}",
+            target: "{count, plural,  one {Es gibt {n} <span><b>Zeichenfolge</b></span>.} other {Es gibt {n} <span><b>Zeichenfolgen</b></span>.}}",
+            expected: {
+                one: "Es gibt {n} <span><b>Zeichenfolge</b></span>.",
+                other: "Es gibt {n} <span><b>Zeichenfolgen</b></span>.",
+            }
+        },
+    ])("converts string target to plural when it contains $name", function ({source, target, expected}) {
         const string = new ResourceString({
             sourceLocale: "en-US",
-            source: "{count, plural, one {There is {n} <span><b>string</b></span>.} other {There are {n} <span><b>strings</b></span>.}}",
+            source,
             targetLocale: "de-DE",
-            target: "{count, plural,  one {Es gibt {n} <span><b>Zeichenfolge</b></span>.} other {Es gibt {n} <span><b>Zeichenfolgen</b></span>.}}",
+            target,
         });
-        const expected = {
-            one: "Es gibt {n} <span><b>Zeichenfolge</b></span>.",
-            other: "Es gibt {n} <span><b>Zeichenfolgen</b></span>.",
-        };
 
         const plural = convert.convertICUToPluralRes(string);
 
@@ -328,7 +343,24 @@ describe("convertICUToPluralRes", () => {
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
     });
 
-    test("converts string source to plural when the target has more plural categories than the source", function() {
+    test("throws SyntaxError when converting string target with unclosed tag to plural ", () => {
+        const consoleSpy = jest.spyOn(console, "log").mockImplementationOnce(() => {});
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} <b>string.} other {There are {n} <b>strings.}}",
+            targetLocale: "de-DE",
+            target: "{count, plural,  one {Es gibt {n} <b>Zeichenfolge.} other {Es gibt {n} <b>Zeichenfolgen.}}"
+        });
+
+        convert.convertICUToPluralRes(string);
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.any(SyntaxError));
+        expect(consoleSpy).toHaveBeenCalledWith(expect.objectContaining({ message: "UNCLOSED_TAG" }));
+
+        consoleSpy.mockRestore();
+    });
+
+    test("converts string source to plural when the target has more plural categories than the source", function () {
         const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
@@ -346,7 +378,7 @@ describe("convertICUToPluralRes", () => {
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
     });
 
-    test("converts string target to plural when the target has more plural categories than the source", function() {
+    test("converts string target to plural when the target has more plural categories than the source", function () {
         const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
@@ -365,7 +397,7 @@ describe("convertICUToPluralRes", () => {
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
     });
 
-    test("converts string source to plural when the target has less plural categories than the source", function() {
+    test("converts string source to plural when the target has less plural categories than the source", function () {
         const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
@@ -383,7 +415,7 @@ describe("convertICUToPluralRes", () => {
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
     });
 
-    test("converts string target to plural when the target has less plural categories than the source", function() {
+    test("converts string target to plural when the target has less plural categories than the source", function () {
         const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
@@ -400,7 +432,7 @@ describe("convertICUToPluralRes", () => {
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
     });
 
-    test("converts string target to plural, preserving all other fields", function() {
+    test("converts string target to plural, preserving all other fields", function () {
         const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
@@ -432,7 +464,7 @@ describe("convertICUToPluralRes", () => {
         expect(string.getState()).toBe("new");
     });
 
-    test("does not convert non-plural string to plural", function() {
+    test("does not convert non-plural string to plural", function () {
         const string = new ResourceString({
             sourceLocale: "en-US",
             source: "There is 1 string.",
@@ -445,7 +477,7 @@ describe("convertICUToPluralRes", () => {
         expect(plural).toBeUndefined();
     });
 
-    test("does not convert array to plural", function() {
+    test("does not convert array to plural", function () {
         const array = new ResourceArray({
             key: "c",
             sourceLocale: "en-US",
@@ -467,7 +499,7 @@ describe("convertICUToPluralRes", () => {
         expect(plural).toBeUndefined();
     });
 
-    test("does not convert plural to another plural", function() {
+    test("does not convert plural to another plural", function () {
         let plural = new ResourcePlural({
             key: "a",
             sourceLocale: "en-US",

--- a/packages/loctool/test/ResourceConvert.test.js
+++ b/packages/loctool/test/ResourceConvert.test.js
@@ -17,14 +17,14 @@
  * limitations under the License.
  */
 
-const ResourcePlural = require("../lib/ResourcePlural.js");
-const ResourceString = require("../lib/ResourceString.js");
-const ResourceArray = require("../lib/ResourceArray.js");
-const convert = require("../lib/ResourceConvert.js");
+var ResourcePlural = require("../lib/ResourcePlural.js");
+var ResourceString = require("../lib/ResourceString.js");
+var ResourceArray = require("../lib/ResourceArray.js");
+var convert = require("../lib/ResourceConvert.js");
 
 describe("convertPluralResToICU", function () {
     test("converts plural source to string", function () {
-        const plural = new ResourcePlural({
+        var plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} string.",
@@ -36,25 +36,25 @@ describe("convertPluralResToICU", function () {
                 other: "Es gibt {n} Zeichenfolgen.",
             }
         });
-        const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        var expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
 
-        const string = convert.convertPluralResToICU(plural);
+        var string = convert.convertPluralResToICU(plural);
 
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
     });
 
     test("converts plural source to string in a source-only resource", function () {
-        const plural = new ResourcePlural({
+        var plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} string.",
                 other: "There are {n} strings."
             }
         });
-        const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        var expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
 
-        const string = convert.convertPluralResToICU(plural);
+        var string = convert.convertPluralResToICU(plural);
 
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
@@ -64,7 +64,7 @@ describe("convertPluralResToICU", function () {
     });
 
     test("converts plural target to string", function () {
-        const plural = new ResourcePlural({
+        var plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} string.",
@@ -76,16 +76,16 @@ describe("convertPluralResToICU", function () {
                 other: "Es gibt {n} Zeichenfolgen.",
             }
         });
-        const expected = "{count, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}";
+        var expected = "{count, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}";
 
-        const string = convert.convertPluralResToICU(plural);
+        var string = convert.convertPluralResToICU(plural);
 
         expect(string.getType()).toBe("string");
         expect(string.getTarget()).toBe(expected);
     });
 
     test("converts plural source to string when the target has more plural categories than the source", function () {
-        const plural = new ResourcePlural({
+        var plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} item.",
@@ -98,16 +98,16 @@ describe("convertPluralResToICU", function () {
                 other: "Jest {n} pozycji.",
             }
         });
-        const expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
+        var expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
 
-        const string = convert.convertPluralResToICU(plural);
+        var string = convert.convertPluralResToICU(plural);
 
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
     });
 
     test("converts plural target to string when the target has more plural categories than the source", function () {
-        const plural = new ResourcePlural({
+        var plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} item.",
@@ -120,16 +120,16 @@ describe("convertPluralResToICU", function () {
                 other: "Jest {n} pozycji.",
             }
         });
-        const expected = "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}";
+        var expected = "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}";
 
-        const string = convert.convertPluralResToICU(plural);
+        var string = convert.convertPluralResToICU(plural);
 
         expect(string.getType()).toBe("string");
         expect(string.getTarget()).toBe(expected);
     });
 
     test("converts plural source to string when the target has less plural categories than the source", function () {
-        const plural = new ResourcePlural({
+        var plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} item.",
@@ -140,16 +140,16 @@ describe("convertPluralResToICU", function () {
                 other: "{n}1件の商品があります。",
             }
         });
-        const expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
+        var expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
 
-        const string = convert.convertPluralResToICU(plural);
+        var string = convert.convertPluralResToICU(plural);
 
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
     });
 
     test("converts plural target to string when the target has less plural categories than the source", function () {
-        const plural = new ResourcePlural({
+        var plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} item.",
@@ -160,16 +160,16 @@ describe("convertPluralResToICU", function () {
                 other: "{n}1件の商品があります。",
             }
         });
-        const expected = "{count, plural, other {{n}1件の商品があります。}}";
+        var expected = "{count, plural, other {{n}1件の商品があります。}}";
 
-        const string = convert.convertPluralResToICU(plural);
+        var string = convert.convertPluralResToICU(plural);
 
         expect(string.getType()).toBe("string");
         expect(string.getTarget()).toBe(expected);
     });
 
     test("don't convert array resources to a string", function () {
-        const plural = new ResourceArray({
+        var plural = new ResourceArray({
             sourceLocale: "en-US",
             sourceArray: [
                 "There is 1 string.",
@@ -182,53 +182,53 @@ describe("convertPluralResToICU", function () {
             ]
         });
 
-        const string = convert.convertPluralResToICU(plural);
+        var string = convert.convertPluralResToICU(plural);
 
         expect(string).toBeUndefined(); // no conversion
     });
 
     test("don't convert string resources to a different string", function () {
-        const plural = new ResourceString({
+        var plural = new ResourceString({
             sourceLocale: "en-US",
             source: "There is 1 string.",
             targetLocale: "de-DE",
             target: "Es gibt 1 Zeichenfolge."
         });
 
-        const string = convert.convertPluralResToICU(plural);
+        var string = convert.convertPluralResToICU(plural);
 
         expect(string).toBeUndefined(); // no conversion
     });
 
     test("converts string source to plural", function () {
-        const string = new ResourceString({
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "de-DE",
             target: "{count, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
         });
-        const expected = {
+        var expected = {
             one: "There is {n} string.",
             other: "There are {n} strings."
         };
 
-        const plural = convert.convertICUToPluralRes(string);
+        var plural = convert.convertICUToPluralRes(string);
 
         expect(plural.getType()).toBe("plural");
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
     });
 
     test("converts string source to plural in a source-only resource", function () {
-        const string = new ResourceString({
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}"
         });
-        const expected = {
+        var expected = {
             one: "There is {n} string.",
             other: "There are {n} strings."
         };
 
-        const plural = convert.convertICUToPluralRes(string);
+        var plural = convert.convertICUToPluralRes(string);
 
         expect(plural.getType()).toBe("plural");
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
@@ -238,7 +238,7 @@ describe("convertPluralResToICU", function () {
     });
 
     test("converts plural source to string preserves all other fields", function () {
-        const plural = new ResourcePlural({
+        var plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} string.",
@@ -257,9 +257,9 @@ describe("convertPluralResToICU", function () {
             comment: "no comment",
             state: "new"
         });
-        const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        var expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
 
-        const string = convert.convertPluralResToICU(plural);
+        var string = convert.convertPluralResToICU(plural);
 
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
@@ -275,18 +275,18 @@ describe("convertPluralResToICU", function () {
 
 describe("convertICUToPluralRes", () => {
     test("converts string target to plural", function () {
-        const string = new ResourceString({
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "de-DE",
             target: "{count, plural,  one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
         });
-        const expected = {
+        var expected = {
             one: "Es gibt {n} Zeichenfolge.",
             other: "Es gibt {n} Zeichenfolgen.",
         };
 
-        const plural = convert.convertICUToPluralRes(string);
+        var plural = convert.convertICUToPluralRes(string);
 
         expect(plural.getType()).toBe("plural");
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
@@ -294,7 +294,7 @@ describe("convertICUToPluralRes", () => {
 
     test.each([
         {
-q            name: "flat tags",
+            name: "flat tags",
             source: "{count, plural, one {There is {n} <b>string</b>.} other {There are {n} <b>strings</b>.}}",
             target: "{count, plural,  one {Es gibt {n} <b>Zeichenfolge</b>.} other {Es gibt {n} <b>Zeichenfolgen</b>.}}",
             expected: {
@@ -330,22 +330,23 @@ q            name: "flat tags",
             }
         },
     ])("converts string target to plural when it contains $name", function ({source, target, expected}) {
-        const string = new ResourceString({
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source,
             targetLocale: "de-DE",
             target,
         });
 
-        const plural = convert.convertICUToPluralRes(string);
+        var plural = convert.convertICUToPluralRes(string);
 
         expect(plural.getType()).toBe("plural");
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
     });
 
     test("throws SyntaxError when converting string target with unclosed tag to plural ", () => {
-        const consoleSpy = jest.spyOn(console, "log").mockImplementationOnce(() => {});
-        const string = new ResourceString({
+        var consoleSpy = jest.spyOn(console, "log").mockImplementationOnce(() => {
+        });
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} <b>string.} other {There are {n} <b>strings.}}",
             targetLocale: "de-DE",
@@ -355,85 +356,85 @@ q            name: "flat tags",
         convert.convertICUToPluralRes(string);
 
         expect(consoleSpy).toHaveBeenCalledWith(expect.any(SyntaxError));
-        expect(consoleSpy).toHaveBeenCalledWith(expect.objectContaining({ message: "UNCLOSED_TAG" }));
+        expect(consoleSpy).toHaveBeenCalledWith(expect.objectContaining({message: "UNCLOSED_TAG"}));
 
         consoleSpy.mockRestore();
     });
 
     test("converts string source to plural when the target has more plural categories than the source", function () {
-        const string = new ResourceString({
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "pl-PL",
             target: "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}"
         });
-        const expected = {
+        var expected = {
             one: "There is {n} string.",
             other: "There are {n} strings."
         };
 
-        const plural = convert.convertICUToPluralRes(string);
+        var plural = convert.convertICUToPluralRes(string);
 
         expect(plural.getType()).toBe("plural");
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
     });
 
     test("converts string target to plural when the target has more plural categories than the source", function () {
-        const string = new ResourceString({
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "pl-PL",
             target: "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}"
         });
-        const expected = {
+        var expected = {
             one: "Jest {n} pozycja.",
             few: "Jest {n} pozycje.",
             other: "Jest {n} pozycji.",
         };
 
-        const plural = convert.convertICUToPluralRes(string);
+        var plural = convert.convertICUToPluralRes(string);
 
         expect(plural.getType()).toBe("plural");
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
     });
 
     test("converts string source to plural when the target has less plural categories than the source", function () {
-        const string = new ResourceString({
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "ja-JP",
             target: "{count, plural, other {{n}1件の商品があります。}}"
         });
-        const expected = {
+        var expected = {
             one: "There is {n} string.",
             other: "There are {n} strings."
         };
 
-        const plural = convert.convertICUToPluralRes(string);
+        var plural = convert.convertICUToPluralRes(string);
 
         expect(plural.getType()).toBe("plural");
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
     });
 
     test("converts string target to plural when the target has less plural categories than the source", function () {
-        const string = new ResourceString({
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "ja-JP",
             target: "{count, plural, other {{n}1件の商品があります。}}"
         });
-        const expected = {
+        var expected = {
             other: "{n}1件の商品があります。",
         };
 
-        const plural = convert.convertICUToPluralRes(string);
+        var plural = convert.convertICUToPluralRes(string);
 
         expect(plural.getType()).toBe("plural");
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
     });
 
     test("converts string target to plural, preserving all other fields", function () {
-        const string = new ResourceString({
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "de-DE",
@@ -446,12 +447,12 @@ q            name: "flat tags",
             comment: "no comment",
             state: "new"
         });
-        const expected = {
+        var expected = {
             one: "Es gibt {n} Zeichenfolge.",
             other: "Es gibt {n} Zeichenfolgen.",
         };
 
-        const plural = convert.convertICUToPluralRes(string);
+        var plural = convert.convertICUToPluralRes(string);
 
         expect(plural.getType()).toBe("plural");
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
@@ -465,20 +466,20 @@ q            name: "flat tags",
     });
 
     test("does not convert non-plural string to plural", function () {
-        const string = new ResourceString({
+        var string = new ResourceString({
             sourceLocale: "en-US",
             source: "There is 1 string.",
             targetLocale: "de-DE",
             target: "Es gibt 1 Zeichenfolge."
         });
 
-        const plural = convert.convertICUToPluralRes(string);
+        var plural = convert.convertICUToPluralRes(string);
 
         expect(plural).toBeUndefined();
     });
 
     test("does not convert array to plural", function () {
-        const array = new ResourceArray({
+        var array = new ResourceArray({
             key: "c",
             sourceLocale: "en-US",
             sourceArray: [
@@ -494,13 +495,13 @@ q            name: "flat tags",
             ]
         });
 
-        const plural = convert.convertICUToPluralRes(array);
+        var plural = convert.convertICUToPluralRes(array);
 
         expect(plural).toBeUndefined();
     });
 
     test("does not convert plural to another plural", function () {
-        let plural = new ResourcePlural({
+        var plural = new ResourcePlural({
             key: "a",
             sourceLocale: "en-US",
             sourceStrings: {

--- a/packages/loctool/test/ResourceConvert.test.js
+++ b/packages/loctool/test/ResourceConvert.test.js
@@ -17,17 +17,14 @@
  * limitations under the License.
  */
 
-var ResourcePlural = require("../lib/ResourcePlural.js");
-var ResourceString = require("../lib/ResourceString.js");
-var ResourceArray = require("../lib/ResourceArray.js");
-var TranslationSet = require("../lib/TranslationSet.js");
-var conv = require("../lib/ResourceConvert.js");
+const ResourcePlural = require("../lib/ResourcePlural.js");
+const ResourceString = require("../lib/ResourceString.js");
+const ResourceArray = require("../lib/ResourceArray.js");
+const convert = require("../lib/ResourceConvert.js");
 
-describe("resource conversion functions", function() {
-    test("convert plural source to string", function() {
-        expect.assertions(2);
-
-        var plural = new ResourcePlural({
+describe("convertPluralResToICU", function() {
+    test("converts plural source to string", function() {
+        const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} string.",
@@ -39,38 +36,35 @@ describe("resource conversion functions", function() {
                 other: "Es gibt {n} Zeichenfolgen.",
             }
         });
+        const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
 
-        var string = conv.convertPluralResToICU(plural);
-        var expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        const string = convert.convertPluralResToICU(plural);
+
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
     });
 
-    test("convert plural source to string in a source-only resource", function() {
-        expect.assertions(5);
-
-        var plural = new ResourcePlural({
+    test("converts plural source to string in a source-only resource", function() {
+        const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} string.",
                 other: "There are {n} strings."
             }
         });
+        const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
 
-        var string = conv.convertPluralResToICU(plural);
-        var expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        const string = convert.convertPluralResToICU(plural);
+
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
         expect(string.getSourceLocale()).toBe("en-US");
-
         expect(string.getTarget()).toBeUndefined();
         expect(string.getTargetLocale()).toBeUndefined();
     });
 
-    test("convert plural target to string", function() {
-        expect.assertions(2);
-
-        var plural = new ResourcePlural({
+    test("converts plural target to string", function() {
+        const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} string.",
@@ -82,17 +76,16 @@ describe("resource conversion functions", function() {
                 other: "Es gibt {n} Zeichenfolgen.",
             }
         });
+        const expected = "{count, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}";
 
-        var string = conv.convertPluralResToICU(plural);
-        var expected = "{count, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}";
+        const string = convert.convertPluralResToICU(plural);
+
         expect(string.getType()).toBe("string");
         expect(string.getTarget()).toBe(expected);
     });
 
-    test("convert plural source to string when the target has more plural categories than the source", function() {
-        expect.assertions(2);
-
-        var plural = new ResourcePlural({
+    test("converts plural source to string when the target has more plural categories than the source", function() {
+        const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} item.",
@@ -105,17 +98,16 @@ describe("resource conversion functions", function() {
                 other: "Jest {n} pozycji.",
             }
         });
+        const expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
 
-        var string = conv.convertPluralResToICU(plural);
-        var expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
+        const string = convert.convertPluralResToICU(plural);
+
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
     });
 
-    test("convert plural target to string when the target has more plural categories than the source", function() {
-        expect.assertions(2);
-
-        var plural = new ResourcePlural({
+    test("converts plural target to string when the target has more plural categories than the source", function() {
+        const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} item.",
@@ -128,17 +120,16 @@ describe("resource conversion functions", function() {
                 other: "Jest {n} pozycji.",
             }
         });
+        const expected = "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}";
 
-        var string = conv.convertPluralResToICU(plural);
-        var expected = "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}";
+        const string = convert.convertPluralResToICU(plural);
+
         expect(string.getType()).toBe("string");
         expect(string.getTarget()).toBe(expected);
     });
 
-    test("convert plural source to string when the target has less plural categories than the source", function() {
-        expect.assertions(2);
-
-        var plural = new ResourcePlural({
+    test("converts plural source to string when the target has less plural categories than the source", function() {
+        const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} item.",
@@ -149,17 +140,16 @@ describe("resource conversion functions", function() {
                 other: "{n}1件の商品があります。",
             }
         });
+        const expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
 
-        var string = conv.convertPluralResToICU(plural);
-        var expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
+        const string = convert.convertPluralResToICU(plural);
+
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
     });
 
-    test("convert plural target to string when the target has less plural categories than the source", function() {
-        expect.assertions(2);
-
-        var plural = new ResourcePlural({
+    test("converts plural target to string when the target has less plural categories than the source", function() {
+        const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} item.",
@@ -170,17 +160,16 @@ describe("resource conversion functions", function() {
                 other: "{n}1件の商品があります。",
             }
         });
+        const expected = "{count, plural, other {{n}1件の商品があります。}}";
 
-        var string = conv.convertPluralResToICU(plural);
-        var expected = "{count, plural, other {{n}1件の商品があります。}}";
+        const string = convert.convertPluralResToICU(plural);
+
         expect(string.getType()).toBe("string");
         expect(string.getTarget()).toBe(expected);
     });
 
     test("don't convert array resources to a string", function() {
-        expect.assertions(1);
-
-        var plural = new ResourceArray({
+        const plural = new ResourceArray({
             sourceLocale: "en-US",
             sourceArray: [
                 "There is 1 string.",
@@ -193,70 +182,63 @@ describe("resource conversion functions", function() {
             ]
         });
 
-        var string = conv.convertPluralResToICU(plural);
+        const string = convert.convertPluralResToICU(plural);
 
-        expect(string).toBeUndefined(); // no conversino
+        expect(string).toBeUndefined(); // no conversion
     });
 
     test("don't convert string resources to a different string", function() {
-        expect.assertions(1);
-
-        var plural = new ResourceString({
+        const plural = new ResourceString({
             sourceLocale: "en-US",
             source: "There is 1 string.",
             targetLocale: "de-DE",
             target: "Es gibt 1 Zeichenfolge."
         });
 
-        var string = conv.convertPluralResToICU(plural);
+        const string = convert.convertPluralResToICU(plural);
 
-        expect(string).toBeUndefined(); // no conversino
+        expect(string).toBeUndefined(); // no conversion
     });
 
-    test("convert string source to plural", function() {
-        expect.assertions(2);
-
-        var string = new ResourceString({
+    test("converts string source to plural", function() {
+        const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "de-DE",
             target: "{count, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
         });
-
-        var expected = {
+        const expected = {
             one: "There is {n} string.",
             other: "There are {n} strings."
         };
-        var plural = conv.convertICUToPluralRes(string);
+
+        const plural = convert.convertICUToPluralRes(string);
+
         expect(plural.getType()).toBe("plural");
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
     });
 
-    test("convert string source to plural in a source-only resource", function() {
-        expect.assertions(5);
-
-        var string = new ResourceString({
+    test("converts string source to plural in a source-only resource", function() {
+        const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}"
         });
-
-        var expected = {
+        const expected = {
             one: "There is {n} string.",
             other: "There are {n} strings."
         };
-        var plural = conv.convertICUToPluralRes(string);
+
+        const plural = convert.convertICUToPluralRes(string);
+
         expect(plural.getType()).toBe("plural");
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
         expect(plural.getSourceLocale()).toBe("en-US");
-
         expect(plural.getTargetPlurals()).toBeUndefined();
         expect(plural.getTargetLocale()).toBeUndefined();
     });
 
-    test("convert plural source to string preserves all other fields", function() {
-        expect.assertions(9);
-
-        var plural = new ResourcePlural({
+    test("converts plural source to string preserves all other fields", function() {
+        const plural = new ResourcePlural({
             sourceLocale: "en-US",
             sourceStrings: {
                 one: "There is {n} string.",
@@ -275,9 +257,10 @@ describe("resource conversion functions", function() {
             comment: "no comment",
             state: "new"
         });
+        const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
 
-        var string = conv.convertPluralResToICU(plural);
-        var expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        const string = convert.convertPluralResToICU(plural);
+
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
         expect(string.getKey()).toBe("asdf");
@@ -288,110 +271,137 @@ describe("resource conversion functions", function() {
         expect(string.getComment()).toBe("no comment");
         expect(string.getState()).toBe("new");
     });
+});
 
-    test("convert string target to plural", function() {
-        expect.assertions(2);
-
-        var string = new ResourceString({
+describe("convertICUToPluralRes", () => {
+    test("converts string target to plural", function() {
+        const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "de-DE",
             target: "{count, plural,  one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
         });
-
-        var expected = {
+        const expected = {
             one: "Es gibt {n} Zeichenfolge.",
             other: "Es gibt {n} Zeichenfolgen.",
         };
-        var plural = conv.convertICUToPluralRes(string);
+
+        const  plural = convert.convertICUToPluralRes(string);
+
         expect(plural.getType()).toBe("plural");
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
     });
 
-    test("convert string source to plural when the target has more plural categories than the source", function() {
-        expect.assertions(2);
+    test("converts string target to plural when it contains HTML tags", function() {
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} <b>string</b>.} other {There are {n} <b>strings</b>.}}",
+            targetLocale: "de-DE",
+            target: "{count, plural,  one {Es gibt {n} <b>Zeichenfolge</b>.} other {Es gibt {n} <b>Zeichenfolgen</b>.}}",
+        });
+        const expected = {
+            one: "Es gibt {n} <b>Zeichenfolge</b>.",
+            other: "Es gibt {n} <b>Zeichenfolgen</b>.",
+        };
 
-        var string = new ResourceString({
+        const plural = convert.convertICUToPluralRes(string);
+
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getTargetPlurals()).toStrictEqual(expected);
+    });
+
+    test("converts string target to plural when it contains nested HTML tags", function() {
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} <span><b>string</b></span>.} other {There are {n} <span><b>strings</b></span>.}}",
+            targetLocale: "de-DE",
+            target: "{count, plural,  one {Es gibt {n} <span><b>Zeichenfolge</b></span>.} other {Es gibt {n} <span><b>Zeichenfolgen</b></span>.}}",
+        });
+        const expected = {
+            one: "Es gibt {n} <span><b>Zeichenfolge</b></span>.",
+            other: "Es gibt {n} <span><b>Zeichenfolgen</b></span>.",
+        };
+
+        const plural = convert.convertICUToPluralRes(string);
+
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getTargetPlurals()).toStrictEqual(expected);
+    });
+
+    test("converts string source to plural when the target has more plural categories than the source", function() {
+        const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "pl-PL",
             target: "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}"
         });
-
-        var expected = {
+        const expected = {
             one: "There is {n} string.",
             other: "There are {n} strings."
         };
 
-        var plural = conv.convertICUToPluralRes(string);
+        const plural = convert.convertICUToPluralRes(string);
+
         expect(plural.getType()).toBe("plural");
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
     });
 
-    test("convert string target to plural when the target has more plural categories than the source", function() {
-        expect.assertions(2);
-
-        var string = new ResourceString({
+    test("converts string target to plural when the target has more plural categories than the source", function() {
+        const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "pl-PL",
             target: "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}"
         });
-
-        var expected = {
+        const expected = {
             one: "Jest {n} pozycja.",
             few: "Jest {n} pozycje.",
             other: "Jest {n} pozycji.",
         };
 
-        var plural = conv.convertICUToPluralRes(string);
+        const plural = convert.convertICUToPluralRes(string);
+
         expect(plural.getType()).toBe("plural");
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
     });
 
-    test("convert string source to plural when the target has less plural categories than the source", function() {
-        expect.assertions(2);
-
-        var string = new ResourceString({
+    test("converts string source to plural when the target has less plural categories than the source", function() {
+        const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "ja-JP",
             target: "{count, plural, other {{n}1件の商品があります。}}"
         });
-
-        var expected = {
+        const expected = {
             one: "There is {n} string.",
             other: "There are {n} strings."
         };
 
-        var plural = conv.convertICUToPluralRes(string);
+        const plural = convert.convertICUToPluralRes(string);
+
         expect(plural.getType()).toBe("plural");
         expect(plural.getSourcePlurals()).toStrictEqual(expected);
     });
 
-    test("convert string target to plural when the target has less plural categories than the source", function() {
-        expect.assertions(2);
-
-        var string = new ResourceString({
+    test("converts string target to plural when the target has less plural categories than the source", function() {
+        const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "ja-JP",
             target: "{count, plural, other {{n}1件の商品があります。}}"
         });
-
-        var expected = {
+        const expected = {
             other: "{n}1件の商品があります。",
         };
 
-        var plural = conv.convertICUToPluralRes(string);
+        const plural = convert.convertICUToPluralRes(string);
+
         expect(plural.getType()).toBe("plural");
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
     });
 
-    test("convert string target to plural, preserving all other fields", function() {
-        expect.assertions(9);
-
-        var string = new ResourceString({
+    test("converts string target to plural, preserving all other fields", function() {
+        const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "de-DE",
@@ -404,12 +414,13 @@ describe("resource conversion functions", function() {
             comment: "no comment",
             state: "new"
         });
-
-        var expected = {
+        const expected = {
             one: "Es gibt {n} Zeichenfolge.",
             other: "Es gibt {n} Zeichenfolgen.",
         };
-        var plural = conv.convertICUToPluralRes(string);
+
+        const plural = convert.convertICUToPluralRes(string);
+
         expect(plural.getType()).toBe("plural");
         expect(plural.getTargetPlurals()).toStrictEqual(expected);
         expect(string.getKey()).toBe("asdf");
@@ -421,24 +432,21 @@ describe("resource conversion functions", function() {
         expect(string.getState()).toBe("new");
     });
 
-    test("don't convert non-plural string to plural", function() {
-        expect.assertions(1);
-
-        var string = new ResourceString({
+    test("does not convert non-plural string to plural", function() {
+        const string = new ResourceString({
             sourceLocale: "en-US",
             source: "There is 1 string.",
             targetLocale: "de-DE",
             target: "Es gibt 1 Zeichenfolge."
         });
 
-        var plural = conv.convertICUToPluralRes(string);
+        const plural = convert.convertICUToPluralRes(string);
+
         expect(plural).toBeUndefined();
     });
 
-    test("don't convert array to plural", function() {
-        expect.assertions(1);
-
-        var array = new ResourceArray({
+    test("does not convert array to plural", function() {
+        const array = new ResourceArray({
             key: "c",
             sourceLocale: "en-US",
             sourceArray: [
@@ -454,14 +462,13 @@ describe("resource conversion functions", function() {
             ]
         });
 
-        var plural = conv.convertICUToPluralRes(array);
+        const plural = convert.convertICUToPluralRes(array);
+
         expect(plural).toBeUndefined();
     });
 
-    test("don't convert plural to another plural", function() {
-        expect.assertions(1);
-
-        var plural = new ResourcePlural({
+    test("does not convert plural to another plural", function() {
+        let plural = new ResourcePlural({
             key: "a",
             sourceLocale: "en-US",
             sourceStrings: {
@@ -475,8 +482,8 @@ describe("resource conversion functions", function() {
             }
         });
 
-        plural = conv.convertICUToPluralRes(plural);
+        plural = convert.convertICUToPluralRes(plural);
+
         expect(plural).toBeUndefined();
     });
-});
-
+})


### PR DESCRIPTION
Summary: Added support for converting string targets containing HTML tags to plural resources. This includes handling both simple and nested HTML tags within the strings, such as:
  * `There is <b>string</b>.`
  * `There is <span><b>string</b></span>.`