### PR TITLE
ilib-loctool-php-resource: Add php resource file plugin for the loctool

### DIFF
--- a/.changeset/tough-apples-hug.md
+++ b/.changeset/tough-apples-hug.md
@@ -1,0 +1,7 @@
+---
+"ilib-loctool-php-resource": minor
+---
+
+Added new loctool plugin that can output php resource files.
+This plugin does not parse resource files. It is only for
+output.

--- a/packages/ilib-loctool-php-resource/LICENSE
+++ b/packages/ilib-loctool-php-resource/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ilib-loctool-php-resource/PHPResourceFile.js
+++ b/packages/ilib-loctool-php-resource/PHPResourceFile.js
@@ -19,7 +19,7 @@
 
 var fs = require("fs");
 var path = require("path");
-var Locale = require("ilib/lib/Locale.js");
+var Locale = require("ilib-locale");
 
 /**
  * @class Represents a PHP resource file.

--- a/packages/ilib-loctool-php-resource/PHPResourceFile.js
+++ b/packages/ilib-loctool-php-resource/PHPResourceFile.js
@@ -163,7 +163,9 @@ PHPResourceFile.prototype.getContent = function() {
         ' * === Auto-generated class. Do not manually edit this file. ===\n' +
         ' *\n' +
         ' */\n' +
-        'class Translation' + spec + '\n' +
+        // make sure to remove any hyphens from the locale spec so that it is
+        // a valid PHP class name
+        'class Translation' + spec.replace(/-/g, "") + '\n' +
         '{\\n' +
         '    /**\n' +
         '     * Gives the pre-populated map of tags to translations\n' +

--- a/packages/ilib-loctool-php-resource/PHPResourceFile.js
+++ b/packages/ilib-loctool-php-resource/PHPResourceFile.js
@@ -1,0 +1,268 @@
+/*
+ * PHPResourceFile.js - represents a PHP resource file
+ *
+ * Copyright © 2024, Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require("fs");
+var path = require("path");
+var Locale = require("ilib/lib/Locale.js");
+
+/**
+ * @class Represents a PHP resource file.
+ *
+ * @constructor
+ * @param {Object} props properties that control the construction of this file.
+ * @param {string} props.project the project that this resource file is part of
+ * @param {string} props.pathName the path to the file, relative
+ * to the root
+ * @param {string} props.locale the locale of this resource file
+ * @param {string} props.type the type of this resource file
+ */
+var PHPResourceFile = function(props) {
+    this.locale = new Locale();
+
+    if (props) {
+        this.project = props.project;
+        this.pathName = props.pathName;
+        this.locale = new Locale(props.locale);
+        this.API = props.project.getAPI();
+        this.type = props.type;
+    }
+
+    this.logger = this.API.getLogger("loctool.plugin.PHPResourceFile");
+
+    this.set = this.API.newTranslationSet(this.project && this.project.sourceLocale || "en-US");
+};
+
+/**
+ * We don't read PHP resource files. We only write them.
+ */
+PHPResourceFile.prototype.extract = function() {};
+
+/**
+ * Get the locale of this resource file. For Android resource files, this
+ * can be extracted automatically based on the name of the directory
+ * that the file is in.
+ *
+ * @returns {String} the locale spec of this file
+ */
+PHPResourceFile.prototype.getLocale = function() {
+    return this.locale;
+};
+
+/**
+ * Get the locale of this resource file. For Android resource files, this
+ * can be extracted automatically based on the name of the directory
+ * that the file is in.
+ *
+ * @returns {String} the locale spec of this file
+ */
+PHPResourceFile.prototype.getContext = function() {
+    return this.context;
+};
+
+/**
+ * Get all resources from this file. This will return all resources
+ * of mixed types (strings, arrays, or plurals).
+ *
+ * @returns {Resource} all of the resources available in this resource file.
+ */
+PHPResourceFile.prototype.getAll = function() {
+    return this.set.getAll();
+};
+
+/**
+ * Add a resource to this file. The locale of the resource
+ * should correspond to the locale of the file, and the
+ * context of the resource should match the context of
+ * the file.
+ *
+ * @param {Resource} res a resource to add to this file
+ */
+PHPResourceFile.prototype.addResource = function(res) {
+    this.logger.trace("PHPResourceFile.addResource: " + JSON.stringify(res) + " to " + this.project.getProjectId() + ", " + this.locale + ", " + JSON.stringify(this.context));
+    var resLocale = res.getTargetLocale() || res.getSourceLocale();
+    if (res && res.getProject() === this.project.getProjectId() && resLocale === this.locale.getSpec()) {
+        this.logger.trace("correct project, context, and locale. Adding.");
+        this.set.add(res);
+    } else {
+        if (res) {
+            if (res.getProject() !== this.project.getProjectId()) {
+                this.logger.warn("Attempt to add a resource to a resource file with the incorrect project.");
+            } else {
+                this.logger.warn("Attempt to add a resource to a resource file with the incorrect locale. " + resLocale + " vs. " + this.locale.getSpec());
+            }
+        } else {
+            this.logger.warn("Attempt to add an undefined resource to a resource file.");
+        }
+    }
+};
+
+/**
+ * Return true if this resource file has been modified
+ * since it was loaded from disk.
+ *
+ * @returns {boolean} true if this resource file has been
+ * modified since it was loaded
+ */
+PHPResourceFile.prototype.isDirty = function() {
+    return this.set.isDirty();
+};
+
+// we don't localize resource files
+PHPResourceFile.prototype.localize = function() {};
+
+function clean(str) {
+    return str.replace(/\s+/, " ").trim();
+}
+
+/**
+ * Return the default locale spec for this resource file.
+ * @private
+ */
+PHPResourceFile.prototype.getDefaultSpec = function() {
+    if (!this.defaultSpec) {
+        this.defaultSpec = this.project.settings.localeDefaults ?
+            this.API.utils.getLocaleDefault(this.locale, this.flavor, this.project.settings.localeDefaults) :
+            this.locale.getSpec();
+    }
+
+    return this.defaultSpec;
+};
+
+/**
+ * Generate the content of the resource file.
+ *
+ * @private
+ * @returns {String} the content of the resource file
+ */
+PHPResourceFile.prototype.getContent = function() {
+    var json = {};
+
+    if (this.set.isDirty()) {
+        var resources = this.set.getAll();
+
+        // make sure resources are sorted by key so that git diff works nicely across runs of the loctool
+        resources.sort(function(left, right) {
+            return (left.getKey() < right.getKey()) ? -1 : (left.getKey() > right.getKey() ? 1 : 0);
+        });
+
+        for (var j = 0; j < resources.length; j++) {
+            var resource = resources[j];
+            if (resource.getSource() && resource.getTarget()) {
+                if (clean(resource.getSource()) !== clean(resource.getTarget())) {
+                    this.logger.trace("writing translation for " + resource.getKey() + " as " + resource.getTarget());
+                    json[resource.getKey()] = this.project.settings.identify ?
+                        '<span loclang="PHP" locid="' + resource.getKey() + '">' + resource.getTarget() + '</span>' :
+                        resource.getTarget();
+                } else {
+                    this.logger.trace("skipping translation with no change");
+                }
+            } else {
+                this.logger.warn("String resource " + resource.getKey() + " has no source text. Skipping...");
+            }
+        }
+    }
+
+    var defaultSpec = this.pathName ? this.locale.getSpec() : this.getDefaultSpec();
+
+    // allow for a project-specific prefix to the file to do things like importing modules and such
+    var output = "";
+    var settings = this.project.settings;
+    if (settings && settings.PHPResourceFile && settings.PHPResourceFile.prefix) {
+        output = settings.PHPResourceFile.prefix;
+    }
+    output += 'ilib.data.strings_' + defaultSpec.replace(/-/g, "_") + " = ";
+    output += JSON.stringify(json, undefined, 4);
+    output += ";\n";
+
+    // take care of double-escaped unicode chars
+    output = output.replace(/\\\\u/g, "\\u");
+
+    return output;
+};
+
+/**
+ * Find the path for the resource file for the given project, context,
+ * and locale.
+ *
+ * @param {String} locale the name of the locale in which the resource
+ * file will reside
+ * @param {String|undefined} flavor the name of the flavor if any
+ * @return {String} the ios strings resource file path that serves the
+ * given project, context, and locale.
+ */
+PHPResourceFile.prototype.getResourceFilePath = function(locale, flavor) {
+    if (this.pathName) return this.pathName;
+
+    var localeDir, dir, newPath, spec;
+    locale = locale || this.locale;
+
+    var defaultSpec = this.getDefaultSpec();
+
+    var filename = defaultSpec + ".js";
+
+    dir = path.join(this.project.target, this.project.getResourceDirs("js")[0] ||this.project.getResourceDirs("PHP")[0] || ".");
+    newPath = path.join(dir, filename);
+
+    this.logger.trace("Getting resource file path for locale " + locale + ": " + newPath);
+
+    return newPath;
+};
+
+/**
+ * Write the resource file out to disk again.
+ */
+PHPResourceFile.prototype.write = function() {
+    this.logger.trace("writing resource file. [" + this.project.getProjectId() + "," + this.locale + "]");
+    if (this.set.isDirty()) {
+        if (!this.pathName) {
+            this.logger.trace("Calculating path name ");
+
+            // must be a new file, so create the name
+            this.pathName = this.getResourceFilePath();
+        } else {
+            this.defaultSpec = this.locale.getSpec();
+        }
+
+        var json = {};
+
+        this.logger.info("Writing PHP resources for locale " + this.locale + " to file " + this.pathName);
+
+        dir = path.dirname(this.pathName);
+        this.API.utils.makeDirs(dir);
+
+        var js = this.getContent();
+        fs.writeFileSync(this.pathName, js, "utf8");
+        this.logger.debug("Wrote string translations to file " + this.pathName);
+    } else {
+        this.logger.debug("File " + this.pathName + " is not dirty. Skipping.");
+    }
+};
+
+/**
+ * Return the set of resources found in the current Android
+ * resource file.
+ *
+ * @returns {TranslationSet} The set of resources found in the
+ * current Java file.
+ */
+PHPResourceFile.prototype.getTranslationSet = function() {
+    return this.set;
+}
+
+module.exports = PHPResourceFile;

