### PR TITLE
ilib-lint: Fix unreplaced <eX/> tag component in linter output

### DIFF
--- a/packages/ilib-lint/src/formatters/ConfigBasedFormatter.js
+++ b/packages/ilib-lint/src/formatters/ConfigBasedFormatter.js
@@ -18,7 +18,7 @@
  */
 import log4js from 'log4js';
 
-import { Formatter, Result } from 'ilib-lint-common';
+import {Formatter, Result} from 'ilib-lint-common';
 
 var logger = log4js.getLogger("ilib-lint.formatters.ConfigBasedFormatter");
 
@@ -50,13 +50,13 @@ export class ConfigBasedFormatter extends Formatter {
      */
     constructor(options) {
         super(options);
-        
+
         if (!options) {
             throw "Attempt to create a ConfigBasedFormatter without options";
         }
 
         for (let prop of requiredFields) {
-            if (typeof(options[prop]) === 'undefined') {
+            if (typeof (options[prop]) === 'undefined') {
                 throw `Missing ${prop} field for a ConfigBasedFormatter`;
             }
             this[prop] = options[prop];
@@ -73,7 +73,7 @@ export class ConfigBasedFormatter extends Formatter {
     format(result) {
         if (!result) return "";
         let output = this.template;
-        
+
         for (let prop of resultFields) {
             output = output.replace(new RegExp(`{${prop}}`, "g"), result[prop] || "");
         }
@@ -82,11 +82,12 @@ export class ConfigBasedFormatter extends Formatter {
         output = output.replace(new RegExp("{ruleDescription}", "g"), result.rule.getDescription());
 
         output = output.replace(/<e\d><\/e\d>/g, `${this.highlightStart}${this.highlightEnd}`);
+        output = output.replace(/<e\d\/>/g, `${this.highlightStart}${this.highlightEnd}`);
         output = output.replace(/<e\d>/g, this.highlightStart);
         output = output.replace(/<\/e\d>/g, this.highlightEnd);
 
         let link = "";
-        if (typeof(result.rule.getLink) === 'function') {
+        if (typeof (result.rule.getLink) === 'function') {
             link = result.rule.getLink() || "";
         }
         output = output.replace(new RegExp("{ruleLink}", "g"), link);

--- a/packages/ilib-lint/src/formatters/__tests__/ConfigBasedFormatter.test.js
+++ b/packages/ilib-lint/src/formatters/__tests__/ConfigBasedFormatter.test.js
@@ -1,0 +1,61 @@
+import {Result} from 'ilib-lint-common';
+import {ConfigBasedFormatter} from '../ConfigBasedFormatter.js';
+import ResourceMatcher from "../../rules/ResourceMatcher.js";
+
+describe('ConfigBasedFormatter', () => {
+    it.each([
+        {
+            name: "a pair of opening and closing tags <eX></eX>",
+            highlight: "This is just <e0>me</e0> testing.",
+            expected: "This is just >>me<< testing."
+        },
+        {
+            name: "a self-closing tag <eX/>",
+            highlight: "This is just me testing.<e0/>",
+            expected: "This is just me testing.>><<"
+        },
+        {
+            name: "an opening tag <eX>",
+            highlight: "This is just me testing.<e0>",
+            expected: "This is just me testing.>>"
+        },
+        {
+            name: "a closing tag </eX>",
+            highlight: "This is just me testing.</e0>",
+            expected: "This is just me testing.<<"
+        },
+    ])('replaces $name with highlight markers', ({highlight, expected}) => {
+        const formatter = new ConfigBasedFormatter({
+            "name": "test-formatter",
+            "description": "A formatter for testing purposes",
+            "template": "{highlight}",
+            "highlightStart": ">>",
+            "highlightEnd": "<<"
+        })
+
+        const result = formatter.format(new Result({
+            description: "A description for testing purposes",
+            highlight,
+            id: "test.id",
+            lineNumber: 123,
+            pathName: "test.txt",
+            rule: getTestRule(),
+            severity: "error",
+            source: "test"
+        }));
+
+
+        expect(result).toBe(expected);
+    });
+});
+
+function getTestRule() {
+    return new ResourceMatcher({
+        "name": "testRule",
+        "description": "Rule for testing purposes",
+        "regexps": ["test"],
+        "note": "test",
+        "sourceLocale": "en-US",
+        "link": ""
+    });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10605,7 +10605,7 @@ snapshots:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.95.0(webpack-cli@5.1.4)
+      webpack: 5.95.0
 
   babel-plugin-add-module-exports@1.0.4: {}
 
@@ -13637,11 +13637,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-leak-detector@26.6.2:
     dependencies:
@@ -17348,6 +17344,36 @@ snapshots:
       wildcard: 2.0.1
 
   webpack-sources@3.2.3: {}
+
+  webpack@5.95.0:
+    dependencies:
+      '@types/estree': 1.0.6
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.14.0
+      acorn-import-attributes: 1.9.5(acorn@8.14.0)
+      browserslist: 4.24.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.5.4
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(webpack@5.95.0)
+      watchpack: 2.4.2
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.95.0(webpack-cli@4.10.0):
     dependencies:


### PR DESCRIPTION
  * Update the `ConfigBasedFormatter` to replace all instances of `eX` tag combinations.
  * Add tests to verify the correct replacement of `eX` tags in various scenarios.
  * Fix an issue where unreplaced `<eX/>` tags appeared in the linter output, ensuring all tags are properly replaced with highlight markers.