### PR TITLE
Fix incomplete package entrypoint definitions

### DIFF
--- a/.changeset/beige-falcons-mate.md
+++ b/.changeset/beige-falcons-mate.md
@@ -1,0 +1,13 @@
+---
+"ilib-lint-python-gnu": patch
+"ilib-tools-common": patch
+"ilib-lint-common": patch
+"ilib-lint-python": patch
+"ilib-data-utils": patch
+"ilib-lint-react": patch
+"ilib-assemble": patch
+"ilib-lint": patch
+"tmxtool": patch
+---
+
+Unified package entrypoint definitions. This should help resolve edge cases where older packages (like Jest 26) were unable to correctly load some of them.

--- a/packages/ilib-assemble/package.json
+++ b/packages/ilib-assemble/package.json
@@ -1,8 +1,9 @@
 {
     "name": "ilib-assemble",
     "version": "1.3.1",
-    "main": "./src/index.js",
     "type": "module",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
     "bin": {
         "ilib-assemble": "./src/index.js",
         "ilib-assemble.bat": "./ilib-assemble.bat"

--- a/packages/ilib-data-utils/package.json
+++ b/packages/ilib-data-utils/package.json
@@ -3,6 +3,12 @@
     "version": "1.2.2",
     "main": "./lib/index.js",
     "module": "./src/index.js",
+    "exports": {
+        ".": {
+            "require": "./lib/index.js",
+            "import": "./src/index.js"
+        }
+    },
     "description": "Utilities used to generate locale data for ilib packages",
     "keywords": [
         "internationalization",

--- a/packages/ilib-lint-common/package.json
+++ b/packages/ilib-lint-common/package.json
@@ -1,8 +1,9 @@
 {
     "name": "ilib-lint-common",
     "version": "3.1.1",
-    "module": "./src/index.js",
     "type": "module",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
     "exports": {
         ".": {
             "import": "./src/index.js"

--- a/packages/ilib-lint-python-gnu/package.json
+++ b/packages/ilib-lint-python-gnu/package.json
@@ -1,13 +1,12 @@
 {
     "name": "ilib-lint-python-gnu",
     "version": "2.0.2",
-    "main": "./src/index.js",
     "type": "module",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
     "exports": {
         ".": {
-            "default": {
-                "default": "./src/index.js"
-            }
+            "import": "./src/index.js"
         },
         "./package.json": "./package.json"
     },

--- a/packages/ilib-lint-python/package.json
+++ b/packages/ilib-lint-python/package.json
@@ -1,13 +1,12 @@
 {
     "name": "ilib-lint-python",
     "version": "2.0.2",
-    "main": "./src/index.js",
     "type": "module",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
     "exports": {
         ".": {
-            "default": {
-                "default": "./src/index.js"
-            }
+            "import": "./src/index.js"
         },
         "./package.json": "./package.json"
     },

--- a/packages/ilib-lint-react/package.json
+++ b/packages/ilib-lint-react/package.json
@@ -1,13 +1,12 @@
 {
     "name": "ilib-lint-react",
     "version": "2.0.2",
-    "main": "./src/index.js",
     "type": "module",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
     "exports": {
         ".": {
-            "default": {
-                "default": "./src/index.js"
-            }
+            "import": "./src/index.js"
         },
         "./package.json": "./package.json"
     },

--- a/packages/ilib-lint/package.json
+++ b/packages/ilib-lint/package.json
@@ -1,8 +1,9 @@
 {
     "name": "ilib-lint",
     "version": "2.7.1",
-    "module": "./src/index.js",
     "type": "module",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
     "bin": "./src/index.js",
     "description": "A linter for i18n issues for any type of project",
     "keywords": [

--- a/packages/ilib-tools-common/package.json
+++ b/packages/ilib-tools-common/package.json
@@ -1,6 +1,7 @@
 {
     "name": "ilib-tools-common",
     "version": "1.12.1",
+    "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {
         ".": {

--- a/packages/tmxtool/package.json
+++ b/packages/tmxtool/package.json
@@ -1,8 +1,9 @@
 {
     "name": "tmxtool",
     "version": "1.0.3",
-    "main": "./src/index.js",
     "type": "module",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
     "bin": {
         "tmxtool": "./src/index.js",
         "tmxtool.bat": "./tmxtool.bat"

--- a/scripts/check-package-exports.js
+++ b/scripts/check-package-exports.js
@@ -1,0 +1,51 @@
+// Usage: node scripts/check-package-exports.js
+// This script checks that all packages have correct entrypoint fields
+
+const fs = require("fs");
+
+const packageFiles = fs
+    .readdirSync("packages")
+    .map((package) => `packages/${package}/package.json`)
+    .filter((file) => fs.existsSync(file));
+for (const path of packageFiles) {
+    console.log(`Processing ${path}`);
+    const data = fs.readFileSync(path, "utf8");
+    const pkg = JSON.parse(data);
+
+    const { main, module } = pkg;
+
+    const type = pkg.type ?? "commonjs";
+
+    // either { exports: { .: { import, require } } } or { exports: { import, require } }
+    const exportsRoot = pkg.exports?.["."] ?? pkg.exports;
+
+    if (!main) {
+        // main should be present regardless of type
+        // because it's the default entry point for a package in Node.js
+        // if type is commonjs, it should point to a commonjs file,
+        // if type is module, it should point to an es module file
+        console.error("No main field found");
+    }
+
+    if (type === "module" && !module) {
+        // module should be present if type is module
+        // this is not officially required, but often used for ESM entry point
+        console.error("Type is module, but no module field found");
+    }
+
+    if (main && module && main !== module && !exportsRoot) {
+        // when both main and module are present and are different,
+        // this means that the package provides both CJS and ESM code;
+        // in this case, per Node documentation, the package should have an exports field
+        // with separate import and require: https://nodejs.org/api/packages.html#conditional-exports
+        console.error("Main and module are different, but no exports field found");
+    }
+
+    if (exportsRoot && (!type || type === "commonjs") && !exportsRoot.require) {
+        console.error("Exports are present and type is commonjs, but no require field found in exports");
+    }
+
+    if (exportsRoot && type === "module" && !exportsRoot.import) {
+        console.error("Exports are present and type is module, but no import field found in exports");
+    }
+}


### PR DESCRIPTION
Fixed package.jsons in multiple monorepo packages to resolve some potential edge cases where various older setups might exhibit unexpected behaviour (like trouble loading them) due to missing or inconsistent `main`, `module` and `exports` entrypoint definitions

* issue was discovered in tests for https://github.com/iLib-js/ilib-mono/pull/31
```log
ilib-loctool-properties:test
cache miss, executing 104049eb1388b187

> ilib-loctool-properties@1.0.5 test /home/runner/work/ilib-mono/ilib-mono/packages/ilib-loctool-properties
> jest

FAIL test/PropertiesFile.test.js
  ● Test suite failed to run

    Cannot find module 'ilib-tools-common' from '../ilib-po/lib/Parser.js'

    Require stack:
      /home/runner/work/ilib-mono/ilib-mono/packages/ilib-po/lib/Parser.js
      /home/runner/work/ilib-mono/ilib-mono/packages/ilib-po/lib/POFile.js
      /home/runner/work/ilib-mono/ilib-mono/packages/ilib-po/lib/index.js
      /home/runner/work/ilib-mono/ilib-mono/packages/loctool/lib/POIntermediateFile.js
      /home/runner/work/ilib-mono/ilib-mono/packages/loctool/lib/IntermediateFileFactory.js
      /home/runner/work/ilib-mono/ilib-mono/packages/loctool/lib/LocalRepository.js
      /home/runner/work/ilib-mono/ilib-mono/packages/loctool/lib/Project.js
      /home/runner/work/ilib-mono/ilib-mono/packages/loctool/lib/CustomProject.js
      test/PropertiesFile.test.js

      45 | };
      46 | Object.defineProperty(exports, "__esModule", { value: true });
    > 47 | const ilib_tools_common_1 = require("ilib-tools-common");
         |                             ^
      48 | // @ts-expect-error -- untyped package
      49 | const ilib_locale_1 = __importDefault(require("ilib-locale"));
      50 | const SyntaxError_1 = __importDefault(require("./SyntaxError"));

      at Resolver.resolveModule (../../node_modules/.pnpm/jest-resolve@26.6.2/node_modules/jest-resolve/build/index.js:306:11)
      at Object.<anonymous> (../ilib-po/lib/Parser.js:47:29)
      at Object.<anonymous> (../ilib-po/lib/POFile.js:27:34)
      at Object.<anonymous> (../ilib-po/lib/index.js:25:34)
      at Object.<anonymous> (../loctool/lib/POIntermediateFile.js:21:10)
      at Object.<anonymous> (../loctool/lib/IntermediateFileFactory.js:23:26)
      at Object.<anonymous> (../loctool/lib/LocalRepository.js:27:27)
      at Object.<anonymous> (../loctool/lib/Project.js:27:23)
      at Object.<anonymous> (../loctool/lib/CustomProject.js:24:15)
      at Object.<anonymous> (test/PropertiesFile.test.js:23:26)
```
* would also be resolved by https://github.com/iLib-js/ilib-mono/pull/36 but merging that first would mask the underlying issue

Also checked in a script to validate package.json entrypoints in bulk.