--- a/packages/ilib-loctool-php-resource/PHPResourceFileType.js
+++ b/packages/ilib-loctool-php-resource/PHPResourceFileType.js
@@ -46,6 +46,8 @@ var PHPResourceFileType = function(project) {
     this.extracted = this.API.newTranslationSet(project.getSourceLocale());
     this.newres = this.API.newTranslationSet(project.getSourceLocale());
     this.pseudo = this.API.newTranslationSet(project.getSourceLocale());
+
+    this.resourceFiles = {};
 };
 
 /*
@@ -136,29 +138,30 @@ PHPResourceFileType.prototype.newFile = function(pathName, options) {
  *
  * @param {String} locale the name of the locale in which the resource
  * file will reside
- * @param {String} pathName the optional path to the resource file if the
- * caller has already calculated what it should be
+ * @param {String|undefined} pathName the optional path template to the
+ * resource file if the caller has already got a template for the path
  * @return {PHPResourceFile} the PHP resource file that serves the
  * given locale.
  */
 PHPResourceFileType.prototype.getResourceFile = function(locale, pathName) {
     var loc = locale || this.project.sourceLocale;
-    var key = [loc, pathName].join("_");
 
-    var resfile = this.resourceFiles && this.resourceFiles[key];
-
-    if (!resfile) {
-        resfile = this.resourceFiles[key] = new PHPResourceFile({
+    if (!this.resourceFiles[loc]) {
+        var formattedPathName = pathName ?
+            this.API.utils.formatPath(pathName, {
+                locale: loc
+            }) : this.getLocalizedPath(loc);
+        this.resourceFiles[loc] = new PHPResourceFile({
             project: this.project,
             locale: loc,
-            pathName: pathName,
+            pathName: formattedPathName,
             type: this
         });
 
         this.logger.trace("Defining new resource file");
     }
 
-    return resfile;
+    return this.resourceFiles[loc];
 };
 
 /**

--- a/packages/ilib-loctool-php-resource/PHPResourceFileType.js
+++ b/packages/ilib-loctool-php-resource/PHPResourceFileType.js
@@ -50,12 +50,6 @@ var PHPResourceFileType = function(project) {
     this.resourceFiles = {};
 };
 
-/*
-PHPResourceFileType.prototype = new FileType();
-PHPResourceFileType.prototype.parent = FileType;
-PHPResourceFileType.prototype.constructor = PHPResourceFileType;
-*/
-
 /**
  * Return true if this file type handles the type of file in the
  * given path name.
@@ -145,13 +139,14 @@ PHPResourceFileType.prototype.newFile = function(pathName, options) {
  */
 PHPResourceFileType.prototype.getResourceFile = function(locale, pathName) {
     var loc = locale || this.project.sourceLocale;
+    var formattedPathName = pathName ?
+        this.API.utils.formatPath(pathName, {
+            locale: loc
+        }) : this.getLocalizedPath(loc);
+    var key = [loc, formattedPathName].join("_");
 
-    if (!this.resourceFiles[loc]) {
-        var formattedPathName = pathName ?
-            this.API.utils.formatPath(pathName, {
-                locale: loc
-            }) : this.getLocalizedPath(loc);
-        this.resourceFiles[loc] = new PHPResourceFile({
+    if (!this.resourceFiles[key]) {
+        this.resourceFiles[key] = new PHPResourceFile({
             project: this.project,
             locale: loc,
             pathName: formattedPathName,
@@ -161,7 +156,7 @@ PHPResourceFileType.prototype.getResourceFile = function(locale, pathName) {
         this.logger.trace("Defining new resource file");
     }
 
-    return this.resourceFiles[loc];
+    return this.resourceFiles[key];
 };
 
 /**

--- a/packages/ilib-loctool-php-resource/PHPResourceFileType.js
+++ b/packages/ilib-loctool-php-resource/PHPResourceFileType.js
@@ -1,0 +1,240 @@
+/*
+ * PHPResourceFileType.js - manages a collection of PHP resource files
+ *
+ * Copyright © 2024 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var path = require("path");
+
+var PHPResourceFile = require("./PHPResourceFile.js");
+
+/**
+ * @class Manage a collection of Android resource files.
+ *
+ * @constructor
+ * @param {Project} project that this type is in
+ */
+var PHPResourceFileType = function(project) {
+    this.type = "PHP";
+
+    this.project = project;
+    this.resourceFiles = {};
+    this.API = project.getAPI();
+
+    this.extensions = [ ".php" ];
+
+    this.logger = this.API.getLogger("loctool.plugin.PHPResourceFileType");
+
+    this.extracted = this.API.newTranslationSet(project.getSourceLocale());
+    this.newres = this.API.newTranslationSet(project.getSourceLocale());
+    this.pseudo = this.API.newTranslationSet(project.getSourceLocale());
+};
+
+/*
+PHPResourceFileType.prototype = new FileType();
+PHPResourceFileType.prototype.parent = FileType;
+PHPResourceFileType.prototype.constructor = PHPResourceFileType;
+*/
+
+/**
+ * Return true if this file type handles the type of file in the
+ * given path name.
+ * @param {String} pathName the path to check
+ * @returns true if this file type handles the given path name, and
+ * false otherwise
+ */
+PHPResourceFileType.prototype.handles = function(pathName) {
+    // php resource files are only generated. Existing ones are never read in.
+    this.logger.debug("PHPResourceFileType handles " + pathName + "?");
+
+    this.logger.debug("No");
+    return false;
+};
+
+/**
+ * Write out all resources for this file type. For PHP resources, each
+ * resource file is written out by itself. This method will
+ * iterate through all of the resource files it knows about and cause them
+ * each to write out.
+ */
+PHPResourceFileType.prototype.write = function() {
+    this.logger.trace("Now writing out " + Object.keys(this.resourceFiles).length + " resource files");
+    for (var hash in this.resourceFiles) {
+        var file = this.resourceFiles[hash];
+        file.write();
+    }
+};
+
+PHPResourceFileType.prototype.name = function() {
+    return "PHP Resource File";
+};
+
+/**
+ * Return a new file of the current file type using the given
+ * path name.
+ *
+ * @param {String} pathName the path of the resource file
+ * @return {PHPResourceFile} a resource file instance for the
+ * given path
+ */
+PHPResourceFileType.prototype.newFile = function(pathName, options) {
+    var file = new PHPResourceFile({
+        project: this.project,
+        pathName: pathName,
+        type: this,
+        locale: options.locale
+    });
+
+    var locale = file.getLocale() || this.project.sourceLocale;
+
+    this.resourceFiles[locale] = file;
+    return file;
+};
+
+/**
+ * Find or create the resource file object for the given project, context,
+ * and locale.
+ *
+ * @param {String} locale the name of the locale in which the resource
+ * file will reside
+ * @param {String} pathName the optional path to the resource file if the
+ * caller has already calculated what it should be
+ * @return {PHPResourceFile} the Android resource file that serves the
+ * given project, context, and locale.
+ */
+PHPResourceFileType.prototype.getResourceFile = function(locale, pathName) {
+    var loc = locale || this.project.sourceLocale;
+    var key = [loc, pathName].join("_");
+
+    var resfile = this.resourceFiles && this.resourceFiles[key];
+
+    if (!resfile) {
+        resfile = this.resourceFiles[key] = new PHPResourceFile({
+            project: this.project,
+            locale: loc,
+            pathName: pathName,
+            type: this
+        });
+
+        this.logger.trace("Defining new resource file");
+    }
+
+    return resfile;
+};
+
+/**
+ * Return all resource files known to this file type instance.
+ *
+ * @returns {Array.<PHPResourceFile>} an array of resource files
+ * known to this file type instance
+ */
+PHPResourceFileType.prototype.getAll = function() {
+    return this.resourceFiles;
+};
+
+/**
+ * Ensure that all resources collected so far have a pseudo translation.
+ */
+PHPResourceFileType.prototype.generatePseudo = function(locale, pb) {
+    var resources = this.extracted.getBy({
+        sourceLocale: pb.getSourceLocale()
+    });
+    this.logger.trace("Found " + resources.length + " source resources for " + pb.getSourceLocale());
+    var resource;
+
+    resources.forEach(function(resource) {
+        if (resource && resource.getKey() !== "app_id" && resource.getKey() !== "live_sdk_client_id") {
+            this.logger.trace("Generating pseudo for " + resource.getKey());
+            var res = resource.generatePseudo(locale, pb);
+            if (res && res.getSource() !== res.getTarget()) {
+                this.pseudo.add(res);
+            }
+        }
+    }.bind(this));
+};
+
+PHPResourceFileType.prototype.getDataType = function() {
+    return this.datatype;
+};
+
+PHPResourceFileType.prototype.getResourceTypes = function() {
+    return {};
+};
+
+/**
+ * Return the list of file name extensions that this plugin can
+ * process.
+ *
+ * @returns {Array.<string>} the list of file name extensions
+ */
+PHPResourceFileType.prototype.getExtensions = function() {
+    return this.extensions;
+};
+
+/**
+ * Return the name of the node module that implements the resource file type, or
+ * the path to a PHP file that implements the resource filetype.
+ * @returns {Function|undefined} node module name or path, or undefined if this file type does not
+ * need resource files
+ */
+PHPResourceFileType.prototype.getResourceFileType = function() {};
+
+/**
+ * Return the translation set containing all of the extracted
+ * resources for all instances of this type of file. This includes
+ * all new strings and all existing strings. If it was extracted
+ * from a source file, it should be returned here.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * extracted resources
+ */
+PHPResourceFileType.prototype.getExtracted = function() {
+    return this.extracted;
+};
+
+/**
+ * Add the contents of the given translation set to the extracted resources
+ * for this file type.
+ *
+ * @param {TranslationSet} set set of resources to add to the current set
+ */
+PHPResourceFileType.prototype.addSet = function(set) {
+    this.extracted.addSet(set);
+};
+
+/**
+ * Return the translation set containing all of the new
+ * resources for all instances of this type of file.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * new resources
+ */
+PHPResourceFileType.prototype.getNew = function() {
+    return this.newres;
+};
+
+/**
+ * Return the translation set containing all of the pseudo
+ * localized resources for all instances of this type of file.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * pseudo localized resources
+ */
+PHPResourceFileType.prototype.getPseudo = function() {
+    return this.pseudo;
+};
+
+module.exports = PHPResourceFileType;

--- a/packages/ilib-loctool-php-resource/README.md
+++ b/packages/ilib-loctool-php-resource/README.md
@@ -7,7 +7,7 @@ resource keys to their values.
 
 ## Release Notes
 
-See the [change log](./ChangeLog.md) for details on changes between releases.
+See the [change log](./CHANGELOG.md) for details on changes between releases.
 
 ## License
 

--- a/packages/ilib-loctool-php-resource/README.md
+++ b/packages/ilib-loctool-php-resource/README.md
@@ -13,11 +13,14 @@ project.json file:
 - `sourceLocale`: The locale of the source strings. This is the locale
   that the strings in the source files are assumed to be in. The default
   is "en-US".
-- `template`: The template to use when generating the output file. The
-  default is `resource-files/Translation[locale].php`. See the documentation
-  of the loctool itself for more information about the template syntax.
+- `template`: The default path template to use when generating the output file
+  name if the source file mapping does not specify it. The default value for 
+  this default is `resource-files/Translation[locale].php` but you can set it
+  here for any file types that do not set it on their own. See the documentation
+  of the loctool itself for more information about path template syntax.
 
-Example project.json configuration snippet:
+Example project.json configuration snippet where strings are extracted from
+tmpl files and the localized resources are output to PHP files:
 
 ```json
 {
@@ -26,30 +29,50 @@ Example project.json configuration snippet:
             "en-US",
             "fr-FR"
         ],
+        "resourceFileTypes" : {
+            "php" : "ilib-loctool-php-resource"
+        },
+        "template": {
+            "mappings": {
+                "admin/**/*.tmpl": {
+                    "sourceLocale": "en-US",
+                    "template": "localized/Template[locale].php"
+                },
+                "src/**/*.tmpl": {
+                    "sourceLocale": "en-US"
+                }
+            }
+        }
         "php": {
             "sourceLocale": "en-US",
-            "template": "localized/Lang[locale].php"
         }
     }
 }
 ```
 
-Additionally, you must specify the plugin name in the loctool configuration
-for resource file types. For example:
+The resourceFileTypes property maps datatypes to loctool plugins. This registers
+the named plugin as the resource file type for resources from your source that
+have that datatype. For example, let's say we use a made up datatype of "template"
+which represents a UI written in some templating language. If you are extracting
+resources from template .tmpl files, you would use "template" as the source file
+data type and map that to "ilib-loctool-php-resource" to output the results to
+php resource files. See the loctool plugin you are using to parse your project's
+source files to find out what the source file data type is.
 
-```json
-{
-    "resourceFileTypes" : {
-        "[your source file data type here]" : "ilib-loctool-php-resource"
-    }
-}
-```
+Note that the `template` property can be specified in the mapping for your source
+files (as shown above), or globally for the whole project in the settings.php.template
+property. If specified in both places, the mapping property takes precedence. Note
+that most of the time you will want to specify the template in the mapping property
+because the source file plugin will already have a default template that may be
+inappropriate for your resources and its default template overrides the one specified
+in the settings.php.template property.
 
-This registers the plugin as the resource file type for resources from
-your source. For example, if you are extracting resources from PHP files,
-you would use "php" as the source file data type. See the loctool plugin
-you are using to parse the source files to find out what the source file
-data type is.
+In the example above, the strings extracted from `admin/**/*.tmpl` files will be output
+to `localized/Template[locale].php` as per the mapping, and the strings extracted
+from `src/**/*.tmpl` files will be output to `localized/Lang[locale].php` as per the
+global setting in the `php` property. If the template is not specified
+in either location, the default template will be used which is
+`resource-files/Translation[locale].php`.
 
 ## Release Notes
 

--- a/packages/ilib-loctool-php-resource/README.md
+++ b/packages/ilib-loctool-php-resource/README.md
@@ -5,6 +5,52 @@ allows it to output resources in PHP format. The output is essentially
 a PHP file that contains a single associative array that maps
 resource keys to their values.
 
+## Configuration
+
+The plugin recognizes the following configuration parameters in the
+project.json file:
+
+- `sourceLocale`: The locale of the source strings. This is the locale
+  that the strings in the source files are assumed to be in. The default
+  is "en-US".
+- `template`: The template to use when generating the output file. The
+  default is `resource-files/Translation[locale].php`. See the documentation
+  of the loctool itself for more information about the template syntax.
+
+Example project.json configuration snippet:
+
+```json
+{
+    "settings": {
+        "locales": [
+            "en-US",
+            "fr-FR"
+        ],
+        "php": {
+            "sourceLocale": "en-US",
+            "template": "localized/Lang[locale].php"
+        }
+    }
+}
+```
+
+Additionally, you must specify the plugin name in the loctool configuration
+for resource file types. For example:
+
+```json
+{
+    "resourceFileTypes" : {
+        "[your source file data type here]" : "ilib-loctool-php-resource"
+    }
+}
+```
+
+This registers the plugin as the resource file type for resources from
+your source. For example, if you are extracting resources from PHP files,
+you would use "php" as the source file data type. See the loctool plugin
+you are using to parse the source files to find out what the source file
+data type is.
+
 ## Release Notes
 
 See the [change log](./CHANGELOG.md) for details on changes between releases.

--- a/packages/ilib-loctool-php-resource/README.md
+++ b/packages/ilib-loctool-php-resource/README.md
@@ -1,0 +1,27 @@
+# ilib-loctool-php-resource
+
+ilib-loctool-php-resource is a plugin for the loctool that
+allows it to output resources in PHP format. The output is essentially
+a PHP file that contains a single associative array that maps
+resource keys to their values.
+
+## Release Notes
+
+See the [change log](./ChangeLog.md) for details on changes between releases.
+
+## License
+
+Copyright © 2024 JEDLSoft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/ilib-loctool-php-resource/README.md
+++ b/packages/ilib-loctool-php-resource/README.md
@@ -80,7 +80,7 @@ See the [change log](./CHANGELOG.md) for details on changes between releases.
 
 ## License
 
-Copyright © 2024 JEDLSoft
+Copyright © 2024 Box, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/ilib-loctool-php-resource/package.json
+++ b/packages/ilib-loctool-php-resource/package.json
@@ -58,6 +58,6 @@
     },
     "devDependencies": {
         "jest": "^29.7.0",
-        "loctool": "workspace:*"
+        "loctool": "workspace:^"
     }
 }

--- a/packages/ilib-loctool-php-resource/package.json
+++ b/packages/ilib-loctool-php-resource/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-php-resource",
-    "version": "0.0.0",
+    "version": "0.1.0",
     "main": "./PHPResourceFileType.js",
     "description": "A loctool plugin that knows how to output PHP resource files",
     "license": "Apache-2.0",
@@ -43,7 +43,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
-        "dist": "pnpm pack",
+        "build": "pnpm pack",
         "test": "jest",
         "test:watch": "jest --watch",
         "debug": "NODE_OPTIONS=\"$NODE_OPTIONS --inspect-brk\" jest -i",

--- a/packages/ilib-loctool-php-resource/package.json
+++ b/packages/ilib-loctool-php-resource/package.json
@@ -53,6 +53,8 @@
         "node": ">=12.0"
     },
     "dependencies": {
+        "ilib-locale": "^1.2.2",
+        "micromatch": "^4.0.8"
     },
     "devDependencies": {
         "jest": "^29.7.0",

--- a/packages/ilib-loctool-php-resource/package.json
+++ b/packages/ilib-loctool-php-resource/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-php-resource",
-    "version": "1.0.0",
+    "version": "0.0.0",
     "main": "./PHPResourceFileType.js",
     "description": "A loctool plugin that knows how to output PHP resource files",
     "license": "Apache-2.0",

--- a/packages/ilib-loctool-php-resource/package.json
+++ b/packages/ilib-loctool-php-resource/package.json
@@ -1,0 +1,61 @@
+{
+    "name": "ilib-loctool-php-resource",
+    "version": "1.0.0",
+    "main": "./PHPResourceFileType.js",
+    "description": "A loctool plugin that knows how to output PHP resource files",
+    "license": "Apache-2.0",
+    "keywords": [
+        "internationalization",
+        "i18n",
+        "localization",
+        "l10n",
+        "globalization",
+        "g11n",
+        "strings",
+        "resources",
+        "locale",
+        "translation",
+        "webpack",
+        "loader",
+        "javascript"
+    ],
+    "email": "ehoogerbeets@gmail.com",
+    "author": {
+        "name": "Edwin Hoogerbeets",
+        "web": "http://www.translationcircle.com/",
+        "email": "ehoogerbeets@gmail.com"
+    },
+    "contributors": [
+        {
+            "name": "Edwin Hoogerbeets",
+            "email": "ehoogerbeets@gmail.com"
+        }
+    ],
+    "files": [
+        "README.md",
+        "LICENSE",
+        "PHPResourceFileType.js",
+        "PHPResourceFile.js",
+        "CHANGELOG.md"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/iLib-js/ilib-mono.git"
+    },
+    "scripts": {
+        "dist": "pnpm pack",
+        "test": "jest",
+        "test:watch": "jest --watch",
+        "debug": "NODE_OPTIONS=\"$NODE_OPTIONS --inspect-brk\" jest -i",
+        "clean": "git clean -f -d *"
+    },
+    "engines": {
+        "node": ">=12.0"
+    },
+    "dependencies": {
+    },
+    "devDependencies": {
+        "jest": "^29.7.0",
+        "loctool": "workspace:*"
+    }
+}

--- a/packages/ilib-loctool-php-resource/test/PHPResourceFile.test.js
+++ b/packages/ilib-loctool-php-resource/test/PHPResourceFile.test.js
@@ -40,7 +40,6 @@ var p = new CustomProject({
         "it-IT": "ItIT",
         "ja-JP": "JaJP",
         "ko-KR": "KoKR",
-        "nl-NL": "NlNL",
         "pt-BR": "PtBR",
         "sv-SE": "SvSE",
         "zh-Hans-CN": "ZhCN",
@@ -636,4 +635,80 @@ describe("PHPresourcefile", function() {
 
         expect(actual).toBe(expected);
     });
+
+    test("PHPResourceFile right contents for a locale that is not in the locale map", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            type: phpft,
+            project: p,
+            locale: "nl-NL"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        [
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "nl-NL",
+                key: "source_text",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "bron tekst"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "nl-NL",
+                key: "more_source_text",
+                sourceLocale: "en-US",
+                source: "more source text",
+                target: "meer bron tekst"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "nl-NL",
+                key: "yet_more_source_text",
+                sourceLocale: "en-US",
+                source: "yet more source text",
+                target: "nog meer bron tekst"
+            })
+        ].forEach(function(res) {
+            phprf.addResource(res);
+        });
+
+        // should use the default locale spec in the first line
+        var expected =
+            '<?php\n' +
+            '\n' +
+            '/**\n' +
+            ' * === Auto-generated class. Do not manually edit this file. ===\n' +
+            ' *\n' +
+            ' */\n' +
+            // the dash should be removed from the locale name to make this a valid PHP identifier
+            'class TranslationnlNL\n' +
+            '{\\n' +
+            '    /**\n' +
+            '     * Gives the pre-populated map of tags to translations\n' +
+            '     *\n' +
+            '     * @return array\n' +
+            '     */\n' +
+            '    public function getTranslationsMap() {\n' +
+            '        return [\n' +
+            "            'more_source_text' => 'meer bron tekst',\n" +
+            "            'source_text' => 'bron tekst',\n" +
+            "            'yet_more_source_text' => 'nog meer bron tekst'\n" +
+            '        ];\n' +
+            '    }\n' +
+            '}\n' +
+            '\n' +
+            '?>\n';
+
+        var actual = phprf.getContent();
+
+        expect(actual).toBe(expected);
+    });
+
 });

--- a/packages/ilib-loctool-php-resource/test/PHPResourceFile.test.js
+++ b/packages/ilib-loctool-php-resource/test/PHPResourceFile.test.js
@@ -18,6 +18,7 @@
  */
 
 var PHPResourceFile = require("../PHPResourceFile.js");
+var PHPResourceFileType = require("../PHPResourceFileType.js");
 var CustomProject = require("loctool/lib/CustomProject.js");
 
 var p = new CustomProject({
@@ -28,39 +29,38 @@ var p = new CustomProject({
     }
 }, "./testfiles", {
     locales:["en-GB", "de-DE", "de-AT"],
+    // map to non-standard locale specifiers
+    "localeMap": {
+        "da-DK": "DaDK",
+        "de-DE": "DeDE",
+        "en-US": "EnUS",
+        "en-GB": "EnGB",
+        "es-ES": "EsES",
+        "fr-FR": "FrFR",
+        "it-IT": "ItIT",
+        "ja-JP": "JaJP",
+        "ko-KR": "KoKR",
+        "nl-NL": "NlNL",
+        "pt-BR": "PtBR",
+        "sv-SE": "SvSE",
+        "zh-Hans-CN": "ZhCN",
+        "zh-Hant-HK": "ZhHK",
+        "zh-Hant-TW": "ZhTW",
+        "zh-Hans-SG": "ZhSG"
+    },
     "php": {
-        // map to non-standard locale specifiers
-        "localeMap": {
-            "da-DK": "DaDK",
-            "de-DE": "DeDE",
-            "en-US": "EnUS",
-            "en-GB": "EnGB",
-            "es-ES": "EsES",
-            "fr-FR": "FrFR",
-            "it-IT": "ItIT",
-            "ja-JP": "JaJP",
-            "ko-KR": "KoKR",
-            "nl-NL": "NlNL",
-            "pt-BR": "PtBR",
-            "sv-SE": "SvSE",
-            "zh-Hans-CN": "ZhCN",
-            "zh-Hant-HK": "ZhHK",
-            "zh-Hant-TW": "ZhTW",
-            "zh-Hans-SG": "ZhSG"
-        },
-        "mappings": {
-            "**/*.php": {
-                template: "resource-files/Translation[locale].php"
-            }
-        }
+        "template": "localized/Translation[locale].php"
     }
 });
+
+var phpft = new PHPResourceFileType(p);
 
 describe("PHPresourcefile", function() {
     test("PHPResourceFileConstructor", function() {
         expect.assertions(1);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p
         });
         expect(phprf).toBeTruthy();
@@ -70,6 +70,7 @@ describe("PHPresourcefile", function() {
         expect.assertions(1);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             pathName: "localized/TranslationEnUS.php",
             locale: "en-US"
@@ -82,6 +83,7 @@ describe("PHPresourcefile", function() {
         expect.assertions(3);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             pathName: "localized/TranslationDeDE.php",
             locale: "de-DE"
@@ -129,6 +131,7 @@ describe("PHPresourcefile", function() {
         expect.assertions(2);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             pathName: "localized/TranslationDeDE.php",
             locale: "de-DE"
@@ -184,9 +187,9 @@ describe("PHPresourcefile", function() {
             '     */\n' +
             '    public function getTranslationsMap() {\n' +
             '        return [\n' +
+            "            'more_source_text' => 'mehr Quellentext',\n" +
             "            'source_text' => 'Quellentext',\n" +
-            "            'more_source_text' => 'mehr Quellentext'\n" +
-            "            'yet_more_source_text' => 'noch mehr Quellentext',\n" +
+            "            'yet_more_source_text' => 'noch mehr Quellentext'\n" +
             '        ];\n' +
             '    }\n' +
             '}\n' +
@@ -200,6 +203,7 @@ describe("PHPresourcefile", function() {
         expect.assertions(2);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             pathName: "localized/TranslationDeDE.php",
             locale: "de-DE"
@@ -236,6 +240,7 @@ describe("PHPresourcefile", function() {
         expect.assertions(2);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             pathName: "localized/TranslationDeDE.php",
             locale: "de-DE"
@@ -281,8 +286,8 @@ describe("PHPresourcefile", function() {
             '     */\n' +
             '    public function getTranslationsMap() {\n' +
             '        return [\n' +
-            "            'source_text' => 'Quellen\"text',\n" +
-            "            'more_source_text' => 'mehr Quellen\"text'\n" +
+            "            'more_source_text' => 'mehr Quellen\"text',\n" +
+            "            'source_text' => 'Quellen\"text'\n" +
             '        ];\n' +
             '    }\n' +
             '}\n' +
@@ -296,6 +301,7 @@ describe("PHPresourcefile", function() {
         expect.assertions(2);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             pathName: "localized/TranslationDeDE.php",
             locale: "de-DE"
@@ -341,8 +347,8 @@ describe("PHPresourcefile", function() {
             '     */\n' +
             '    public function getTranslationsMap() {\n' +
             '        return [\n' +
-            "            'source_text' => 'Quellen\\'text',\n" +
-            "            'more_source_text' => 'mehr Quellen\\'text'\n" +
+            "            'more_source_text' => 'mehr Quellen\\'text',\n" +
+            "            'source_text' => 'Quellen\\'text'\n" +
             '        ];\n' +
             '    }\n' +
             '}\n' +
@@ -352,23 +358,11 @@ describe("PHPresourcefile", function() {
         expect(phprf.getContent()).toBe(expected);
     });
 
-    test("PHPResourceFileGetResourceFilePathDefaultLocaleForLanguage", function() {
-        expect.assertions(2);
-
-        var phprf = new PHPResourceFile({
-            project: p,
-            locale: "de-DE"
-        });
-
-        expect(phprf).toBeTruthy();
-
-        expect(phprf.getResourceFilePath()).toBe("testfiles/localized/de.php");
-    });
-
     test("PHPResourceFileGetResourceFilePathDefaultLocaleForLanguageNoDefaultAvailable", function() {
         expect.assertions(2);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             locale: "de-DE"
         });
@@ -378,23 +372,11 @@ describe("PHPresourcefile", function() {
         expect(phprf.getResourceFilePath()).toBe("testfiles/localized/TranslationDeDE.php");
     });
 
-    test("PHPResourceFileGetResourceFilePathNonDefaultLocaleForLanguage", function() {
-        expect.assertions(2);
-
-        var phprf = new PHPResourceFile({
-            project: p,
-            locale: "de-AT"
-        });
-
-        expect(phprf).toBeTruthy();
-
-        expect(phprf.getResourceFilePath()).toBe("testfiles/localized/TranslationDeAT.php");
-    });
-
     test("PHPResourceFileGetResourceFilePathDefaultLocaleForLanguageZH", function() {
         expect.assertions(2);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             locale: "zh-Hans-CN"
         });
@@ -409,6 +391,7 @@ describe("PHPresourcefile", function() {
 
         // should default to English/US
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p
         });
 
@@ -421,6 +404,7 @@ describe("PHPresourcefile", function() {
         expect.assertions(2);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             locale: "de-AT",
             pathName: "path/to/foo.php"
@@ -435,6 +419,7 @@ describe("PHPresourcefile", function() {
         expect.assertions(2);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             locale: "de-DE"
         });
@@ -490,9 +475,9 @@ describe("PHPresourcefile", function() {
             '     */\n' +
             '    public function getTranslationsMap() {\n' +
             '        return [\n' +
+            "            'more_source_text' => 'mehr Quellentext',\n" +
             "            'source_text' => 'Quellentext',\n" +
-            "            'more_source_text' => 'mehr Quellentext'\n" +
-            "            'yet_more_source_text' => 'noch mehr Quellentext',\n" +
+            "            'yet_more_source_text' => 'noch mehr Quellentext'\n" +
             '        ];\n' +
             '    }\n' +
             '}\n' +
@@ -508,6 +493,7 @@ describe("PHPresourcefile", function() {
         expect.assertions(2);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             locale: "zh-Hans-CN"
         });
@@ -563,9 +549,9 @@ describe("PHPresourcefile", function() {
             '     */\n' +
             '    public function getTranslationsMap() {\n' +
             '        return [\n' +
+            "            'more_source_text' => '更多源文本',\n" +
             "            'source_text' => '源文本',\n" +
-            "            'more_source_text' => '更多源文本'\n" +
-            "            'yet_more_source_text' => '还有附加源文本',\n" +
+            "            'yet_more_source_text' => '还有附加源文本'\n" +
             '        ];\n' +
             '    }\n' +
             '}\n' +
@@ -581,6 +567,7 @@ describe("PHPresourcefile", function() {
         expect.assertions(2);
 
         var phprf = new PHPResourceFile({
+            type: phpft,
             project: p,
             locale: "zh-Hant-HK"
         });
@@ -636,9 +623,9 @@ describe("PHPresourcefile", function() {
             '     */\n' +
             '    public function getTranslationsMap() {\n' +
             '        return [\n' +
+            "            'more_source_text' => '更多源文本',\n" +
             "            'source_text' => '原始文字',\n" +
-            "            'more_source_text' => '更多源文本'\n" +
-            "            'yet_more_source_text' => '還有額外的源文本',\n" +
+            "            'yet_more_source_text' => '還有額外的源文本'\n" +
             '        ];\n' +
             '    }\n' +
             '}\n' +

--- a/packages/ilib-loctool-php-resource/test/PHPResourceFile.test.js
+++ b/packages/ilib-loctool-php-resource/test/PHPResourceFile.test.js
@@ -1,0 +1,652 @@
+/*
+ * PHPResourceFile.test.js - test the PHP file handler object.
+ *
+ * Copyright © 2024 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var PHPResourceFile = require("../PHPResourceFile.js");
+var CustomProject = require("loctool/lib/CustomProject.js");
+
+var p = new CustomProject({
+    id: "webapp",
+    sourceLocale: "en-US",
+    resourceDirs: {
+        "js": "localized"
+    }
+}, "./testfiles", {
+    locales:["en-GB", "de-DE", "de-AT"],
+    "php": {
+        // map to non-standard locale specifiers
+        "localeMap": {
+            "da-DK": "DaDK",
+            "de-DE": "DeDE",
+            "en-US": "EnUS",
+            "en-GB": "EnGB",
+            "es-ES": "EsES",
+            "fr-FR": "FrFR",
+            "it-IT": "ItIT",
+            "ja-JP": "JaJP",
+            "ko-KR": "KoKR",
+            "nl-NL": "NlNL",
+            "pt-BR": "PtBR",
+            "sv-SE": "SvSE",
+            "zh-Hans-CN": "ZhCN",
+            "zh-Hant-HK": "ZhHK",
+            "zh-Hant-TW": "ZhTW",
+            "zh-Hans-SG": "ZhSG"
+        },
+        "mappings": {
+            "**/*.php": {
+                template: "resource-files/Translation[locale].php"
+            }
+        }
+    }
+});
+
+describe("PHPresourcefile", function() {
+    test("PHPResourceFileConstructor", function() {
+        expect.assertions(1);
+
+        var phprf = new PHPResourceFile({
+            project: p
+        });
+        expect(phprf).toBeTruthy();
+    });
+
+    test("PHPResourceFileConstructorParams", function() {
+        expect.assertions(1);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            pathName: "localized/TranslationEnUS.php",
+            locale: "en-US"
+        });
+
+        expect(phprf).toBeTruthy();
+    });
+
+    test("PHPResourceFileIsDirty", function() {
+        expect.assertions(3);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            pathName: "localized/TranslationDeDE.php",
+            locale: "de-DE"
+        });
+
+        expect(phprf).toBeTruthy();
+        expect(!phprf.isDirty()).toBeTruthy();
+
+        [
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "source_text",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "Quellentext"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "more_source_text",
+                sourceLocale: "en-US",
+                source: "more source text",
+                target: "mehr Quellentext"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "yet_more_source_text",
+                sourceLocale: "en-US",
+                source: "yet more source text",
+                target: "noch mehr Quellentext"
+            })
+        ].forEach(function(res) {
+            phprf.addResource(res);
+        });
+
+        expect(phprf.isDirty()).toBeTruthy();
+    });
+
+    test("PHPResourceFileRightContents", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            pathName: "localized/TranslationDeDE.php",
+            locale: "de-DE"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        [
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "source_text",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "Quellentext"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "more_source_text",
+                sourceLocale: "en-US",
+                source: "more source text",
+                target: "mehr Quellentext"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "yet_more_source_text",
+                sourceLocale: "en-US",
+                source: "yet more source text",
+                target: "noch mehr Quellentext"
+            })
+        ].forEach(function(res) {
+            phprf.addResource(res);
+        });
+
+        var expected =
+            '<?php\n' +
+            '\n' +
+            '/**\n' +
+            ' * === Auto-generated class. Do not manually edit this file. ===\n' +
+            ' *\n' +
+            ' */\n' +
+            'class TranslationDeDE\n' +
+            '{\\n' +
+            '    /**\n' +
+            '     * Gives the pre-populated map of tags to translations\n' +
+            '     *\n' +
+            '     * @return array\n' +
+            '     */\n' +
+            '    public function getTranslationsMap() {\n' +
+            '        return [\n' +
+            "            'source_text' => 'Quellentext',\n" +
+            "            'more_source_text' => 'mehr Quellentext'\n" +
+            "            'yet_more_source_text' => 'noch mehr Quellentext',\n" +
+            '        ];\n' +
+            '    }\n' +
+            '}\n' +
+            '\n' +
+            '?>\n';
+        
+        expect(phprf.getContent()).toBe(expected);
+    });
+
+    test("PHPResourceFileGetContentsNoContent", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            pathName: "localized/TranslationDeDE.php",
+            locale: "de-DE"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        var expected =
+            '<?php\n' +
+            '\n' +
+            '/**\n' +
+            ' * === Auto-generated class. Do not manually edit this file. ===\n' +
+            ' *\n' +
+            ' */\n' +
+            'class TranslationDeDE\n' +
+            '{\\n' +
+            '    /**\n' +
+            '     * Gives the pre-populated map of tags to translations\n' +
+            '     *\n' +
+            '     * @return array\n' +
+            '     */\n' +
+            '    public function getTranslationsMap() {\n' +
+            '        return [\n' +
+            '        ];\n' +
+            '    }\n' +
+            '}\n' +
+            '\n' +
+            '?>\n';
+
+        expect(phprf.getContent()).toBe(expected);
+    });
+
+    test("PHPResourceFile don't escape double quotes", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            pathName: "localized/TranslationDeDE.php",
+            locale: "de-DE"
+        });
+
+        expect(phprf).toBeTruthy();
+        [
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "source_text",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "Quellen\"text"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "more_source_text",
+                sourceLocale: "en-US",
+                source: "more source text",
+                target: "mehr Quellen\"text"
+            })
+        ].forEach(function(res) {
+            phprf.addResource(res);
+        });
+
+        var expected =
+            '<?php\n' +
+            '\n' +
+            '/**\n' +
+            ' * === Auto-generated class. Do not manually edit this file. ===\n' +
+            ' *\n' +
+            ' */\n' +
+            'class TranslationDeDE\n' +
+            '{\\n' +
+            '    /**\n' +
+            '     * Gives the pre-populated map of tags to translations\n' +
+            '     *\n' +
+            '     * @return array\n' +
+            '     */\n' +
+            '    public function getTranslationsMap() {\n' +
+            '        return [\n' +
+            "            'source_text' => 'Quellen\"text',\n" +
+            "            'more_source_text' => 'mehr Quellen\"text'\n" +
+            '        ];\n' +
+            '    }\n' +
+            '}\n' +
+            '\n' +
+            '?>\n';
+
+        expect(phprf.getContent()).toBe(expected);
+    });
+
+    test("PHPResourceFile Do Escape Single Quotes", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            pathName: "localized/TranslationDeDE.php",
+            locale: "de-DE"
+        });
+
+        expect(phprf).toBeTruthy();
+        [
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "source_text",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "Quellen'text"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "more_source_text",
+                sourceLocale: "en-US",
+                source: "more source text",
+                target: "mehr Quellen'text"
+            })
+        ].forEach(function(res) {
+            phprf.addResource(res);
+        });
+
+        var expected =
+            '<?php\n' +
+            '\n' +
+            '/**\n' +
+            ' * === Auto-generated class. Do not manually edit this file. ===\n' +
+            ' *\n' +
+            ' */\n' +
+            'class TranslationDeDE\n' +
+            '{\\n' +
+            '    /**\n' +
+            '     * Gives the pre-populated map of tags to translations\n' +
+            '     *\n' +
+            '     * @return array\n' +
+            '     */\n' +
+            '    public function getTranslationsMap() {\n' +
+            '        return [\n' +
+            "            'source_text' => 'Quellen\\'text',\n" +
+            "            'more_source_text' => 'mehr Quellen\\'text'\n" +
+            '        ];\n' +
+            '    }\n' +
+            '}\n' +
+            '\n' +
+            '?>\n';
+
+        expect(phprf.getContent()).toBe(expected);
+    });
+
+    test("PHPResourceFileGetResourceFilePathDefaultLocaleForLanguage", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            locale: "de-DE"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        expect(phprf.getResourceFilePath()).toBe("testfiles/localized/de.php");
+    });
+
+    test("PHPResourceFileGetResourceFilePathDefaultLocaleForLanguageNoDefaultAvailable", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            locale: "de-DE"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        expect(phprf.getResourceFilePath()).toBe("testfiles/localized/TranslationDeDE.php");
+    });
+
+    test("PHPResourceFileGetResourceFilePathNonDefaultLocaleForLanguage", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            locale: "de-AT"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        expect(phprf.getResourceFilePath()).toBe("testfiles/localized/TranslationDeAT.php");
+    });
+
+    test("PHPResourceFileGetResourceFilePathDefaultLocaleForLanguageZH", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            locale: "zh-Hans-CN"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        expect(phprf.getResourceFilePath()).toBe("testfiles/localized/TranslationZhCN.php");
+    });
+
+    test("PHPResourceFileGetResourceFilePathDefaultLocale", function() {
+        expect.assertions(2);
+
+        // should default to English/US
+        var phprf = new PHPResourceFile({
+            project: p
+        });
+
+        expect(phprf).toBeTruthy();
+
+        expect(phprf.getResourceFilePath()).toBe("testfiles/localized/TranslationEnUS.php");
+    });
+
+    test("PHPResourceFileGetResourceFilePathAlreadyHasPath", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            locale: "de-AT",
+            pathName: "path/to/foo.php"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        expect(phprf.getResourceFilePath()).toBe("path/to/foo.php");
+    });
+
+    test("PHPResourceFileGetContentDefaultLocale", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            locale: "de-DE"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        [
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "source_text",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "Quellentext"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "more_source_text",
+                sourceLocale: "en-US",
+                source: "more source text",
+                target: "mehr Quellentext"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "de-DE",
+                key: "yet_more_source_text",
+                sourceLocale: "en-US",
+                source: "yet more source text",
+                target: "noch mehr Quellentext"
+            })
+        ].forEach(function(res) {
+            phprf.addResource(res);
+        });
+
+        // should use the default locale spec in the first line
+        var expected =
+            '<?php\n' +
+            '\n' +
+            '/**\n' +
+            ' * === Auto-generated class. Do not manually edit this file. ===\n' +
+            ' *\n' +
+            ' */\n' +
+            'class TranslationDeDE\n' +
+            '{\\n' +
+            '    /**\n' +
+            '     * Gives the pre-populated map of tags to translations\n' +
+            '     *\n' +
+            '     * @return array\n' +
+            '     */\n' +
+            '    public function getTranslationsMap() {\n' +
+            '        return [\n' +
+            "            'source_text' => 'Quellentext',\n" +
+            "            'more_source_text' => 'mehr Quellentext'\n" +
+            "            'yet_more_source_text' => 'noch mehr Quellentext',\n" +
+            '        ];\n' +
+            '    }\n' +
+            '}\n' +
+            '\n' +
+            '?>\n';
+
+        var actual = phprf.getContent();
+
+        expect(actual).toBe(expected);
+    });
+
+    test("PHPResourceFileGetContentDefaultLocaleZH", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            locale: "zh-Hans-CN"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        [
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "zh-Hans-CN",
+                key: "source_text",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "源文本"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "zh-Hans-CN",
+                key: "more_source_text",
+                sourceLocale: "en-US",
+                source: "more source text",
+                target: "更多源文本"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "zh-Hans-CN",
+                key: "yet_more_source_text",
+                sourceLocale: "en-US",
+                source: "yet more source text",
+                target: "还有附加源文本"
+            })
+        ].forEach(function(res) {
+            phprf.addResource(res);
+        });
+
+        // should use the default locale spec in the first line
+        var expected =
+            '<?php\n' +
+            '\n' +
+            '/**\n' +
+            ' * === Auto-generated class. Do not manually edit this file. ===\n' +
+            ' *\n' +
+            ' */\n' +
+            'class TranslationZhCN\n' +
+            '{\\n' +
+            '    /**\n' +
+            '     * Gives the pre-populated map of tags to translations\n' +
+            '     *\n' +
+            '     * @return array\n' +
+            '     */\n' +
+            '    public function getTranslationsMap() {\n' +
+            '        return [\n' +
+            "            'source_text' => '源文本',\n" +
+            "            'more_source_text' => '更多源文本'\n" +
+            "            'yet_more_source_text' => '还有附加源文本',\n" +
+            '        ];\n' +
+            '    }\n' +
+            '}\n' +
+            '\n' +
+            '?>\n';
+
+        var actual = phprf.getContent();
+
+        expect(actual).toBe(expected);
+    });
+
+    test("PHPResourceFileGetContentDefaultLocaleZH2", function() {
+        expect.assertions(2);
+
+        var phprf = new PHPResourceFile({
+            project: p,
+            locale: "zh-Hant-HK"
+        });
+
+        expect(phprf).toBeTruthy();
+
+        [
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "zh-Hant-HK",
+                key: "source_text",
+                sourceLocale: "en-US",
+                source: "source text",
+                target: "原始文字"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "zh-Hant-HK",
+                key: "more_source_text",
+                sourceLocale: "en-US",
+                source: "more source text",
+                target: "更多源文本"
+            }),
+            p.getAPI().newResource({
+                type: "string",
+                project: "webapp",
+                targetLocale: "zh-Hant-HK",
+                key: "yet_more_source_text",
+                sourceLocale: "en-US",
+                source: "yet more source text",
+                target: "還有額外的源文本"
+            })
+        ].forEach(function(res) {
+            phprf.addResource(res);
+        });
+
+        // should use the default locale spec in the first line
+        var expected =
+            '<?php\n' +
+            '\n' +
+            '/**\n' +
+            ' * === Auto-generated class. Do not manually edit this file. ===\n' +
+            ' *\n' +
+            ' */\n' +
+            'class TranslationZhHK\n' +
+            '{\\n' +
+            '    /**\n' +
+            '     * Gives the pre-populated map of tags to translations\n' +
+            '     *\n' +
+            '     * @return array\n' +
+            '     */\n' +
+            '    public function getTranslationsMap() {\n' +
+            '        return [\n' +
+            "            'source_text' => '原始文字',\n" +
+            "            'more_source_text' => '更多源文本'\n" +
+            "            'yet_more_source_text' => '還有額外的源文本',\n" +
+            '        ];\n' +
+            '    }\n' +
+            '}\n' +
+            '\n' +
+            '?>\n';
+
+        var actual = phprf.getContent();
+
+        expect(actual).toBe(expected);
+    });
+});

--- a/packages/ilib-loctool-php-resource/test/PHPResourceFileType.test.js
+++ b/packages/ilib-loctool-php-resource/test/PHPResourceFileType.test.js
@@ -96,12 +96,12 @@ describe("PHPresourcefiletype", function() {
         var ptf = new PHPResourceFileType(p);
         expect(ptf).toBeTruthy();
 
-        var phprf1 = ptf.getResourceFile("fr-FR", "fr/FR/foo.phpon");
+        var phprf1 = ptf.getResourceFile("fr-FR");
         expect(phprf1.getLocale().toString()).toBe("fr-FR");
 
         var phprf2 = ptf.getResourceFile("fr-FR", "sublibrary/fr/FR/foo.phpon");
         expect(phprf2.getLocale().toString()).toBe("fr-FR");
 
-        expect(phprf1).not.toBe(phprf2);
+        expect(phprf1 !== phprf2).toBeTruthy();
     });
 });

--- a/packages/ilib-loctool-php-resource/test/PHPResourceFileType.test.js
+++ b/packages/ilib-loctool-php-resource/test/PHPResourceFileType.test.js
@@ -1,0 +1,107 @@
+/*
+ * PHPResourceFileType.test.js - test the php resource file type
+ *
+ * Copyright © 2024 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var PHPResourceFileType = require("../PHPResourceFileType.js");
+var CustomProject =  require("loctool/lib/CustomProject.js");
+
+var p = new CustomProject({
+    sourceLocale: "en-US"
+}, "./testfiles", {
+    locales:["en-GB"]
+});
+
+describe("PHPresourcefiletype", function() {
+    test("PHPResourceFileTypeConstructor", function() {
+        expect.assertions(1);
+
+        var ptf = new PHPResourceFileType(p);
+
+        expect(ptf).toBeTruthy();
+    });
+
+    test("PHPResourceFileTypeHandlesPHP", function() {
+        expect.assertions(2);
+
+        var ptf = new PHPResourceFileType(p);
+        expect(ptf).toBeTruthy();
+
+        expect(ptf.handles("foo.php")).toBeFalsy();
+    });
+
+    test("PHPResourceFileTypeHandlesActualPHPResFile", function() {
+        expect.assertions(2);
+
+        var ptf = new PHPResourceFileType(p);
+        expect(ptf).toBeTruthy();
+
+        expect(ptf.handles("localized_js/de-DE.php")).toBeFalsy();
+    });
+
+    test("PHPResourceFileTypeHandlesAnythingFalse", function() {
+        expect.assertions(4);
+
+        var ptf = new PHPResourceFileType(p);
+        expect(ptf).toBeTruthy();
+
+        expect(ptf.handles("foo.tmpl.html")).toBeFalsy();
+        expect(ptf.handles("foo.html.haml")).toBeFalsy();
+        expect(ptf.handles("foo.yml")).toBeFalsy();
+    });
+
+    test("PHPResourceFileTypeGetResourceFile", function() {
+        expect.assertions(2);
+
+        var ptf = new PHPResourceFileType(p);
+        expect(ptf).toBeTruthy();
+
+        var phprf = ptf.getResourceFile("fr-FR");
+
+        expect(phprf.getLocale().toString()).toBe("fr-FR");
+    });
+
+    test("PHPResourceFileTypeGetResourceFileSameOneEachTime", function() {
+        expect.assertions(4);
+
+        var ptf = new PHPResourceFileType(p);
+        expect(ptf).toBeTruthy();
+
+        var phprf1 = ptf.getResourceFile("fr-FR");
+        expect(phprf1.getLocale().toString()).toBe("fr-FR");
+
+        var phprf2 = ptf.getResourceFile("fr-FR");
+        expect(phprf2.getLocale().toString()).toBe("fr-FR");
+
+        expect(phprf1).toStrictEqual(phprf2);
+    });
+
+    test("PHPResourceFileTypeGetResourceFileDifferentOneForDifferentPaths", function() {
+        expect.assertions(4);
+
+        var ptf = new PHPResourceFileType(p);
+        expect(ptf).toBeTruthy();
+
+        var phprf1 = ptf.getResourceFile("fr-FR", "fr/FR/foo.phpon");
+        expect(phprf1.getLocale().toString()).toBe("fr-FR");
+
+        var phprf2 = ptf.getResourceFile("fr-FR", "sublibrary/fr/FR/foo.phpon");
+        expect(phprf2.getLocale().toString()).toBe("fr-FR");
+
+        expect(phprf1).not.toBe(phprf2);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,7 +673,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
+        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1054,7 +1054,7 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.17.4)(node-notifier@8.0.2)
       loctool:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../loctool
 
   packages/ilib-loctool-po:
@@ -1546,7 +1546,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
+        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -10621,7 +10621,7 @@ snapshots:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.95.0(webpack-cli@5.1.4)
+      webpack: 5.95.0
 
   babel-plugin-add-module-exports@1.0.4: {}
 
@@ -17364,6 +17364,36 @@ snapshots:
       wildcard: 2.0.1
 
   webpack-sources@3.2.3: {}
+
+  webpack@5.95.0:
+    dependencies:
+      '@types/estree': 1.0.6
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.14.0
+      acorn-import-attributes: 1.9.5(acorn@8.14.0)
+      browserslist: 4.24.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.5.4
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(webpack@5.95.0)
+      watchpack: 2.4.2
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.95.0(webpack-cli@4.10.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,7 +673,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
+        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1037,6 +1037,22 @@ importers:
       jest:
         specifier: ^26.6.3
         version: 26.6.3
+      loctool:
+        specifier: workspace:*
+        version: link:../loctool
+
+  packages/ilib-loctool-php-resource:
+    dependencies:
+      ilib-locale:
+        specifier: ^1.2.2
+        version: 1.2.2
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
+    devDependencies:
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.4)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:*
         version: link:../loctool
@@ -1530,7 +1546,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
+        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -10605,7 +10621,7 @@ snapshots:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.95.0
+      webpack: 5.95.0(webpack-cli@5.1.4)
 
   babel-plugin-add-module-exports@1.0.4: {}
 
@@ -17348,36 +17364,6 @@ snapshots:
       wildcard: 2.0.1
 
   webpack-sources@3.2.3: {}
-
-  webpack@5.95.0:
-    dependencies:
-      '@types/estree': 1.0.6
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.14.0
-      acorn-import-attributes: 1.9.5(acorn@8.14.0)
-      browserslist: 4.24.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
-      es-module-lexer: 1.5.4
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.95.0)
-      watchpack: 2.4.2
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   webpack@5.95.0(webpack-cli@4.10.0):
     dependencies:


### PR DESCRIPTION
- copied from ilib-loctool-javascript-resource and modified to work with php (hence the ES5 code)
- still needs a loctool sample to show it working correctly, but all unit tests pass and this code is reviewable