### PR TITLE
ilib-loctool-regex: Add new regex-based plugin

### DIFF
--- a/.changeset/weak-fireants-brake.md
+++ b/.changeset/weak-fireants-brake.md
@@ -1,0 +1,8 @@
+---
+"ilib-loctool-regex": major
+---
+
+- Added a regular expression-based parser for text files.
+- Regular expressions are given in the project.json config file
+  plus some configuration instructing loctool how to make
+  Resource instances out of the result

--- a/.changeset/weak-fireants-brake.md
+++ b/.changeset/weak-fireants-brake.md
@@ -2,7 +2,9 @@
 "ilib-loctool-regex": major
 ---
 
-- Added a regular expression-based parser for text files.
+- Added a regular expression-based parser to extract localizable
+  strings from any type of textual source file such as php, java,
+  or javascript.
 - Regular expressions are given in the project.json config file
-  plus some configuration instructing loctool how to make
-  Resource instances out of the result
+  plus some configuration instructing loctool how to construct
+  Resource instances out of the regex match results.

--- a/packages/ilib-loctool-regex/LICENSE
+++ b/packages/ilib-loctool-regex/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -316,7 +316,7 @@ most recent updates to this package.
 
 ## License
 
-Copyright © 2024 Box, Inc.
+Copyright © 2024-2025 Box, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -14,7 +14,10 @@ of the `project.json` file:
 - The `projectType` setting should be set to `custom`
 - The `resourceFileTypes` setting should be set to an object that
   maps a resource file type to a loctool plugin that implements
-  the resource file format.
+  the resource file format. You can choose any name for the resource
+  file type, but you should choose a name that is descriptive of the
+  type of resource file that will be generated, and one that is
+  unique.
 
 ### Custom Settings
 

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -93,10 +93,14 @@ used within the `regex` property:
         - keyStrategy - if the unique key is not extracted with a capturing group
           in the source file, this property can be used to specify how to calculate
           a key automatically. This can be one of the following values:
-            - "hash" - use a hash of the source string as the key
-            - "source" - use the whole source string as the key
+            - "hash" - use a hash of the source string as the key. The hash is
+              usually much shorter than the source string, but has a 1 in a
+              few million chance of conflicting with the hash of another unrelated
+              string.
+            - "source" - use the whole source string as the key. This can get
+              quite long, but it is always unique.
             - "truncate" - use the first 32 characters of the source
-              string as the key
+              string as the key. This fixed-length key is usually unique.
 
 Example configuration for a web project with PHP and JavaScript files:
 
@@ -162,7 +166,9 @@ given regular expressions. Explanation of the above regexes:
 
 1. The first regular expression extracts strings
 that are passed as the first parameter to the `translate` function. It will match
-a string like `translate("string to translate")`.
+a string like `translate("string to translate")`. Since the string does not have
+a unique id, one is generated using the `source` strategy. That is, the source
+string itself is re-used as its own unique id.
 1. The second regular expression extracts strings that are passed as the first
 parameter to the `translate` function and the second parameter is the
 key of the string. It will match a string like `translate("string to translate", "unique.id")`.
@@ -187,7 +193,10 @@ the first parameter to the `$t` function. The extracted strings will be
 localized and placed in a JSON resource file. The resource file will be
 named `strings-[locale].json` where `[locale]` is replaced with the locale
 of the localized strings. It matches strings like 
-`$t("this is the string to translate")`.
+`$t("this is the string to translate")`. Since this type of string extracted
+from js files file do not have their own unique id, one is generated using
+the `hash` strategy. That is, the hash of the source string is taken, and
+the string version of that hash is used as unique id.
 
 ## Some Tips for Getting Your Regular Expressions to Work Correctly
 
@@ -200,9 +209,11 @@ of the localized strings. It matches strings like
 - Regular expressions are greedy by default. This means that they will
   match as much as possible. If you want to match as little as possible,
   you can add the `?` flag to the regular expression. For example, the
-  regular expression `"[^"]*"` will match a string, but it may capture
+  regular expression `"[^"]*"` will match a string, but it may also capture
   everything between two strings on the same line. `"[^"]*?"` will only
-  match the first string on the line.
+  match the first string on the line. Example input:
+  `"first string", other stuff, "second string"`. The first regex will
+  match all of that, whereas the second one will only match "first string".
 - Remember to escape things properly in the json strings. If you put
   the regular expression `"a\sb"`, it will be looking for the string "asb".
   You need to escape the backslack in order to get "a" followed by a

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -207,6 +207,34 @@ Trying regular expression: translate\s*(\s*['"](?<source>[^'"]*)['"]\s*\)
 ]
 ```
 
+### Some Tips
+
+- Regular expressions are case sensitive by default. If you want to
+  match case insensitively, you can add the `i` flag to the regular
+  expression.
+- Regular expressions are greedy by default. This means that they will
+  match as much as possible. If you want to match as little as possible,
+  you can add the `?` flag to the regular expression.
+- Regular expressions will match the first occurrence in the string by
+  default. If you want to match all occurrences, you can add the `g` flag
+  to the regular expression. Pretty much all regular expressions in your
+  config file should have the `g` flag.
+- Regular expressions by default only match regular ASCII characters. If
+  you want to match Unicode characters, you can add the `u` or the `v`
+  flag to the regular expression. This will allow you to match any Unicode
+  character in the string encoded with the `\u` escape sequences. Example:
+  `/\u{1F600}/u` will match the Unicode character for the grinning face emoji.
+- Expressions in the config file are applied in the order they are listed.
+  If you have two expressions that could match the same string or part of the
+  same string, the first one that matches will be the one that is used. Make
+  sure that the expressions are listed such that the longer expressions are
+  listed first.
+- To test your regular expressions in a much more friendly and interactive
+  way, you can use the [RegExr](https://regexr.com/) website. This website
+  allows you to enter a regular expression and a string to match against. It
+  will show you the results in real time as you type. It can also give you
+  a description of what each part of the regular expression does.
+
 ## Release Notes
 
 Please see the [release notes](./CHANGELOG.md) for information on the

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -50,8 +50,13 @@ used within the json property:
           Regular expressions use [JavaScript regular expression
           syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions).
           The regular expressions must contain named capturing groups to
-          indicate the various parts that form a Resource. The named
-          capturing groups should be from this list:
+          indicate the various parts that form a Resource. The value of
+          the named capturing group can be any string. If the string is
+          surrounded by quotes (either single or double), the plugin will
+          remove the quotes. For array resources, the strings should be
+          separated by commas and may have quotes around each element of
+          the array. The names of the named capturing groups should be from
+          this list:
             - `source` - the string in the source language (required). For
               plural resources, use this for the singular form of the string.
               For array resources, this should contain the list of strings

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -29,12 +29,15 @@ used within the `regex` property:
   similar to the the `includes` and `excludes` section of a
   `project.json` file. The value of that mapping is an object that
   can contain the following properties:
-    - resourceFileType - the type of the resource file that will be
-      generated from the localized strings. This is the name of the
-      plugin that will be used to generate the resource file. This
-      overrides the shared resourceFileType at the root level of the
-      project.json, which specifies the default resource file type
-      for the whole project.
+    - resourceFileType - the name of the type of the resource file that
+      will be generated from the localized strings extracted from these
+      files. The resource file types are defined in the `resourceFileTypes`
+      setting at the top level of the `project.json` file. The name can
+      be any string as long as it is defined in `resourceFileTypes` object.
+      The resourceFileTypes object gives a mapping between these names
+      and the npm package name of the plugin that implements the resource
+      file type. The plugin must be installed in the project, with a
+      dependency in the `package.json` file in order to be loaded successfully.
     - template - the template to specify the output resource file
       path. See the loctool documentation for more information on
       how to use path name templates.
@@ -106,11 +109,16 @@ Example configuration for a web project with PHP and JavaScript files:
 
 ```json
 {
+    "projectType": "custom",
+    "resourceFileTypes": {
+        "php": "ilib-loctool-php-resource",
+        "json": "ilib-loctool-javascript-resource"
+    },
     "settings": {
         "regex": {
             "mappings": {
                 "**/*.php": {
-                    "resourceFileType": "ilib-loctool-php-resource",
+                    "resourceFileType": "php",
                     "template": "resources/Translations-[locale].php",
                     "sourceLocale": "en-US",
                     "expressions": [
@@ -142,7 +150,7 @@ Example configuration for a web project with PHP and JavaScript files:
                     ]
                 },
                 "**/*.js": {
-                    "resourceFileType": "ilib-loctool-json",
+                    "resourceFileType": "json",
                     "template": "resources/strings-[locale].json",
                     "sourceLocale": "en-US",
                     "expressions": [
@@ -183,20 +191,27 @@ string and is assigned to the `sourcePlural` capturing group. This creates a plu
 resource where the `source` string is the `one` plural category, and the `sourcePlural`
 string is the `other` plural category.
 
-The extracted strings will be localized and placed in
-a PHP resource file. The resource file will be named `Translations-[locale].php`
-where `[locale]` is replaced with the locale of the localized strings.
+The first mapping extracts strings from PHP files. The strings are
+extracted from the first parameter of `translate` function calls. The extracted
+strings will be
+localized and placed in a resource file of the type `php` which is implemented
+by the npm package `ilib-loctool-php-resource`. The resource file will be named
+`Translations-[locale].php` where `[locale]` is replaced with the locale of the
+localized strings, and the loctool will produce one of these files for each
+locale that it processes.
 
 Furthermore, any file named `*.js` will be parsed with the given regular
-expression. The regular expression extracts strings that are passed as
+js expression. The regular expression extracts strings that are passed as
 the first parameter to the `$t` function. The extracted strings will be
-localized and placed in a JSON resource file. The resource file will be
+localized and placed in a resource file of type `json`, which is implemented
+by the npm package `ilib-loctool-javascript-resource`. The resource file will be
 named `strings-[locale].json` where `[locale]` is replaced with the locale
 of the localized strings. It matches strings like 
 `$t("this is the string to translate")`. Since this type of string extracted
 from js files does not have its own unique id, one is generated using
-the `hash` strategy. That is, the hash of the source string is taken, and
-the string version of that hash is used as unique id.
+the `hash` strategy. That is, the hash of the source string is calculated
+and prepended with an "r" for "resource" (eg. "r34523234") and that is used
+as the unique id for that string.
 
 ## Some Tips for Getting Your Regular Expressions to Work Correctly
 

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -85,9 +85,11 @@ used within the `regex` property:
           helps when trying to escape or unescape the string. Typically this
           is something like "java" or "js" or "html". This can be any string.
         - resourceType - the type of the resource that is being extracted.
-          This can be one of the following values:
-            - string - a simple string (the default - must define the source capturing group)
-            - plural - a plural string (regex must define both source and sourcePlural capturing groups)
+          See the description below for how the named capturing groups are
+          mapped to field names for each of these resource types.
+          The `resourceType` setting must have one of the following values:
+            - string - a simple string
+            - plural - a plural string
             - array - an array of strings
         - context - the context of the string. This can be any string
           that gives more information about the context of the string. This
@@ -212,6 +214,52 @@ from js files does not have its own unique id, one is generated using
 the `hash` strategy. That is, the hash of the source string is calculated
 and prepended with an "r" for "resource" (eg. "r34523234") and that is used
 as the unique id for that string.
+
+### Resource Type Field Mapping
+
+The `resourceType` setting for each mapping specifies the type of the
+resource that is being extracted. The named capturing groups in the regular
+expression are mapped to the fields in the resource file based on this
+setting. The following table shows how the named capturing groups are
+mapped to the fields in the resource file for each of the resource types:
+
+| Resource Type | Named Capturing Groups | Resource Fields      |
+|---------------|------------------------|----------------------|
+| string        | source                 | source               |
+| plural        | source                 | source.one           |
+| plural        | sourcePlural           | source.other         |
+| array         | source                 | source               |
+| all           | key                    | reskey               |
+| all           | comment                | comment              |
+| all           | context                | context              |
+| all           | flavor                 | flavor               |
+
+For array resource types, the `source` capturing group should contain a
+comma-separated list of strings. The plugin will split this string on commas
+and trim the quotes from each part. This will be the array of strings
+in the resource file.
+
+Example source file:
+
+```javascript
+$t(["array", "to", "translate"], "unique_reskey");
+```
+
+The expressions in the sample configuration above would parse this example
+and set the value of the `source` capturing group to
+`"array", "to", "translate"` which would create a resource file entry
+like this:
+
+```javascript
+    const resource = new ResourceArray({
+        "reskey": "unique_reskey",
+        "source": [
+            "array",
+            "to",
+            "translate"
+        ]
+    });
+```
 
 ## Some Tips for Getting Your Regular Expressions to Work Correctly
 

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -154,6 +154,48 @@ localized and placed in a JSON resource file. The resource file will be
 named `strings-[locale].json` where `[locale]` is replaced with the locale
 of the localized strings.
 
+## Testing your Regular Expressions
+
+Getting regular expressions right can be tricky. The `ilib-loctool-regex`
+plugin uses the JavaScript regular expression engine to extract strings
+from your source files. This means that you can use any regular expression
+that is valid in JavaScript. Javascript regular expressions have their
+own quirks different than other regular expression engines. Often, you
+will create a regular expression,
+place it into the config file, run the loctool, and see that it does not
+extract all the strings you expect it to extract. This is almost always
+because the regular expression itself is not quite right. When this happens,
+you will not necessarily get any error messages from the loctool. The strings
+will just mysteriously not show up in the resource file.
+
+To help you get your regular expressions right, you can test them using
+the `testregex` command line tool that comes with this plugin. The `testregex`
+tool takes a path to your project's config file and the name of a file
+to match against. It will run the regular expressions in the config file
+against the contents of the file and show you the results in a very verbose
+manner. This can help you see exactly what the regular expression is doing
+and perhaps give a clue as to why it is not extracting the strings that
+you expect.
+
+Example usage:
+
+```sh
+testregex folder/a/b/c/project.json myfile.php
+```
+
+This will run the regular expressions in the `project.json` file against
+the contents of the `myfile.php` file in the same way that the loctool
+will and show you the results.
+
+Example output:
+
+```
+Running regular expression "\\btranslate\\s*(\\s*['\"](?<source>[^'\"]*)['\"]\\s*)" against file "myfile.php"
+Extracted strings:
+    translate("Hello, world!")
+    translate("Goodbye, world!")
+```
+
 ## Release Notes
 
 Please see the [release notes](./CHANGELOG.md) for information on the

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -104,14 +104,14 @@ Example configuration for a web project with PHP and JavaScript files:
                     "sourceLocale": "en-US",
                     "expressions": [
                         {
-                            "expression": "\\btranslate\\s*(\\s*['\"](?<source>[^'\"]*)['\"]\\s*\\)",
+                            "expression": "translate\\s*(\\s*['\"](?<source>[^'\"]*)['\"]\\s*\\)",
                             "flags": "g",
                             "datatype": "php",
                             "resourceType": "string",
                             "keyStrategy": "source"
                         },
                         {
-                            "expression": "\\btranslate\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*,\\s*['\"](?<key>[^'\"]*)['\"]\\s*\\)",
+                            "expression": "translate\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*,\\s*['\"](?<key>[^'\"]*)['\"]\\s*\\)",
                             "flags": "g",
                             "datatype": "php",
                             "resourceType": "string"
@@ -170,8 +170,9 @@ will just mysteriously not show up in the resource file.
 
 To help you get your regular expressions right, you can test them using
 the `testregex` command line tool that comes with this plugin. The `testregex`
-tool takes a path to your project's config file and the name of a file
-to match against. It will run the regular expressions in the config file
+tool takes a path to the root of your project where the project.json config file
+is located, and the name of a file to match against.
+It will run the regular expressions in the config file
 against the contents of the file and show you the results in a very verbose
 manner. This can help you see exactly what the regular expression is doing
 and perhaps give a clue as to why it is not extracting the strings that
@@ -180,20 +181,30 @@ you expect.
 Example usage:
 
 ```sh
-testregex folder/a/b/c/project.json myfile.php
+testregex folder/a/b/c myfile.php
 ```
 
-This will run the regular expressions in the `project.json` file against
+This will run the regular expressions in the `folder/a/b/c/project.json` file against
 the contents of the `myfile.php` file in the same way that the loctool
 will and show you the results.
 
 Example output:
 
 ```
-Running regular expression "\\btranslate\\s*(\\s*['\"](?<source>[^'\"]*)['\"]\\s*)" against file "myfile.php"
-Extracted strings:
-    translate("Hello, world!")
-    translate("Goodbye, world!")
+File: ./myfile.php
+Matched mapping: ["**/*.php"]
+Trying regular expression: translate\s*(\s*['"](?<source>[^'"]*)['"]\s*\)
+  Flags: g
+  Result:
+[
+  "0": "translate(\"Hello, world!\");",
+  "1": "Hello, world!",
+  "groups": {
+    "source": "Hello, world!"
+  },
+  "index": 0,
+  "length": 2
+]
 ```
 
 ## Release Notes

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -8,12 +8,13 @@ with regular expressions.
 
 ### Standard Settings
 
-To use this plugin, you should set these two settings:
+To use this plugin, you should set these two settings at the top level
+of the `project.json` file:
 
 - The `projectType` setting should be set to `custom`
 - The `resourceFileTypes` setting should be set to an object that
-  includes the `regex` property. The value names the plugin
-  that will be used as a resource file format.
+  maps a resource file type to a loctool plugin that implements
+  the resource file format.
 
 ### Custom Settings
 
@@ -29,8 +30,8 @@ used within the `regex` property:
   similar to the the `includes` and `excludes` section of a
   `project.json` file. The value of that mapping is an object that
   can contain the following properties:
-    - resourceFileType - the name of the type of the resource file that
-      will be generated from the localized strings extracted from these
+    - resourceFileType - the name of the type of the resource file type
+      that will be generated from the localized strings extracted from these
       files. The resource file types are defined in the `resourceFileTypes`
       setting at the top level of the `project.json` file. The name can
       be any string as long as it is defined in `resourceFileTypes` object.
@@ -38,6 +39,7 @@ used within the `regex` property:
       and the npm package name of the plugin that implements the resource
       file type. The plugin must be installed in the project, with a
       dependency in the `package.json` file in order to be loaded successfully.
+      (Usually, it is a `devDependency`.)
     - template - the template to specify the output resource file
       path. See the loctool documentation for more information on
       how to use path name templates.
@@ -77,6 +79,9 @@ used within the `regex` property:
               translator
             - `context` - the context of the string
             - `flavor` - the flavor of the string (mostly for Android)
+          Examples of various regular expressions are given below in the section
+          "Example Configuration" which give an idea of how to use these
+          capturing groups.
         - flags - the regular expression flags to use when extracting
           the strings. See the [JavaScript regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions)
           documentation for more information on regular expression flags.
@@ -106,6 +111,8 @@ used within the `regex` property:
               quite long, but it is always unique.
             - "truncate" - use the first 32 characters of the source
               string as the key. This fixed-length key is usually unique.
+
+### Example Configuration
 
 Example configuration for a web project with PHP and JavaScript files:
 

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -1,0 +1,172 @@
+# ilib-loctool-regex
+
+ilib-loctool-regex is a plugin for the loctool that
+allows it to read and localize any file types that can be processed
+with regular expressions.
+
+## Configuring the Plugin
+
+### Standard Settings
+
+To use this plugin, you should set these two settings:
+
+- The `projectType` setting should be set to `custom`
+- The `resourceFileTypes` setting should be set to an object that
+  includes the `regex` property. The value names the plugin
+  that will be used as a resource file format.
+
+### Custom Settings
+
+The plugin will look for the `regex` property within the `settings`
+of your `project.json` file. The following settings are
+used within the json property:
+
+- mappings: a mapping between file matchers and an object that gives
+  info used to localize the files that match it. This allows different
+  files within the project to be processed with different regular
+  expressions. The matchers are
+  a [micromatch-style string](https://www.npmjs.com/package/micromatch),
+  similar to the the `includes` and `excludes` section of a
+  `project.json` file. The value of that mapping is an object that
+  can contain the following properties:
+    - resourceFileType - the type of the resource file that will be
+      generated from the localized strings. This is the name of the
+      plugin that will be used to generate the resource file.
+    - template - the template to specify the output resource file
+      path. See the loctool documentation for more information on
+      how to use path name templates.
+    - sourceLocale - the locale of the source strings. This is the
+      locale in which the strings are written in the source files.
+    - expressions - an array of objects that document the regular
+      expressions to use to extract strings from the source file
+      and some additional information. The strings
+      will be extracted, localized, and placed in the resource file.
+      Each object in the array can contain the following properties:
+        - expression - the regular expression to use to extract the
+          strings from the source file. The regular expressions should
+          be in the form of a string, not a regular expression object,
+          because json files cannot contain regular expression objects.
+          The string should not have the leading and trailing slashes.
+          Regular expressions use [JavaScript regular expression
+          syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions).
+          The regular expressions must contain named capturing groups to
+          indicate the various parts that form a Resource. The named
+          capturing groups should be from this list:
+            - `source` - the string in the source language (required). For
+              plural resources, use this for the singular form of the string.
+              For array resources, this should contain the list of strings
+              in comma-separated form. For example, "one, two, three". The
+              plugin will split this string on commas and trim each part.
+            - `sourcePlural` - for plural resources, this gives the plural
+              form of the string.
+            - `key` - the unique key of the string
+            - `comment` - a comment that describes the string for the
+              translator
+            - `context` - the context of the string
+            - `flavor` - the flavor of the string (mostly for Android)
+        - flags - the regular expression flags to use when extracting
+          the strings. See the [JavaScript regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions)
+          documentation for more information on regular expression flags.
+        - datatype - the type of the resource that is being extracted.
+          This indicates the type of file that the resource came from which
+          helps when trying to escape or unescape the string. Typically this
+          is something like "java" or "js" or "html". This can be any string.
+        - resourceType - the type of the resource that is being extracted.
+          This can be one of the following values:
+            - string - a simple string (the default)
+            - plural - a plural string
+            - array - an array of strings
+        - context - the context of the string. This can be any string
+          that gives more information about the context of the string.
+        - keyStrategy - if the unique key is not given in the source
+          file, this property can be used to specify how to calculate
+          the key. This can be one of the following values:
+            - "hash" - use a hash of the source string as the key
+            - "source" - use the whole source string as the key
+            - "truncate" - use the first 32 characters of the source
+              string as the key
+
+Example configuration for a web project with PHP and JavaScript files:
+
+```json
+{
+    "settings": {
+        "regex": {
+            "mappings": {
+                "**/*.php": {
+                    "resourceFileType": "ilib-loctool-php-resource",
+                    "template": "resources/Translations-[locale].php",
+                    "sourceLocale": "en-US",
+                    "expressions": [
+                        {
+                            "expression": "\\btranslate\\s*(\\s*['\"](?<source>[^'\"]*)['\"]\\s*\\)",
+                            "flags": "g",
+                            "datatype": "php",
+                            "resourceType": "string",
+                            "keyStrategy": "source"
+                        },
+                        {
+                            "expression": "\\btranslate\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*,\\s*['\"](?<key>[^'\"]*)['\"]\\s*\\)",
+                            "flags": "g",
+                            "datatype": "php",
+                            "resourceType": "string"
+                        }
+                    ]
+                },
+                "**/*.js": {
+                    "resourceFileType": "ilib-loctool-json",
+                    "template": "resources/strings-[locale].json",
+                    "sourceLocale": "en-US",
+                    "expressions": [
+                        {
+                            "expression": "\b\\$t\\s*\\(\"(?<source>[^\"]*)\"\\)",
+                            "flags": "g",
+                            "datatype": "js",
+                            "resourceType": "string",
+                            "keyStrategy": "hash"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+```
+
+In the above example, any file named `*.php` will be parsed with both the
+given regular expressions. The first regular expression extracts strings
+that are passed as the first parameter to the `translate` function. The
+second regular expression extracts strings that are passed as the first
+parameter to the `translate` function and the second parameter is the
+key of the string. The extracted strings will be localized and placed in
+a PHP resource file. The resource file will be named `Translations-[locale].php`
+where `[locale]` is replaced with the locale of the localized strings.
+
+Furthermore, any file named `*.js` will be parsed with the given regular
+expression. The regular expression extracts strings that are passed as
+the first parameter to the `$t` function. The extracted strings will be
+localized and placed in a JSON resource file. The resource file will be
+named `strings-[locale].json` where `[locale]` is replaced with the locale
+of the localized strings.
+
+## Release Notes
+
+Please see the [release notes](./CHANGELOG.md) for information on the
+most recent updates to this package.
+
+## License
+
+Copyright © 2024 Box, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -19,7 +19,7 @@ To use this plugin, you should set these two settings:
 
 The plugin will look for the `regex` property within the `settings`
 of your `project.json` file. The following settings are
-used within the json property:
+used within the `regex` property:
 
 - mappings: a mapping between file matchers and an object that gives
   info used to localize the files that match it. This allows different
@@ -31,7 +31,10 @@ used within the json property:
   can contain the following properties:
     - resourceFileType - the type of the resource file that will be
       generated from the localized strings. This is the name of the
-      plugin that will be used to generate the resource file.
+      plugin that will be used to generate the resource file. This
+      overrides the shared resourceFileType at the root level of the
+      project.json, which specifies the default resource file type
+      for the whole project.
     - template - the template to specify the output resource file
       path. See the loctool documentation for more information on
       how to use path name templates.
@@ -46,16 +49,18 @@ used within the json property:
           strings from the source file. The regular expressions should
           be in the form of a string, not a regular expression object,
           because json files cannot contain regular expression objects.
-          The string should not have the leading and trailing slashes.
           Regular expressions use [JavaScript regular expression
           syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions).
           The regular expressions must contain named capturing groups to
           indicate the various parts that form a Resource. The value of
-          the named capturing group can be any string. If the string is
-          surrounded by quotes (either single or double), the plugin will
-          remove the quotes. For array resources, the strings should be
+          the named capturing group can be any string. If the matched
+          string for a capturing group is surrounded by quotes (either single
+          or double), the plugin will remove the outer quotes. For array
+          resources, the matched strings should be
           separated by commas and may have quotes around each element of
-          the array. The names of the named capturing groups should be from
+          the array. This plugin will remove all the quotes from each array
+          element.
+          The names of the named capturing groups should be from
           this list:
             - `source` - the string in the source language (required). For
               plural resources, use this for the singular form of the string.
@@ -73,19 +78,21 @@ used within the json property:
           the strings. See the [JavaScript regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions)
           documentation for more information on regular expression flags.
         - datatype - the type of the resource that is being extracted.
-          This indicates the type of file that the resource came from which
+          This indicates the type of file that the resource came from, which
           helps when trying to escape or unescape the string. Typically this
           is something like "java" or "js" or "html". This can be any string.
         - resourceType - the type of the resource that is being extracted.
           This can be one of the following values:
-            - string - a simple string (the default)
-            - plural - a plural string
+            - string - a simple string (the default - must define the source capturing group)
+            - plural - a plural string (regex must define both source and sourcePlural capturing groups)
             - array - an array of strings
         - context - the context of the string. This can be any string
-          that gives more information about the context of the string.
-        - keyStrategy - if the unique key is not given in the source
-          file, this property can be used to specify how to calculate
-          the key. This can be one of the following values:
+          that gives more information about the context of the string. This
+          string is used if the regular expression does not have a `context`
+          capturing group.
+        - keyStrategy - if the unique key is not extracted with a capturing group
+          in the source file, this property can be used to specify how to calculate
+          a key automatically. This can be one of the following values:
             - "hash" - use a hash of the source string as the key
             - "source" - use the whole source string as the key
             - "truncate" - use the first 32 characters of the source
@@ -115,6 +122,18 @@ Example configuration for a web project with PHP and JavaScript files:
                             "flags": "g",
                             "datatype": "php",
                             "resourceType": "string"
+                        },
+                        {
+                            "expression": "translateArray\\s*\\(\\s*\\[\\s*(?<source>['\"][^'\"]*['\"](\\s*,\\s*['\"][^'\"]*['\"])*)\\s*\\]\\s*\\)",
+                            "flags": "g",
+                            "datatype": "php",
+                            "resourceType": "array"
+                        },
+                        {
+                            "expression": "translatePlural\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*,\\s*['\"](?<sourcePlural>[^'\"]*)['\"]",
+                            "flags": "g",
+                            "datatype": "php",
+                            "resourceType": "plural"
                         }
                     ]
                 },
@@ -138,12 +157,28 @@ Example configuration for a web project with PHP and JavaScript files:
 }
 ```
 
-In the above example, any file named `*.php` will be parsed with both the
-given regular expressions. The first regular expression extracts strings
-that are passed as the first parameter to the `translate` function. The
-second regular expression extracts strings that are passed as the first
+In the above example, any file named `*.php` will be parsed with all of the
+given regular expressions. Explanation of the above regexes:
+
+1. The first regular expression extracts strings
+that are passed as the first parameter to the `translate` function. It will match
+a string like `translate("string to translate")`.
+1. The second regular expression extracts strings that are passed as the first
 parameter to the `translate` function and the second parameter is the
-key of the string. The extracted strings will be localized and placed in
+key of the string. It will match a string like `translate("string to translate", "unique.id")`.
+1. The third regular expression is an example of an array translation. The
+`source` capturing group will have a value like `"a", "b", "c"` which this plugin
+will transform into a an array of 3 strings. This will match a string like
+`translateArray(["a", "b", "c"])`.
+1. The fourth regular expression is an example of a plural translation. The
+first parameter to the `translatePlural` function is the singular string and is
+assigned to the `source` capturing group. The second parameter is the plural
+string and is assigned to the `sourcePlural` capturing group.
+1. The fifth regular expression extracts strings from js files. It is looking
+for the source string in first parameter of calls to the `$t` function. It matches
+strings like `$t("this is the string to translate")`
+
+The extracted strings will be localized and placed in
 a PHP resource file. The resource file will be named `Translations-[locale].php`
 where `[locale]` is replaced with the locale of the localized strings.
 
@@ -154,7 +189,50 @@ localized and placed in a JSON resource file. The resource file will be
 named `strings-[locale].json` where `[locale]` is replaced with the locale
 of the localized strings.
 
-## Testing your Regular Expressions
+## Some Tips for Getting Your Regular Expressions to Work Correctly
+
+- The regular expression in json should be given as a string and should not
+  have the leading and trailing slashes. For example, do not write
+  `"/^text/"`. Instead, just put `"^text"` as your expression.
+- Regular expressions are case sensitive by default. If you want to
+  match case insensitively, you can add the `i` flag to the regular
+  expression.
+- Regular expressions are greedy by default. This means that they will
+  match as much as possible. If you want to match as little as possible,
+  you can add the `?` flag to the regular expression. For example, the
+  regular expression `"[^"]*"` will match a string, but it may capture
+  everything between two strings on the same line. `"[^"]*?"` will only
+  match the first string on the line.
+- Remember to escape things properly in the json strings. If you put
+  the regular expression `"a\sb"`, it will be looking for the string "asb".
+  You need to escape the backslack in order to get "a" followed by a
+  whitespace characters followed by a "b". ie. it should read `"a\\sb"`.
+  Also, remember to escape double quote characters in your expression
+  so that they don't cause problems with json syntax.
+- Regular expressions will match the first occurrence in the string by
+  default. If you want to match all occurrences, you can add the `g` flag
+  to the regular expression. Almost all regular expressions in your
+  config file should have the `g` flag.
+- Regular expressions by default only match regular ASCII characters. If
+  you want to match Unicode characters, you can add the `u` or the `v`
+  flag to the regular expression. This will allow you to match any Unicode
+  character in the string encoded with the `\u` escape sequences. Example:
+  `/\u{1F600}/u` will match the Unicode character for the grinning face emoji.
+- Expressions in the config file are applied in the order they are listed.
+  If you have two expressions that could match the same string or part of the
+  same string, the first one that matches will be the one that is used. Make
+  sure that the expressions are listed such that the longer expressions are
+  listed first.
+- To test your regular expressions in a much more friendly and interactive
+  way, you can use the [RegExr](https://regexr.com/) website. This website
+  allows you to enter a regular expression and a string to match against. It
+  will show you the results in real time as you type. It can also give you
+  a description of what each part of the regular expression does. This is
+  great for the initial development of the regular expression. For fine
+  tuning, see the section below about Testing Your Regular Expressions to
+  try them in the context of your project.
+
+## Testing your Regular Expressions in Your Project
 
 Getting regular expressions right can be tricky. The `ilib-loctool-regex`
 plugin uses the JavaScript regular expression engine to extract strings
@@ -206,34 +284,6 @@ Trying regular expression: translate\s*(\s*['"](?<source>[^'"]*)['"]\s*\)
   "length": 2
 ]
 ```
-
-### Some Tips
-
-- Regular expressions are case sensitive by default. If you want to
-  match case insensitively, you can add the `i` flag to the regular
-  expression.
-- Regular expressions are greedy by default. This means that they will
-  match as much as possible. If you want to match as little as possible,
-  you can add the `?` flag to the regular expression.
-- Regular expressions will match the first occurrence in the string by
-  default. If you want to match all occurrences, you can add the `g` flag
-  to the regular expression. Pretty much all regular expressions in your
-  config file should have the `g` flag.
-- Regular expressions by default only match regular ASCII characters. If
-  you want to match Unicode characters, you can add the `u` or the `v`
-  flag to the regular expression. This will allow you to match any Unicode
-  character in the string encoded with the `\u` escape sequences. Example:
-  `/\u{1F600}/u` will match the Unicode character for the grinning face emoji.
-- Expressions in the config file are applied in the order they are listed.
-  If you have two expressions that could match the same string or part of the
-  same string, the first one that matches will be the one that is used. Make
-  sure that the expressions are listed such that the longer expressions are
-  listed first.
-- To test your regular expressions in a much more friendly and interactive
-  way, you can use the [RegExr](https://regexr.com/) website. This website
-  allows you to enter a regular expression and a string to match against. It
-  will show you the results in real time as you type. It can also give you
-  a description of what each part of the regular expression does.
 
 ## Release Notes
 

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -194,7 +194,7 @@ localized and placed in a JSON resource file. The resource file will be
 named `strings-[locale].json` where `[locale]` is replaced with the locale
 of the localized strings. It matches strings like 
 `$t("this is the string to translate")`. Since this type of string extracted
-from js files file do not have their own unique id, one is generated using
+from js files does not have its own unique id, one is generated using
 the `hash` strategy. That is, the hash of the source string is taken, and
 the string version of that hash is used as unique id.
 
@@ -283,7 +283,12 @@ testregex folder/a/b/c myfile.php
 
 This will run the regular expressions in the `folder/a/b/c/project.json` file against
 the contents of the `myfile.php` file in the same way that the loctool
-will and show you the results.
+will, and it will show you the results of every match in the file in the order that they
+were matched. The match result is in the style of the output of a regular expression
+match that you may see in a js debugger such as chrome inspect. ie. it is a hybrid of an
+array of numbered match group values and an object with other properties, such as the "groups"
+subobject which gives the values of named capturing groups you might have defined in your
+expression.
 
 Example output:
 

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -168,15 +168,14 @@ parameter to the `translate` function and the second parameter is the
 key of the string. It will match a string like `translate("string to translate", "unique.id")`.
 1. The third regular expression is an example of an array translation. The
 `source` capturing group will have a value like `"a", "b", "c"` which this plugin
-will transform into a an array of 3 strings. This will match a string like
+will transform into an array of 3 strings. This will match a string like
 `translateArray(["a", "b", "c"])`.
 1. The fourth regular expression is an example of a plural translation. The
 first parameter to the `translatePlural` function is the singular string and is
 assigned to the `source` capturing group. The second parameter is the plural
-string and is assigned to the `sourcePlural` capturing group.
-1. The fifth regular expression extracts strings from js files. It is looking
-for the source string in first parameter of calls to the `$t` function. It matches
-strings like `$t("this is the string to translate")`
+string and is assigned to the `sourcePlural` capturing group. This creates a plural
+resource where the `source` string is the `one` plural category, and the `sourcePlural`
+string is the `other` plural category.
 
 The extracted strings will be localized and placed in
 a PHP resource file. The resource file will be named `Translations-[locale].php`
@@ -187,7 +186,8 @@ expression. The regular expression extracts strings that are passed as
 the first parameter to the `$t` function. The extracted strings will be
 localized and placed in a JSON resource file. The resource file will be
 named `strings-[locale].json` where `[locale]` is replaced with the locale
-of the localized strings.
+of the localized strings. It matches strings like 
+`$t("this is the string to translate")`.
 
 ## Some Tips for Getting Your Regular Expressions to Work Correctly
 
@@ -222,7 +222,15 @@ of the localized strings.
   If you have two expressions that could match the same string or part of the
   same string, the first one that matches will be the one that is used. Make
   sure that the expressions are listed such that the longer expressions are
-  listed first.
+  listed first so that they can more easily match. Example, if you have an
+  expression that can match `functionCall("first param"` and another that
+  can match `functionCall("first param", "second param"`, you will see that
+  there is overlap in what they can match. The first
+  expression will match and the second one never will because the first
+  expression will "use up" the input first. If you reverse their
+  order, then the second one will match only if there are two parameters 
+  to the `functionCall` call, otherwise the first one will match if there
+  is only one parameter, which is what is intended.
 - To test your regular expressions in a much more friendly and interactive
   way, you can use the [RegExr](https://regexr.com/) website. This website
   allows you to enter a regular expression and a string to match against. It

--- a/packages/ilib-loctool-regex/RegexFile.js
+++ b/packages/ilib-loctool-regex/RegexFile.js
@@ -1,0 +1,295 @@
+/*
+ * RegexFile.js - plugin to extract resources from a Regex source code file
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require("fs");
+var path = require("path");
+var Locale = require("ilib/lib/Locale");
+
+
+var strGetStringBogusConcatenation1 = "\\s*\\(\\s*(\"[^\"]*\"|'[^']*')\\s*\\+";
+var strGetStringBogusConcatenation2 = "\\s*\\([^\\)]*\\+\\s*(\"[^\"]*\"|'[^']*')\\s*\\)";
+var strGetStringBogusParam = "\\s*\\([^\"'\\)]*\\)/";
+
+var strGetString = "\\s*\\(\\s*(\"((\\\\\"|[^\"])*)\"|'((\\\\'|[^'])*)')\\s*\\)";
+var strGetStringWithId = "\\s*\\(\\s*(\"((\\\\\"|[^\"])*)\"|'((\\\\'|[^'])*)')\\s*,\\s*(\"((\\\\\"|[^\"])*)\"|'((\\\\'|[^'])*)')?\\s*,?\\s*\\)";
+
+/**
+ * Create a new Regex file with the given path name and within
+ * the given project.
+ *
+ * @param {Project} project the project object
+ * @param {String} pathName path to the file relative to the root
+ * of the project file
+ * @param {FileType} type the file type of this instance
+ */
+var RegexFile = function(props) {
+    this.project = props.project;
+    this.pathName = props.pathName;
+    this.type = props.type;
+    this.API = this.project.getAPI();
+
+    this.logger = this.API.getLogger("loctool.plugin.RegexFile");
+    this.set = this.API.newTranslationSet(this.project ? this.project.sourceLocale : "zxx-XX");
+    this.mapping = this.type.getMapping(this.pathName);
+
+    this.localeSpec = props.locale || (this.mapping && this.API.utils.getLocaleFromPath(this.mapping.template, this.pathName)) || "en-US";
+    this.locale = new Locale(this.localeSpec);
+
+    // get the regexp that finds the function call that wraps strings to translate
+    var jsSettings = this.project.settings && this.project.settings.Regex;
+    var wrapper = (jsSettings && jsSettings.wrapper) || "(^R|\\WR)B\\s*\\.\\s*getString(JS)?";
+
+    if (wrapper) {
+        this.wrapperCaptureGroupCount = 0;
+        for (var i = 0; i < wrapper.length; i++) {
+            if (wrapper[i] === '\\') {
+                i++;
+            } else if (wrapper[i] === '(') {
+                this.wrapperCaptureGroupCount++;
+            }
+        }
+    }
+    this.reGetString = new RegExp(wrapper + strGetString, "g");
+    this.reGetStringWithId = new RegExp(wrapper + strGetStringWithId, "g");
+    this.reGetStringBogusConcatenation1 = new RegExp(wrapper + strGetStringBogusConcatenation1, "g");
+    this.reGetStringBogusConcatenation2 = new RegExp(wrapper + strGetStringBogusConcatenation2, "g");
+    this.reGetStringBogusParam = new RegExp(wrapper + strGetStringBogusParam, "g");
+
+    this.resourceIndex = 0;
+};
+
+/**
+ * Unescape the string to make the same string that would be
+ * in memory in the target programming language.
+ *
+ * @static
+ * @param {String} string the string to unescape
+ * @returns {String} the unescaped string
+ */
+RegexFile.unescapeString = function(string) {
+    var unescaped = string;
+
+    unescaped = unescaped.
+        replace(/\\\\n/g, "").                // line continuation
+        replace(/\\\n/g, "").                // line continuation
+        replace(/^\\\\/, "\\").             // unescape backslashes
+        replace(/([^\\])\\\\/g, "$1\\").
+        replace(/^\\'/, "'").               // unescape quotes
+        replace(/([^\\])\\'/g, "$1'").
+        replace(/^\\"/, '"').
+        replace(/([^\\])\\"/g, '$1"');
+
+    return unescaped;
+};
+
+/**
+ * Clean the string to make a resource name string. This means
+ * removing leading and trailing white space, compressing
+ * whitespaces, and unescaping characters. This changes
+ * the string from what it looks like in the source
+ * code but increases matching.
+ *
+ * @static
+ * @param {String} string the string to clean
+ * @returns {String} the cleaned string
+ */
+RegexFile.cleanString = function(string) {
+    var unescaped = RegexFile.unescapeString(string);
+
+    unescaped = unescaped.
+        replace(/\\[btnfr]/g, " ").
+        replace(/[ \n\t\r\f]+/g, " ").
+        trim();
+
+    return unescaped;
+};
+
+/**
+ * Make a new key for the given string. This must correspond
+ * exactly with the code in htglob jar file so that the
+ * resources match up. See the class IResourceBundle in
+ * this project under the java directory for the corresponding
+ * code.
+ *
+ * @private
+ * @param {String} source the source string to make a resource
+ * key for
+ * @returns {String} a unique key for this string
+ */
+RegexFile.prototype.makeKey = function(source) {
+    return RegexFile.unescapeString(source);
+};
+
+var reI18nComment = new RegExp("//\\s*i18n\\s*:\\s*(.*)$");
+
+/**
+ * Parse the data string looking for the localizable strings and add them to the
+ * project's translation set.
+ * @param {String} data the string to parse
+ */
+RegexFile.prototype.parse = function(data) {
+    this.logger.debug("Extracting strings from " + this.pathName);
+    this.resourceIndex = 0;
+
+    var comment, match, key;
+
+    reI18nComment.lastIndex = 0;
+    this.reGetString.lastIndex = 0; // just to be safe
+
+    var result = this.reGetString.exec(data);
+    while (result && result.length > 1 && result[this.wrapperCaptureGroupCount+1]) {
+        // different matches for single and double quotes
+        match = (result[this.wrapperCaptureGroupCount+1][0] === '"') ?
+            result[this.wrapperCaptureGroupCount+2] :
+            result[this.wrapperCaptureGroupCount+4];
+
+        if (match && match.length) {
+            this.logger.trace("Found string key: " + this.makeKey(match) + ", string: '" + match + "'");
+
+            var last = data.indexOf('\n', this.reGetString.lastIndex);
+            last = (last === -1) ? data.length : last;
+            var line = data.substring(this.reGetString.lastIndex, last);
+            var commentResult = reI18nComment.exec(line);
+            comment = (commentResult && commentResult.length > 1) ? commentResult[1] : undefined;
+
+            var r = this.API.newResource({
+                resType: "string",
+                project: this.project.getProjectId(),
+                key: RegexFile.unescapeString(match),
+                sourceLocale: this.project.sourceLocale,
+                source: RegexFile.cleanString(match),
+                autoKey: true,
+                pathName: this.pathName,
+                state: "new",
+                comment: comment,
+                datatype: this.type.datatype,
+                index: this.resourceIndex++
+            });
+            // for use later when we write out resources
+            r.mapping = this.mapping;
+            this.set.add(r);
+        } else {
+            this.logger.warn("Warning: Bogus empty string in get string call: ");
+            this.logger.warn("... " + data.substring(result.index, this.reGetString.lastIndex) + " ...");
+        }
+        result = this.reGetString.exec(data);
+    }
+
+    // just to be safe
+    reI18nComment.lastIndex = 0;
+    this.reGetStringWithId.lastIndex = 0;
+
+    result = this.reGetStringWithId.exec(data);
+    while (result && result.length > 2 && result[this.wrapperCaptureGroupCount+1]) {
+        // different matches for single and double quotes
+        var autoKey = false;
+        match = (result[this.wrapperCaptureGroupCount+1][0] === '"') ?
+            result[this.wrapperCaptureGroupCount+2] :
+            result[this.wrapperCaptureGroupCount+4];
+        key = (result[this.wrapperCaptureGroupCount+6] && result[this.wrapperCaptureGroupCount+6][0] === '"') ?
+            result[this.wrapperCaptureGroupCount+7] :
+            result[this.wrapperCaptureGroupCount+9];
+        if (!key) {
+            key = RegexFile.unescapeString(match);
+            autoKey = true;
+        }
+
+        if (match && key && match.length && key.length) {
+            var last = data.indexOf('\n', this.reGetStringWithId.lastIndex);
+            last = (last === -1) ? data.length : last;
+            var line = data.substring(this.reGetStringWithId.lastIndex, last);
+            var commentResult = reI18nComment.exec(line);
+            comment = (commentResult && commentResult.length > 1) ? commentResult[1] : undefined;
+
+            this.logger.trace("Found string '" + match + "' with unique key " + key + ", comment: " + comment);
+
+            var r = this.API.newResource({
+                resType: "string",
+                project: this.project.getProjectId(),
+                key: key,
+                sourceLocale: this.project.sourceLocale,
+                source: RegexFile.cleanString(match),
+                pathName: this.pathName,
+                state: "new",
+                comment: comment,
+                datatype: this.type.datatype,
+                index: this.resourceIndex++,
+                autoKey: autoKey
+            });
+            // for use later when we write out resources
+            r.mapping = this.mapping;
+            this.set.add(r);
+        } else {
+            this.logger.warn("Warning: Bogus empty string in get string call: ");
+            this.logger.warn("... " + data.substring(result.index, this.reGetString.lastIndex) + " ...");
+        }
+        result = this.reGetStringWithId.exec(data);
+    }
+
+    // now check for and report on errors in the source
+    this.API.utils.generateWarnings(data, this.reGetStringBogusConcatenation1,
+        "Warning: string concatenation is not allowed in the RB.getString() parameters:",
+        this.logger,
+        this.pathName);
+
+    this.API.utils.generateWarnings(data, this.reGetStringBogusConcatenation2,
+        "Warning: string concatenation is not allowed in the RB.getString() parameters:",
+        this.logger,
+        this.pathName);
+
+    this.API.utils.generateWarnings(data, this.reGetStringBogusParam,
+        "Warning: non-string arguments are not allowed in the RB.getString() parameters:",
+        this.logger,
+        this.pathName);
+};
+
+/**
+ * Extract all the localizable strings from the java file and add them to the
+ * project's translation set.
+ */
+RegexFile.prototype.extract = function() {
+    this.logger.debug("Extracting strings from " + this.pathName);
+    if (this.pathName) {
+        var p = path.join(this.project.root, this.pathName);
+        try {
+            var data = fs.readFileSync(p, "utf8");
+            if (data) {
+                this.parse(data);
+            }
+        } catch (e) {
+            this.logger.warn("Could not read file: " + p);
+        }
+    }
+};
+
+/**
+ * Return the set of resources found in the current Regex file.
+ *
+ * @returns {TranslationSet} The set of resources found in the
+ * current Regex file.
+ */
+RegexFile.prototype.getTranslationSet = function() {
+    return this.set;
+}
+
+// we don't localize or write Regex source files
+RegexFile.prototype.localize = function() {};
+RegexFile.prototype.write = function() {};
+
+module.exports = RegexFile;

--- a/packages/ilib-loctool-regex/RegexFile.js
+++ b/packages/ilib-loctool-regex/RegexFile.js
@@ -1,7 +1,7 @@
 /*
  * RegexFile.js - plugin to extract resources from a Regex source code file
  *
- * Copyright © 2024 JEDLSoft
+ * Copyright © 2024-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ var RegexFile = function(props) {
 
     // get the regexps that finds the strings to translate
     this.mapping = this.type && this.type.getMapping(this.pathName);
-    if (this.mapping) {
+    if (this.mapping && this.mapping.expressions) {
         this.mapping.expressions.forEach(function(exp) {
             // make sure the expression string is turned into a real regex
             if (!exp.regex) {
@@ -361,6 +361,20 @@ RegexFile.prototype.parse = function(data, cb) {
     this.resourceIndex = 0;
 
     var chunks = [data];
+
+    if (!this.mapping) {
+        // report the problem, but continue processing other files
+        const msg = "No mapping found in project.json for " + this.pathName;
+        this.logger.debug(msg);
+        return undefined;
+    }
+
+    if (!this.mapping.expressions || this.mapping.expressions.length < 1) {
+        // there is a mapping, but it is misconfigured, so throw an exception
+        const msg = "No expressions found in project.json for " + this.pathName;
+        this.logger.error(msg);
+        throw new Error(msg);
+    }
 
     // Parse the chunks of data into smaller and smaller pieces until we have found
     // all the localizable strings. For each chunk, we find all matches of the 

--- a/packages/ilib-loctool-regex/RegexFile.js
+++ b/packages/ilib-loctool-regex/RegexFile.js
@@ -187,6 +187,8 @@ function parseArray(data) {
  * undefined.
  */
 RegexFile.prototype.matchExpression = function(data, exp, cb) {
+    // The cb parameter is a hidden, undocumented parameter that is used for testing only.
+    // It is a callback that gets called to give information about regex matches
     var regex = exp.regex;
     regex.lastIndex = 0;
     var result = regex.exec(data);

--- a/packages/ilib-loctool-regex/RegexFileType.js
+++ b/packages/ilib-loctool-regex/RegexFileType.js
@@ -17,14 +17,11 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
 var path = require("path");
 var Locale = require("ilib/lib/Locale.js");
-var ResBundle = require("ilib/lib/ResBundle.js");
 var mm = require("micromatch");
 
 var RegexFile = require("./RegexFile.js");
-var JavaScriptResourceFileType = require("ilib-loctool-javascript-resource");
 
 var RegexFileType = function(project) {
     this.type = "regex";
@@ -38,6 +35,7 @@ var RegexFileType = function(project) {
     // figure out what file extensions we should be looking for by looking at the minimatch
     // expressions in the mappings
     if (project.settings && project.settings.regex && project.settings.regex.mappings) {
+        this.mappings = project.settings.regex.mappings;
         var globExpressions = Object.keys(project.settings.regex.mappings);
         this.extensions = globExpressions.map(function(expression) {
             var match = expression.match(/\.(\w+)$/);
@@ -89,6 +87,7 @@ RegexFileType.prototype.getMapping = function(pathName) {
     if (typeof(pathName) === "undefined") {
         return undefined;
     }
+    pathName = path.normalize(pathName);
     var regexSettings = this.project.settings.regex;
     var mappings = regexSettings && regexSettings.mappings;
     if (!mappings) {

--- a/packages/ilib-loctool-regex/RegexFileType.js
+++ b/packages/ilib-loctool-regex/RegexFileType.js
@@ -1,7 +1,7 @@
 /*
  * RegexFileType.js - Represents a collection of regex-parsable files
  *
- * Copyright © 2024 JEDLSoft
+ * Copyright © 2024-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,12 @@ var Locale = require("ilib-locale");
 var mm = require("micromatch");
 
 var RegexFile = require("./RegexFile.js");
+
+var defaultMappings = {
+    "**/*.js": {
+        "template": "resources/strings_[locale].json"
+    }
+};
 
 var RegexFileType = function(project) {
     this.type = "regex";

--- a/packages/ilib-loctool-regex/RegexFileType.js
+++ b/packages/ilib-loctool-regex/RegexFileType.js
@@ -1,0 +1,354 @@
+/*
+ * RegexFileType.js - Represents a collection of regex-parsable files
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require("fs");
+var path = require("path");
+var Locale = require("ilib/lib/Locale.js");
+var ResBundle = require("ilib/lib/ResBundle.js");
+var mm = require("micromatch");
+
+var RegexFile = require("./RegexFile.js");
+var JavaScriptResourceFileType = require("ilib-loctool-javascript-resource");
+
+var RegexFileType = function(project) {
+    this.type = "regex";
+    this.datatype = "regex";
+
+    this.project = project;
+    this.API = project.getAPI();
+
+    this.logger = this.API.getLogger("loctool.plugin.RegexFileType");
+
+    // figure out what file extensions we should be looking for by looking at the minimatch
+    // expressions in the mappings
+    if (project.settings && project.settings.regex && project.settings.regex.mappings) {
+        var globExpressions = Object.keys(project.settings.regex.mappings);
+        this.extensions = globExpressions.map(function(expression) {
+            var match = expression.match(/\.(\w+)$/);
+            if (match && match.length > 1) {
+                return match[1];
+            }
+            // no extension in this glob expression, so don't return anything
+            return undefined;
+        }.bind(this));
+
+        // make sure all of the resource file types are loaded
+        this.fileTypes = {};
+        globExpressions.forEach(function(expression) {
+            var mapping = project.settings.regex.mappings[expression];
+            if (mapping && mapping.resourceFileType) {
+                var resourceFileTypeClass = require(mapping.resourceFileType);
+                mapping.resourceFileTypeInstance = new resourceFileTypeClass(project);
+            }
+        });
+    }
+
+    this.extracted = this.API.newTranslationSet(project.getSourceLocale());
+    this.newres = this.API.newTranslationSet(project.getSourceLocale());
+    this.pseudo = this.API.newTranslationSet(project.getSourceLocale());
+
+    this.pseudos = {};
+
+    // generate all the pseudo bundles we'll need
+    project.settings && project.settings.locales && project.settings.locales.forEach(function(locale) {
+        var pseudo = this.API.getPseudoBundle(locale, this, project);
+        if (pseudo) {
+            this.pseudos[locale] = pseudo;
+        }
+    }.bind(this));
+
+    // for use with missing strings
+    if (!project.settings.nopseudo) {
+        this.missingPseudo = this.API.getPseudoBundle(project.pseudoLocale, this, project);
+    }
+};
+
+/**
+ * Return the mapping corresponding to this path.
+ * @param {String} pathName the path to check
+ * @returns {Object} the mapping object corresponding to the
+ * path or undefined if none of the mappings match
+ */
+RegexFileType.prototype.getMapping = function(pathName) {
+    if (typeof(pathName) === "undefined") {
+        return undefined;
+    }
+    var regexSettings = this.project.settings.regex;
+    var mappings = regexSettings && regexSettings.mappings;
+    if (!mappings) {
+        return undefined;
+    }
+    var patterns = Object.keys(mappings);
+
+    var match = patterns.find(function(pattern) {
+        return mm.isMatch(pathName, pattern);
+    });
+
+    return match && mappings[match];
+}
+
+/**
+ * Return true if the given path is a file that is handled by this
+ * configuration. In order to be handled by this configuration, the
+ * path must match one of the mapping patterns and must not be a
+ * resource file.
+ *
+ * @param {String} pathName path to the file in question
+ * @returns {boolean} true if the path is handled by this
+ * configuration, or false otherwise
+ */
+RegexFileType.prototype.handles = function(pathName) {
+    this.logger.debug("RegexFileType handles " + pathName + "?");
+    var ret = false;
+
+    var mapping = this.getMapping(pathName);
+    if (!mapping) {
+        this.logger.debug("No");
+        return false;
+    }
+
+    // resource files should be handled by the resource file plugin instead
+    if (this.project.isResourcePath("regex", pathName)) {
+        this.logger.debug("No");
+        return false;
+    }
+
+    this.logger.debug("Yes");
+    return true;
+};
+
+RegexFileType.prototype.name = function() {
+    return "Regex File Type";
+};
+
+/**
+ * Return the alternate output locale or the shared output locale for the given
+ * mapping. If there are no locale mappings, it returns the locale parameter.
+ *
+ * @param {Object} mapping the mapping for this source file
+ * @param {String} locale the locale spec for the target locale
+ * @returns {Locale} the output locale
+ */
+RegexFileType.prototype.getOutputLocale = function(mapping, locale) {
+    // we can remove the replace() call after upgrading to
+    // ilib 14.10.0 or later because it can parse locale specs
+    // with underscores in them
+    return new Locale(
+        (mapping && mapping.localeMap && mapping.localeMap[locale] && mapping.localeMap[locale]) ||
+        this.project.getOutputLocale(locale));
+};
+
+/**
+ * Return the location on disk where the version of this file localized
+ * for the given locale should be written.
+ * @param {String} template template for the output file
+ * @param {String} pathname path to the source file
+ * @param {String} locale the locale spec for the target locale
+ * @returns {String} the localized path name
+ */
+RegexFileType.prototype.getLocalizedPath = function(mapping, pathname, locale) {
+    var template = mapping && mapping.template;
+    var l = this.getOutputLocale(mapping, locale);
+
+    if (!template) {
+        template = defaultMappings["**/*.js"].template;
+    }
+
+    return path.normalize(this.API.utils.formatPath(template, {
+        sourcepath: pathname,
+        locale: l
+    }));
+};
+
+/**
+ * Write out the aggregated resources for this file type. In
+ * some cases, the string are written out to a common resource
+ * file, and in other cases, to a type-specific resource file.
+ * In yet other cases, nothing is written out, as the each of
+ * the files themselves are localized individually, so there
+ * are no aggregated strings.
+ * @param {TranslationSet} translations the set of translations from the
+ * repository
+ * @param {Array.<String>} locales the list of locales to localize to
+ */
+RegexFileType.prototype.write = function(translations, locales) {
+    // distribute all the resources to their resource files
+    // and then let them write themselves out
+    var resFileType = this.project.getResourceFileType(this.type);
+    var res, file,
+        resources = this.extracted.getAll(),
+        db = this.project.db,
+        translationLocales = locales.filter(function(locale) {
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
+        }.bind(this));
+
+    for (var i = 0; i < resources.length; i++) {
+        res = resources[i];
+
+        // for each extracted string, write out the translations of it
+        translationLocales.forEach(function(locale) {
+            this.logger.trace("Localizing Regex strings to " + locale);
+
+            db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(locale), function(err, translated) {
+                var r = translated;
+                if (!translated || this.API.utils.cleanString(res.getSource()) !== this.API.utils.cleanString(r.getSource())) {
+                    if (r) {
+                        this.logger.trace("extracted   source: " + this.API.utils.cleanString(res.getSource()));
+                        this.logger.trace("translation source: " + this.API.utils.cleanString(r.getSource()));
+                    }
+                    var note = r && 'The source string has changed. Please update the translation to match if necessary. Previous source: "' + r.getSource() + '"';
+                    var newres = res.clone();
+                    newres.setTargetLocale(locale);
+                    newres.setTarget((r && r.getTarget()) || res.getSource());
+                    newres.setState("new");
+                    newres.setComment(note);
+
+                    this.newres.add(newres);
+
+                    this.logger.trace("No translation for " + res.reskey + " to " + locale);
+                } else {
+                    if (res.reskey != r.reskey) {
+                        // if reskeys don't match, we matched on cleaned string.
+                        //so we need to overwrite reskey of the translated resource to match
+                        r = r.clone();
+                        r.reskey = res.reskey;
+                    }
+
+                    file = resFileType.getResourceFile(locale, this.getLocalizedPath(res.mapping, res.getPath(), locale));
+                    file.addResource(r);
+                    this.logger.trace("Added " + r.reskey + " to " + file.pathName);
+                }
+            }.bind(this));
+        }.bind(this));
+    }
+
+    resources = this.pseudo.getAll().filter(function(resource) {
+        return resource.datatype === this.datatype;
+    }.bind(this));
+
+    for (var i = 0; i < resources.length; i++) {
+        res = resources[i];
+        if (res.getTargetLocale() !== this.project.sourceLocale && res.getSource() !== res.getTarget()) {
+            file = resFileType.getResourceFile(res.getTargetLocale(), this.getLocalizedPath(res.mapping, res.getPath(), locale));
+            file.addResource(res);
+            this.logger.trace("Added " + res.reskey + " to " + file.pathName);
+        }
+    }
+};
+
+RegexFileType.prototype.newFile = function(path, options) {
+    return new RegexFile({
+        project: this.project,
+        pathName: path,
+        type: this,
+        locale: options && options.targetLocale
+    });
+};
+
+RegexFileType.prototype.getDataType = function() {
+    return this.datatype;
+};
+
+RegexFileType.prototype.getResourceTypes = function() {
+    return {};
+};
+
+/**
+ * Return the list of file name extensions that this plugin can
+ * process.
+ *
+ * @returns {Array.<string>} the list of file name extensions
+ */
+RegexFileType.prototype.getExtensions = function() {
+    return this.extensions;
+};
+
+/**
+ * Return the name of the node module that implements the resource file type, or
+ * the path to a Regex file that implements the resource filetype.
+ * @returns {Function|undefined} node module name or path, or undefined if this file type does not
+ * need resource files
+ */
+RegexFileType.prototype.getResourceFileType = function() {
+    // no generic resource file type for regex files
+};
+
+/**
+ * Return the file type that implements the resource file type for the given path.
+ * The path is matched against the mappings in the project settings to determine
+ * which resource file type to use.
+ *
+ * @param {String} pathName path to the file in question
+ * @returns {Function|undefined} an instance of the file type class, or undefined if
+ * the file type could not be determined
+ */
+RegexFileType.prototype.getResourceFileTypeForPath = function(pathName) {
+    var mapping = this.getMapping(pathName);
+    if (mapping && mapping.resourceFileTypeInstance) {
+        return mapping.resourceFileTypeInstance;
+    }
+    return undefined;
+};
+
+/**
+ * Return the translation set containing all of the extracted
+ * resources for all instances of this type of file. This includes
+ * all new strings and all existing strings. If it was extracted
+ * from a source file, it should be returned here.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * extracted resources
+ */
+RegexFileType.prototype.getExtracted = function() {
+    return this.extracted;
+};
+
+/**
+ * Add the contents of the given translation set to the extracted resources
+ * for this file type.
+ *
+ * @param {TranslationSet} set set of resources to add to the current set
+ */
+RegexFileType.prototype.addSet = function(set) {
+    this.extracted.addSet(set);
+};
+
+/**
+ * Return the translation set containing all of the new
+ * resources for all instances of this type of file.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * new resources
+ */
+RegexFileType.prototype.getNew = function() {
+    return this.newres;
+};
+
+/**
+ * Return the translation set containing all of the pseudo
+ * localized resources for all instances of this type of file.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * pseudo localized resources
+ */
+RegexFileType.prototype.getPseudo = function() {
+    return this.pseudo;
+};
+
+module.exports = RegexFileType;

--- a/packages/ilib-loctool-regex/RegexFileType.js
+++ b/packages/ilib-loctool-regex/RegexFileType.js
@@ -44,7 +44,7 @@ var RegexFileType = function(project) {
         this.mappings = project.settings.regex.mappings;
         var globExpressions = Object.keys(project.settings.regex.mappings);
         this.extensions = globExpressions.map(function(expression) {
-            var match = expression.match(/\.(\w+)$/);
+            var match = expression.match(/(\.\w+)$/);
             if (match && match.length > 1) {
                 return match[1];
             }

--- a/packages/ilib-loctool-regex/RegexFileType.js
+++ b/packages/ilib-loctool-regex/RegexFileType.js
@@ -18,7 +18,7 @@
  */
 
 var path = require("path");
-var Locale = require("ilib/lib/Locale.js");
+var Locale = require("ilib-locale");
 var mm = require("micromatch");
 
 var RegexFile = require("./RegexFile.js");
@@ -100,6 +100,26 @@ RegexFileType.prototype.getMapping = function(pathName) {
     });
 
     return match && mappings[match];
+}
+
+/**
+ * Return the property name of the mapping that corresponds to
+ * the given path. This is mostly used in the testregex command
+ * to tell the caller which mapping matched the given path.
+ *
+ * @param {String} pathName the path to check
+    * @returns {String} the property name of the mapping object
+    * corresponding to the path or undefined if none of the mappings
+    * match
+    */
+RegexFileType.prototype.getMappingName = function(pathName) {
+    var mapping = this.getMapping(pathName);
+    if (mapping) {
+        return Object.keys(this.project.settings.regex.mappings).find(function(key) {
+            return this.project.settings.regex.mappings[key] === mapping;
+        }.bind(this));
+    }
+    return undefined;
 }
 
 /**

--- a/packages/ilib-loctool-regex/bin/testregex.js
+++ b/packages/ilib-loctool-regex/bin/testregex.js
@@ -19,13 +19,9 @@
  */
 
 var fs = require("fs");
-var path = require("path");
-var flatted = require("flatted");
 
 var ProjectFactory = require("loctool/lib/ProjectFactory.js");
 var RegexFileType = require("../RegexFileType.js");
-
-var stringify = flatted.stringify;
 
 if (process.argv.length < 4) {
     console.log("Usage: testregex path-to-project-dir file1 [file2 ...]");
@@ -47,7 +43,7 @@ function stringifyRegexResult(result) {
     if (!result) return;
     var str = "[\n";
     for (var i = 0; i < result.length; i++) {
-        var stringified = stringify(result[i]).replace(/[\[\]]/g, "");
+        var stringified = JSON.stringify(result[i]).replace(/[\[\]]/g, "");
         stringified = stringified.length > 80 ? stringified.substring(0, 79) + '…"' : stringified;
         var matchString = result[i] ? stringified : "undefined"
         str += '  "' + i + '": ' + matchString + ",\n";
@@ -58,7 +54,7 @@ function stringifyRegexResult(result) {
         if (key.match(/^\d/)) {
             return;
         }
-        groups[key] = JSON.stringify(result.groups[key]);
+        groups[key] = result.groups[key];
     })
     str += JSON.stringify(groups, undefined, 2).split(/\n/g).join("\n  ") + ",\n";
     str += '  "index": ' + result.index + ",\n";
@@ -75,10 +71,9 @@ files.forEach(function(file) {
         var data = fs.readFileSync(file, "utf-8");
         var regexFile = rft.newFile(file, {});
         console.log("File: " + file);
-        console.log("Matched mapping: " + stringify(rft.getMappingName(file)));
+        console.log('Matched mapping: "' + rft.getMappingName(file) + '"');
         regexFile.parse(data, function(info) {
-            console.log("Trying regular expression: " + info.expression.expression);
-            console.log("  Flags: " + info.expression.flags);
+            console.log("Trying regular expression: /" + info.expression.expression + "/" + info.expression.flags);
             console.log("  Result:\n" + stringifyRegexResult(info.result));
         });
         console.log("\n");

--- a/packages/ilib-loctool-regex/bin/testregex.js
+++ b/packages/ilib-loctool-regex/bin/testregex.js
@@ -1,0 +1,76 @@
+/*
+ * testregex.js - utility command to test your regex project against
+ * real files
+ *
+ * Copyright © 2024 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require("fs");
+var path = require("path");
+var flatted = require("flatted");
+
+var ProjectFactory = require("loctool/lib/ProjectFactory.js");
+var RegexFileType = require("../RegexFileType.js");
+
+var stringify = flatted.stringify;
+
+if (process.argv.length < 4) {
+    console.log("Usage: testregex path-to-project-dir file1 [file2 ...]");
+    console.log("Test the regular expressions in the given ilib-loctool-regex project against the given files.");
+
+    process.exit(1);
+}
+
+var projectDir = process.argv[2];
+var files = process.argv.slice(3);
+
+var project = ProjectFactory(projectDir, {
+    sourceLocale: "en-US"
+});
+
+var rft = new RegexFileType(project);
+
+function stringifyRegexResult(result) {
+    if (!result) return;
+    var str = "[\n";
+    for (var i = 0; i < result.length; i++) {
+        str += "  '" + i + "': " + stringify(result[i]).replace(/[\[\]]/g, "") + ",\n";
+    }
+    str += '  "index": ' + result.index + ",\n";
+    str += '  "groups": ' + stringify(result.groups, undefined, 2).split(/\n/g).join("\n  ") + "\n";
+    str += "]";
+    return str;
+}
+
+files.forEach(function(file) {
+    try {
+        var data = fs.readFileSync(file, "utf-8");
+        var regexFile = rft.newFile(file, {});
+        console.log("File: " + file);
+        console.log("Matched mapping: " + stringify(rft.getMappingName(file)));
+        console.log("Matches:");
+        regexFile.parse(data, function(info) {
+            console.log("Regular expression: " + info.expression.expression);
+            console.log("  Flags: " + info.expression.flags);
+            console.log("  Result\n" + stringifyRegexResult(info.result));
+        });
+        console.log("\n");
+    } catch (e) {
+        console.log("Error reading file " + file + ": " + e);
+    }
+});
+
+console.log("Done.");

--- a/packages/ilib-loctool-regex/bin/testregex.js
+++ b/packages/ilib-loctool-regex/bin/testregex.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*
  * testregex.js - utility command to test your regex project against
  * real files

--- a/packages/ilib-loctool-regex/bin/testregex.js
+++ b/packages/ilib-loctool-regex/bin/testregex.js
@@ -44,10 +44,9 @@ function stringifyRegexResult(result) {
     if (!result) return;
     var str = "[\n";
     for (var i = 0; i < result.length; i++) {
-        var stringified = JSON.stringify(result[i]).replace(/[\[\]]/g, "");
+        var stringified = result[i] ? JSON.stringify(result[i]).replace(/[\[\]]/g, "") : "undefined";
         stringified = stringified.length > 80 ? stringified.substring(0, 79) + '…"' : stringified;
-        var matchString = result[i] ? stringified : "undefined"
-        str += '  "' + i + '": ' + matchString + ",\n";
+        str += '  "' + i + '": ' + stringified + ",\n";
     }
     str += '  "groups": ';
     var groups = {};

--- a/packages/ilib-loctool-regex/bin/testregex.js
+++ b/packages/ilib-loctool-regex/bin/testregex.js
@@ -47,11 +47,26 @@ function stringifyRegexResult(result) {
     if (!result) return;
     var str = "[\n";
     for (var i = 0; i < result.length; i++) {
-        str += "  '" + i + "': " + stringify(result[i]).replace(/[\[\]]/g, "") + ",\n";
+        var stringified = stringify(result[i]).replace(/[\[\]]/g, "");
+        stringified = stringified.length > 80 ? stringified.substring(0, 79) + '…"' : stringified;
+        var matchString = result[i] ? stringified : "undefined"
+        str += '  "' + i + '": ' + matchString + ",\n";
     }
+    str += '  "groups": ';
+    var groups = {};
+    Object.keys(result.groups).forEach(function(key) {
+        if (key.match(/^\d/)) {
+            return;
+        }
+        groups[key] = JSON.stringify(result.groups[key]);
+    })
+    str += JSON.stringify(groups, undefined, 2).split(/\n/g).join("\n  ") + ",\n";
     str += '  "index": ' + result.index + ",\n";
-    str += '  "groups": ' + stringify(result.groups, undefined, 2).split(/\n/g).join("\n  ") + "\n";
+    str += '  "length": ' + result.length + "\n";
     str += "]";
+    if (!groups.source) {
+        str += ",\nWarning: no source group found in the match! Cannot create a Resource from this match.";
+    }
     return str;
 }
 
@@ -61,11 +76,10 @@ files.forEach(function(file) {
         var regexFile = rft.newFile(file, {});
         console.log("File: " + file);
         console.log("Matched mapping: " + stringify(rft.getMappingName(file)));
-        console.log("Matches:");
         regexFile.parse(data, function(info) {
-            console.log("Regular expression: " + info.expression.expression);
+            console.log("Trying regular expression: " + info.expression.expression);
             console.log("  Flags: " + info.expression.flags);
-            console.log("  Result\n" + stringifyRegexResult(info.result));
+            console.log("  Result:\n" + stringifyRegexResult(info.result));
         });
         console.log("\n");
     } catch (e) {

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -2,6 +2,7 @@
     "name": "ilib-loctool-regex",
     "version": "1.0.0",
     "main": "./RegexFileType.js",
+    "bin": "./bin/testregex.js",
     "description": "A loctool plugin that knows how to process any files using regular expressions",
     "license": "Apache-2.0",
     "keywords": [
@@ -33,6 +34,7 @@
         }
     ],
     "files": [
+        "bin",
         "README.md",
         "CHANGELOG.md",
         "LICENSE",
@@ -48,13 +50,13 @@
         "test": "jest",
         "test:watch": "jest --watch",
         "debug": "NODE_OPTIONS=\"$NODE_OPTIONS --inspect-brk\" jest -i",
-        "clean": "git clean -f -d *"
+        "clean": "git clean -f -d *",
+        "testregex": "node ./bin/testregex.js"
     },
     "engines": {
         "node": ">=12.0"
     },
     "devDependencies": {
-        "flatted": "^3.3.2",
         "ilib-loctool-javascript-resource": "workspace:^",
         "jest": "^29.7.0",
         "loctool": "workspace:^"

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-regex",
-    "version": "1.0.0",
+    "version": "0.0.0",
     "main": "./RegexFileType.js",
     "bin": "./bin/testregex.js",
     "description": "A loctool plugin that knows how to process any files using regular expressions",

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -48,7 +48,6 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
-        "dist": "pnpm pack",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -60,6 +60,7 @@
         "loctool": "workspace:^"
     },
     "dependencies": {
+        "ilib-istring": "^1.1.0",
         "ilib-locale": "^1.2.2",
         "micromatch": "^4.0.8"
     }

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -54,9 +54,8 @@
         "node": ">=12.0"
     },
     "devDependencies": {
-        "ilib-loctool-javascript-resource": "workspace:*",
-        "ilib-loctool-php-resource": "workspace:*",
+        "ilib-loctool-javascript-resource": "workspace:^",
         "jest": "^29.7.0",
-        "loctool": "workspace:*"
+        "loctool": "workspace:^"
     }
 }

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -49,9 +49,9 @@
     },
     "scripts": {
         "dist": "pnpm pack",
-        "test": "jest",
-        "test:watch": "jest --watch",
-        "debug": "NODE_OPTIONS=\"$NODE_OPTIONS --inspect-brk\" jest -i",
+        "test": "node node_modules/jest/bin/jest.js",
+        "test:watch": "node node_modules/jest/bin/jest.js --watch",
+        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d *",
         "testregex": "node ./bin/testregex.js"
     },
@@ -61,6 +61,9 @@
     "devDependencies": {
         "ilib-loctool-javascript-resource": "workspace:^",
         "jest": "^29.7.0",
+        "loctool": "workspace:^"
+    },
+    "peerDependency": {
         "loctool": "workspace:^"
     },
     "dependencies": {

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -1,0 +1,62 @@
+{
+    "name": "ilib-loctool-regex",
+    "version": "1.0.0",
+    "main": "./RegexFileType.js",
+    "description": "A loctool plugin that knows how to process any files using regular expressions",
+    "license": "Apache-2.0",
+    "keywords": [
+        "internationalization",
+        "i18n",
+        "localization",
+        "l10n",
+        "globalization",
+        "g11n",
+        "strings",
+        "resources",
+        "locale",
+        "translation",
+        "webpack",
+        "loader",
+        "regex",
+        "regular expression"
+    ],
+    "email": "ehoogerbeets@gmail.com",
+    "author": {
+        "name": "Edwin Hoogerbeets",
+        "web": "http://www.translationcircle.com/",
+        "email": "ehoogerbeets@gmail.com"
+    },
+    "contributors": [
+        {
+            "name": "Edwin Hoogerbeets",
+            "email": "ehoogerbeets@gmail.com"
+        }
+    ],
+    "files": [
+        "README.md",
+        "CHANGELOG.md",
+        "LICENSE",
+        "RegexFileType.js",
+        "RegexFile.js"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/iLib-js/ilib-mono.git"
+    },
+    "scripts": {
+        "dist": "pnpm pack",
+        "test": "jest",
+        "test:watch": "jest --watch",
+        "debug": "NODE_OPTIONS=\"$NODE_OPTIONS --inspect-brk\" jest -i",
+        "clean": "git clean -f -d *"
+    },
+    "engines": {
+        "node": ">=12.0"
+    },
+    "devDependencies": {
+        "ilib-loctool-javascript-resource": "workspace:*",
+        "ilib-loctool-php-resource": "workspace:*",
+        "jest": "^29.7.0",
+        "loctool": "workspace:*"
+    }
+}

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -64,8 +64,8 @@
         "loctool": "workspace:^"
     },
     "dependencies": {
-        "ilib-istring": "^1.1.0",
-        "ilib-locale": "^1.2.2",
+        "ilib-istring": "workspace:^",
+        "ilib-locale": "workspace:^",
         "micromatch": "^4.0.8"
     }
 }

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -54,8 +54,13 @@
         "node": ">=12.0"
     },
     "devDependencies": {
+        "flatted": "^3.3.2",
         "ilib-loctool-javascript-resource": "workspace:^",
         "jest": "^29.7.0",
         "loctool": "workspace:^"
+    },
+    "dependencies": {
+        "ilib-locale": "^1.2.2",
+        "micromatch": "^4.0.8"
     }
 }

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -2,7 +2,9 @@
     "name": "ilib-loctool-regex",
     "version": "0.0.0",
     "main": "./RegexFileType.js",
-    "bin": "./bin/testregex.js",
+    "bin": {
+        "testregex": "./bin/testregex.js"
+    },
     "description": "A loctool plugin that knows how to process any files using regular expressions",
     "license": "Apache-2.0",
     "keywords": [

--- a/packages/ilib-loctool-regex/test/RegexFile.test.js
+++ b/packages/ilib-loctool-regex/test/RegexFile.test.js
@@ -1,0 +1,1169 @@
+/*
+ * RegexFile.test.js - test the Regex file handler object.
+ *
+ * Copyright © 2024 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var RegexFile = require("../RegexFile.js");
+var RegexFileType = require("../RegexFileType.js");
+var CustomProject =  require("loctool/lib/CustomProject.js");
+
+var p = new CustomProject({
+    id: "app",
+    plugins: [require.resolve("../.")],
+    sourceLocale: "en-US"
+}, "./test/testfiles", {
+    "locales":["en-GB", "de-DE", "fr-FR", "ja-JP"],
+    "regex": {
+        "mappings": {
+            "**/*.js": {
+                "resourceFileType": "ilib-loctool-javascript-resource",
+                "template": "resources/strings_[locale].json",
+                "sourceLocale": "en-US",
+                "expressions": [
+                    {
+                        "expression": "\b\\$t\\s*\\(\"(?<source>[^\"]*)\"\\)",
+                        "flags": "g",
+                        "datatype": "javascript",
+                        "resourceType": "string",
+                        "keyStrategy": "hash"
+                    }
+                ]
+            },
+            "**/*.tmpl": {
+                "resourceFileType": "ilib-loctool-php-resource",
+                "template": "resources/Translation[locale].json",
+                "sourceLocale": "en-US",
+                "expressions": [
+                    {
+                        // example:
+                        // {* @L10N The message shown to users whose passwords have just been changed *}
+                        // {'Your password was changed. Please log in again.'|f:'login_success_password_changed'}
+                        "expression": "\\{.*@L10N\\s*(?<comment>[^*]*)\\*\\}.*\\{.*'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*\\}",
+                        "flags": "g",
+                        "datatype": "template",
+                        "resourceType": "string"
+                    }
+                ]
+            }
+        }
+    },
+    "php": {
+        "localeMap": {
+            "en-US": "EnUS",
+            "en-GB": "EnGB",
+            "de-DE": "DeDE",
+            "fr-FR": "FrFR",
+            "ja-JP": "JaJP"
+        },
+        "sourceLocale": "en-US"
+    }
+});
+
+var rft = new RegexFileType(p);
+
+// test a different wrapper
+var p2 = new CustomProject({
+    id: "app",
+    plugins: [require.resolve("../.")],
+    sourceLocale: "en-US"
+}, "./test/testfiles", {
+    locales:["en-GB"],
+    javascript: {
+        wrapper: "(^r|\\Wr)b\\s*\\.\\s*getString(JS)?"
+    }
+});
+
+var rft2 = new RegexFileType(p2);
+
+describe("regex file tests", function() {
+    test("RegexFileConstructor", function() {
+        expect.assertions(1);
+
+        var rf = new RegexFile({
+            project: p,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+    });
+
+    test("RegexFileConstructorParams", function() {
+        expect.assertions(1);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: "./testfiles/js/t1.js",
+            type: rft
+        });
+
+        expect(rf).toBeTruthy();
+    });
+
+    test("RegexFileConstructorNoFile", function() {
+        expect.assertions(1);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+    });
+
+    test("RegexFileMakeKey", function() {
+        expect.assertions(2);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        expect(rf.makeKey("This is a test")).toBe("This is a test");
+    });
+
+    test("RegexFileParseSimpleGetByKey", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test")');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "This is a test"
+        });
+        expect(r).toBeTruthy();
+
+        expect(r[0].getSource()).toBe("This is a test");
+        expect(r[0].getKey()).toBe("This is a test");
+    });
+
+    test("RegexFileParseSimpleGetBySource", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test")');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+    });
+
+    test("RegexFileParseJSSimpleGetBySource", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getStringJS("This is a test")');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+    });
+
+    test("RegexFileParseSimpleSingleQuotes", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("RB.getString('This is a test')");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+    });
+
+    test("RegexFileParseJSSimpleSingleQuotes", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("RB.getStringJS('This is a test')");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+    });
+
+    test("RegexFileParseMoreComplexSingleQuotes", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("if (subcat == 'Has types') {title = RB.getString('Types of {topic}').format({topic: topic.attribute.name})}");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("Types of {topic}");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Types of {topic}");
+        expect(r.getKey()).toBe("Types of {topic}");
+    });
+
+    test("RegexFileParseSimpleIgnoreWhitespace", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('   RB.getString  (    \t "This is a test"    );  ');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+    });
+
+    test("RegexFileParseJSCompressWhitespaceInKey", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getStringJS("\t\t This \\n \n is \\\n\t a    test")');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("\t\t This \\n \n is \t a    test");
+    });
+
+    test("RegexFileParseSimpleRightSize", function() {
+        expect.assertions(4);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        var set = rf.getTranslationSet();
+        expect(set.size()).toBe(0);
+
+        rf.parse('RB.getString("This is a test")');
+
+        expect(set).toBeTruthy();
+
+        expect(set.size()).toBe(1);
+    });
+
+    test("RegexFileParseSimpleWithTranslatorComment", function() {
+        expect.assertions(6);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('\tRB.getString("This is a test"); // i18n: this is a translator\'s comment\n\tfoo("This is not");');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+        expect(r.getComment()).toBe("this is a translator's comment");
+    });
+
+    test("RegexFileParseSingleQuotesWithTranslatorComment", function() {
+        expect.assertions(6);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("\tRB.getString('This is a test'); // i18n: this is a translator\'s comment\n\tfoo('This is not');");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+        expect(r.getComment()).toBe("this is a translator's comment");
+    });
+
+    test("RegexFileParseSingleQuotesWithEmbeddedSingleQuotes", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse(
+            '    RB.getString(\'We\\\'ll notify you when {prefix}{last_name} accepts you as a friend!\').format({\n' +
+            '        prefix: detail.name_prefix,\n' +
+            '        last_name: detail.last_name\n' +
+            '    });'
+        );
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("We'll notify you when {prefix}{last_name} accepts you as a friend!");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("We'll notify you when {prefix}{last_name} accepts you as a friend!");
+        expect(r.getKey()).toBe("We'll notify you when {prefix}{last_name} accepts you as a friend!");
+    });
+
+    test("RegexFileParseSingleQuotesWithEmbeddedDoubleQuotes", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse(
+            '    RB.getString("We\\"ll notify you when {prefix}{last_name} accepts you as a friend!").format({\n' +
+            '        prefix: detail.name_prefix,\n' +
+            '        last_name: detail.last_name\n' +
+            '    });'
+        );
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource('We"ll notify you when {prefix}{last_name} accepts you as a friend!');
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe('We"ll notify you when {prefix}{last_name} accepts you as a friend!');
+        expect(r.getKey()).toBe('We"ll notify you when {prefix}{last_name} accepts you as a friend!');
+    });
+
+    test("RegexFileParseSimpleWithUniqueIdAndTranslatorComment", function() {
+        expect.assertions(6);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('\tRB.getString("This is a test", "foobar"); // i18n: this is a translator\'s comment\n\tfoo("This is not");');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "foobar"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is a test");
+        expect(r[0].getKey()).toBe("foobar");
+        expect(r[0].getComment()).toBe("this is a translator's comment");
+    });
+
+    test("RegexFileParseWithKey", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test", "unique_id")');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "unique_id"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is a test");
+        expect(r[0].getKey()).toBe("unique_id");
+    });
+
+    test("RegexFileParseJSWithKey", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getStringJS("This is a test", "unique_id")');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "unique_id"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is a test");
+        expect(r[0].getKey()).toBe("unique_id");
+    });
+
+    test("RegexFileParseWithKeySingleQuotes", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("RB.getString('This is a test', 'unique_id')");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "unique_id"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is a test");
+        expect(r[0].getKey()).toBe("unique_id");
+    });
+
+    test("RegexFileParseJSWithKeySingleQuotes", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("RB.getStringJS('This is a test', 'unique_id')");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "unique_id"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is a test");
+        expect(r[0].getKey()).toBe("unique_id");
+    });
+
+    test("RegexFileParseWithKeyCantGetBySource", function() {
+        expect.assertions(3);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test", "unique_id")');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(!r).toBeTruthy();
+    });
+
+    test("RegexFileParseMultiple", function() {
+        expect.assertions(8);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test");\n\ta.parse("This is another test.");\n\t\tRB.getString("This is also a test");');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+
+        r = set.getBySource("This is also a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is also a test");
+        expect(r.getKey()).toBe("This is also a test");
+    });
+
+    test("RegexFileParseMultipleWithKey", function() {
+        expect.assertions(10);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test", "x");\n\ta.parse("This is another test.");\n\t\tRB.getString("This is a test", "y");');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "x"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is a test");
+        expect(!r[0].getAutoKey()).toBeTruthy();
+        expect(r[0].getKey()).toBe("x");
+
+        r = set.getBy({
+            reskey: "y"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is a test");
+        expect(!r[0].getAutoKey()).toBeTruthy();
+        expect(r[0].getKey()).toBe("y");
+    });
+
+    test("RegexFileParseMultipleSameLine", function() {
+        expect.assertions(12);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test"), RB.getString("This is a second test"), RB.getString("This is a third test")');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        expect(set.size()).toBe(3);
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+
+        r = set.getBySource("This is a second test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a second test");
+        expect(r.getKey()).toBe("This is a second test");
+
+        r = set.getBySource("This is a third test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a third test");
+        expect(r.getKey()).toBe("This is a third test");
+    });
+
+    test("RegexFileParseMultipleWithComments", function() {
+        expect.assertions(10);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test");   // i18n: foo\n\ta.parse("This is another test.");\n\t\tRB.getString("This is also a test");\t// i18n: bar');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+        expect(r.getComment()).toBe("foo");
+
+        r = set.getBySource("This is also a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is also a test");
+        expect(r.getKey()).toBe("This is also a test");
+        expect(r.getComment()).toBe("bar");
+    });
+
+    test("RegexFileParseMultipleWithUniqueIdsAndComments", function() {
+        expect.assertions(10);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test", "asdf");   // i18n: foo\n\ta.parse("This is another test.");\n\t\tRB.getString("This is also a test", "kdkdkd");\t// i18n: bar');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "asdf"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is a test");
+        expect(r[0].getKey()).toBe("asdf");
+        expect(r[0].getComment()).toBe("foo");
+
+        r = set.getBy({
+            reskey: "kdkdkd"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is also a test");
+        expect(r[0].getKey()).toBe("kdkdkd");
+        expect(r[0].getComment()).toBe("bar");
+    });
+
+    test("RegexFileParseWithDups", function() {
+        expect.assertions(6);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test");\n\ta.parse("This is another test.");\n\t\tRB.getString("This is a test");');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+
+        expect(set.size()).toBe(1);
+    });
+
+    test("RegexFileParseDupsDifferingByKeyOnly", function() {
+        expect.assertions(8);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test");\n\ta.parse("This is another test.");\n\t\tRB.getString("This is a test", "unique_id");');
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+
+        r = set.getBy({
+            reskey: "unique_id"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is a test");
+        expect(r[0].getKey()).toBe("unique_id");
+    });
+
+    test("RegexFileParseBogusConcatenation", function() {
+        expect.assertions(2);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test" + " and this isnt");');
+
+        var set = rf.getTranslationSet();
+
+        expect(set.size()).toBe(0);
+    });
+
+    test("RegexFileParseBogusConcatenation2", function() {
+        expect.assertions(2);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString("This is a test" + foobar);');
+
+        var set = rf.getTranslationSet();
+        expect(set.size()).toBe(0);
+    });
+
+    test("RegexFileParseBogusNonStringParam", function() {
+        expect.assertions(2);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString(foobar);');
+
+        var set = rf.getTranslationSet();
+        expect(set.size()).toBe(0);
+    });
+
+    test("RegexFileParseEmptyParams", function() {
+        expect.assertions(2);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('RB.getString();');
+
+        var set = rf.getTranslationSet();
+        expect(set.size()).toBe(0);
+    });
+
+    test("RegexFileParseWholeWord", function() {
+        expect.assertions(2);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('EPIRB.getString("This is a test");');
+
+        var set = rf.getTranslationSet();
+        expect(set.size()).toBe(0);
+    });
+
+    test("RegexFileParseSubobject", function() {
+        expect.assertions(2);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse('App.RB.getString("This is a test");');
+
+        var set = rf.getTranslationSet();
+        expect(set.size()).toBe(1);
+    });
+
+    test("RegexFileParsePunctuationBeforeRB", function() {
+        expect.assertions(9);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse(
+            "        <%\n" +
+            "        var listsOver4 = false;\n" +
+            "        var seemoreLen = 0;\n" +
+            "        var subcats = [RB.getStringJS('Personal'), RB.getStringJS('Smart Watches')];\n" +
+            "        _.each(subcats, function(subcat, j){\n" +
+            "            var list = topic.attribute.kb_attribute_relationships[subcat] || [];\n" +
+            "            if (list.length > 0) {\n" +
+            "        %>\n");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        expect(set.size()).toBe(2);
+
+        var r = set.getBySource("Personal");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Personal");
+        expect(r.getKey()).toBe("Personal");
+
+        r = set.getBySource("Smart Watches");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Smart Watches");
+        expect(r.getKey()).toBe("Smart Watches");
+    });
+
+    test("RegexFileParseEmptyString", function() {
+        expect.assertions(3);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("var subcats = [RB.getStringJS(''), RB.getString(''), RB.getStringJS('', 'foo')];\n");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        expect(set.size()).toBe(0);
+    });
+
+    test("RegexFileParseNonString", function() {
+        expect.assertions(3);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("var subcats = [\n" +
+        "    RB.getStringJS(variableName),\n" +
+        "    RB.getString(undefined),\n" +
+        "    RB.getStringJS(variableName, 'foo')\n" +
+        "    RB.getString(function(x) {\n" +
+        "       return foo.getId(x);\n" +
+        "    }),\n" +
+        "];\n");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        expect(set.size()).toBe(0);
+    });
+
+    test("RegexFileExtractFile", function() {
+        expect.assertions(8);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: "./js/t1.js",
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        // should read the file
+        rf.extract();
+
+        var set = rf.getTranslationSet();
+
+        expect(set.size()).toBe(2);
+
+        var r = set.getBySource("This is a test");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("This is a test");
+        expect(r.getKey()).toBe("This is a test");
+
+        var r = set.getBy({
+            reskey: "id1"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("This is a test with a unique id");
+        expect(r[0].getKey()).toBe("id1");
+    });
+
+    test("RegexFileExtractTemplateFile", function() {
+        expect.assertions(11);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: "./tmpl/topic_types.tmpl.html",
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        // should read the file
+        rf.extract();
+
+        var set = rf.getTranslationSet();
+
+        expect(set.size()).toBe(4);
+
+        var r = set.getBySource("Hand-held Devices");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Hand-held Devices");
+        expect(r.getKey()).toBe("Hand-held Devices");
+
+        r = set.getBySource("Tablets");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Tablets");
+        expect(r.getKey()).toBe("Tablets");
+
+        r = set.getBySource("Smart Watches");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Smart Watches");
+        expect(r.getKey()).toBe("Smart Watches");
+    });
+
+    test("RegexFileExtractUndefinedFile", function() {
+        expect.assertions(2);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        // should attempt to read the file and not fail
+        rf.extract();
+
+        var set = rf.getTranslationSet();
+
+        expect(set.size()).toBe(0);
+    });
+
+    test("RegexFileExtractBogusFile", function() {
+        expect.assertions(2);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: "./java/foo.js",
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        // should attempt to read the file and not fail
+        rf.extract();
+
+        var set = rf.getTranslationSet();
+
+        expect(set.size()).toBe(0);
+    });
+
+    test("RegexFileParseWithAlternateWrapper", function() {
+        expect.assertions(9);
+
+        var rf = new RegexFile({
+            project: p2,
+            pathName: undefined,
+            type: rft2
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse(
+            "if (subcat === 'Has types') {\n" +
+            "    buttonText = rb\n" +
+            "                . getStringJS   (\n" +
+            "                     'Start Download'\n" +
+            "                ) ;\n" +
+            "    title = rb\n" +
+            "                .  getString (\n" +
+            "                     'Types of {topic}',\n" +
+            "                     'unique key'\n" +
+            "                )\n" +
+            "                .format({\n" +
+            "                    topic: topic.attribute.name\n" +
+            "                });\n" +
+            "}\n"
+        );
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "unique key"
+        });
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(1);
+        expect(r[0].getSource()).toBe("Types of {topic}");
+        expect(r[0].getKey()).toBe("unique key");
+
+        r = set.getBySource("Start Download");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Start Download");
+        expect(r.getKey()).toBe("Start Download");
+    });
+
+    test("RegexFileParseWithAlternateWrapperAndEmbeddedQuote", function() {
+        expect.assertions(9);
+
+        var rf = new RegexFile({
+            project: p2,
+            pathName: undefined,
+            type: rft2
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse(
+            "if (subcat === 'Has types') {\n" +
+            "    buttonText = rb\n" +
+            "                . getStringJS   (\n" +
+            "                     'Start \\\"Download'\n" +
+            "                ) ;\n" +
+            "    title = rb\n" +
+            "                .  getString (\n" +
+            "                     'Types of {topic}',\n" +
+            "                     'unique key'\n" +
+            "                )\n" +
+            "                .format({\n" +
+            "                    topic: topic.attribute.name\n" +
+            "                });\n" +
+            "}\n"
+        );
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "unique key"
+        });
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(1);
+        expect(r[0].getSource()).toBe("Types of {topic}");
+        expect(r[0].getKey()).toBe("unique key");
+
+        r = set.getBySource("Start \"Download");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Start \"Download");
+        expect(r.getKey()).toBe("Start \"Download");
+    });
+
+    test("RegexFileParseParametersWithExtraTrailingCommas", function() {
+        expect.assertions(9);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: undefined,
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        // eslint has this nasty habit of inserting useless extra commas at the end
+        // of parameter lists
+        rf.parse(
+            "if (subcat === 'Has types') {\n" +
+            "    buttonText = RB.getStringJS(\n" +
+            "        'Start Download',\n" +
+            "    );\n" +
+            "    title = RB.getString(\n" +
+            "        'Types of {topic}',\n" +
+            "        'unique key',\n" +
+            "    )\n" +
+            "    .format({\n" +
+            "        topic: topic.attribute.name\n" +
+            "    });\n" +
+            "}\n"
+        );
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBy({
+            reskey: "unique key"
+        });
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(1);
+        expect(r[0].getSource()).toBe("Types of {topic}");
+        expect(r[0].getKey()).toBe("unique key");
+
+        r = set.getBySource("Start Download");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Start Download");
+        expect(r.getKey()).toBe("Start Download");
+    });
+});

--- a/packages/ilib-loctool-regex/test/RegexFile.test.js
+++ b/packages/ilib-loctool-regex/test/RegexFile.test.js
@@ -23,14 +23,19 @@ var CustomProject =  require("loctool/lib/CustomProject.js");
 
 var p = new CustomProject({
     id: "app",
-    plugins: [require.resolve("../.")],
-    sourceLocale: "en-US"
+    plugins: [
+        require.resolve("../.")
+    ],
+    sourceLocale: "en-US",
+    resourceFileTypes: {
+        "javascript": "ilib-loctool-javascript-resource"
+    }
 }, "./test/testfiles", {
     "locales":["en-GB", "de-DE", "fr-FR", "ja-JP"],
     "regex": {
         "mappings": {
             "**/*.js": {
-                "resourceFileType": "ilib-loctool-javascript-resource",
+                "resourceFileType": "javascript",
                 "template": "resources/strings_[locale].json",
                 "sourceLocale": "en-US",
                 "expressions": [
@@ -86,7 +91,7 @@ var p = new CustomProject({
                 ]
             },
             "**/*.tmpl": {
-                "resourceFileType": "ilib-loctool-javascript-resource",
+                "resourceFileType": "javascript",
                 "template": "resources/Translation[locale].json",
                 "sourceLocale": "en-US",
                 "expressions": [

--- a/packages/ilib-loctool-regex/test/RegexFileType.test.js
+++ b/packages/ilib-loctool-regex/test/RegexFileType.test.js
@@ -1,5 +1,5 @@
 /*
- * RegexFileType.test.js - test the HTML template file type handler object.
+ * RegexFileType.test.js - test the regex file type handler object.
  *
  * Copyright © 2024 Box, Inc.
  *
@@ -77,15 +77,16 @@ describe("javascriptfiletype", function() {
 
         expect(rft).toBeTruthy();
     });
-    
+
     test("RegexFileType gives the right set of extensions", function() {
         expect.assertions(2);
-        
+
         var rft = new RegexFileType(p);
         expect(rft).toBeTruthy();
-        
+
         var exts = rft.getExtensions();
         exts.sort();
+        // should automatically calculate the extensions from the mappings
         expect(exts).toEqual(["js", "tmpl"]);
     });
 
@@ -122,6 +123,7 @@ describe("javascriptfiletype", function() {
         var rft = new RegexFileType(p);
         expect(rft).toBeTruthy();
 
+        // no dot in the extension
         expect(rft.handles("foojs")).toBeFalsy();
     });
 
@@ -166,7 +168,7 @@ describe("javascriptfiletype", function() {
 
     test("RegexFileType get the right resource file type for a js file", function() {
         expect.assertions(4);
-debugger;
+
         var rft = new RegexFileType(p);
         expect(rft).toBeTruthy();
 

--- a/packages/ilib-loctool-regex/test/RegexFileType.test.js
+++ b/packages/ilib-loctool-regex/test/RegexFileType.test.js
@@ -24,14 +24,19 @@ var CustomProject =  require("loctool/lib/CustomProject.js");
 
 var p = new CustomProject({
     id: "app",
-    plugins: [require.resolve("../.")],
+    plugins: [
+        require.resolve("../.")
+    ],
     sourceLocale: "en-US"
 }, "./testfiles", {
     locales:["en-GB"],
+    resourceFileTypes: {
+        "javascript": "ilib-loctool-javascript-resource"
+    },
     regex: {
         mappings: {
             "**/*.js": {
-                "resourceFileType": "ilib-loctool-javascript-resource",
+                "resourceFileType": "javascript",
                 "template": "resources/strings_[locale].json",
                 "sourceLocale": "en-US",
                 "expressions": [
@@ -45,7 +50,7 @@ var p = new CustomProject({
                 ]
             },
             "**/*.tmpl": {
-                "resourceFileType": "ilib-loctool-javascript-resource",
+                "resourceFileType": "javascript",
                 "template": "resources/template_[locale].json",
                 "sourceLocale": "en-US",
                 "expressions": [

--- a/packages/ilib-loctool-regex/test/RegexFileType.test.js
+++ b/packages/ilib-loctool-regex/test/RegexFileType.test.js
@@ -1,0 +1,236 @@
+/*
+ * RegexFileType.test.js - test the HTML template file type handler object.
+ *
+ * Copyright © 2024 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var JavaScriptResourceFileType = require("ilib-loctool-javascript-resource");
+
+var RegexFileType = require("../RegexFileType.js");
+var CustomProject =  require("loctool/lib/CustomProject.js");
+
+var p = new CustomProject({
+    id: "app",
+    plugins: [require.resolve("../.")],
+    sourceLocale: "en-US"
+}, "./testfiles", {
+    locales:["en-GB"],
+    regex: {
+        mappings: {
+            "**/*.js": {
+                "resourceFileType": "ilib-loctool-javascript-resource",
+                "template": "resources/strings_[locale].json",
+                "sourceLocale": "en-US",
+                "expressions": [
+                    {
+                        "expression": "\b\\$t\\s*\\(\"(?<source>[^\"]*)\"\\)",
+                        "flags": "g",
+                        "datatype": "javascript",
+                        "resourceType": "string",
+                        "keyStrategy": "hash"
+                    }
+                ]
+            },
+            "**/*.tmpl": {
+                "resourceFileType": "ilib-loctool-javascript-resource",
+                "template": "resources/template_[locale].json",
+                "sourceLocale": "en-US",
+                "expressions": [
+                    {
+                        // example:
+                        // {* @L10N The message shown to users whose passwords have just been changed *}
+                        // {'Your password was changed. Please log in again.'|f:'login_success_password_changed'}
+                        "expression": "\\{.*@L10N\\s*(?<comment>[^*]*)\\*\\}.*\\{.*'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*\\}",
+                        "flags": "g",
+                        "datatype": "template",
+                        "resourceType": "string"
+                    }
+                ]
+            }
+        }
+    }
+});
+
+
+beforeAll(function() {
+    p.defineFileTypes();
+});
+
+describe("javascriptfiletype", function() {
+    test("RegexFileTypeConstructor", function() {
+        expect.assertions(1);
+
+        var rft = new RegexFileType(p);
+
+        expect(rft).toBeTruthy();
+    });
+    
+    test("RegexFileType gives the right set of extensions", function() {
+        expect.assertions(2);
+        
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+        
+        var exts = rft.getExtensions();
+        exts.sort();
+        expect(exts).toEqual(["js", "tmpl"]);
+    });
+
+    test("RegexFileType handles JS files", function() {
+        expect.assertions(2);
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        expect(rft.handles("foo.js")).toBeTruthy();
+    });
+
+    test("RegexFileType does not handle JSX files", function() {
+        expect.assertions(2);
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        expect(rft.handles("foo.jsx")).toBeFalsy();
+    });
+
+    test("RegexFileType handles template files", function() {
+        expect.assertions(2);
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        expect(rft.handles("foo.tmpl")).toBeTruthy();
+    });
+
+    test("RegexFileType does not handle JS that is missing the dot", function() {
+        expect.assertions(2);
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        expect(rft.handles("foojs")).toBeFalsy();
+    });
+
+    test("RegexFileType does not handle other random file types", function() {
+        expect.assertions(2);
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        expect(rft.handles("foo.html")).toBeFalsy();
+    });
+
+    test("RegexFileType handles js with a directory", function() {
+        expect.assertions(2);
+
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        expect(rft.handles("a/b/c/foo.js")).toBeTruthy();
+    });
+
+    test("RegexFileType handles template files with a directory", function() {
+        expect.assertions(2);
+
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        expect(rft.handles("a/b/c/foo.tmpl")).toBeTruthy();
+    });
+
+    test("RegexFileType does not handle resource files", function() {
+        expect.assertions(2);
+
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        expect(rft.handles("resources/strings_de-DE.json")).toBeFalsy();
+    });
+
+    test("RegexFileType get the right resource file type for a js file", function() {
+        expect.assertions(4);
+debugger;
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        var resFileType = rft.getResourceFileTypeForPath("a/b/c/foo.js");
+        expect(resFileType instanceof JavaScriptResourceFileType).toBeTruthy();
+
+        var resfile = resFileType.getResourceFile("de-DE");
+
+        expect(resfile).toBeTruthy();
+        expect(resfile.locale.getSpec()).toBe("de-DE");
+    });
+
+    test("RegexFileType get the right resource file type for template files", function() {
+        expect.assertions(4);
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        var resFileType = rft.getResourceFileTypeForPath("a/b/c/foo.tmpl");
+        expect(resFileType instanceof JavaScriptResourceFileType).toBeTruthy();
+
+        var resfile = resFileType.getResourceFile("de-DE");
+
+        expect(resfile).toBeTruthy();
+        expect(resfile.locale.getSpec()).toBe("de-DE");
+    });
+
+    test("RegexFileTypeGetResourceFileSameForSameLocale", function() {
+        expect.assertions(5);
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        var resFileType = rft.getResourceFileTypeForPath("x/y/z/foo.js");
+        expect(resFileType instanceof JavaScriptResourceFileType).toBeTruthy();
+
+        var resfile1 = resFileType.getResourceFile("de-DE");
+
+        expect(resfile1).toBeTruthy();
+
+        var resfile2 = resFileType.getResourceFile("de-DE");
+
+        expect(resfile2).toBeTruthy();
+
+        expect(resfile1).toBe(resfile2);
+    });
+
+    test("RegexFileTypeGetResourceFileDifferentForDifferentLocales", function() {
+        expect.assertions(5);
+
+        var rft = new RegexFileType(p);
+        expect(rft).toBeTruthy();
+
+        var resFileType = rft.getResourceFileTypeForPath("m/n/o/foo.js");
+        expect(resFileType instanceof JavaScriptResourceFileType).toBeTruthy();
+
+        var resfile1 = resFileType.getResourceFile("de-DE");
+
+        expect(resfile1).toBeTruthy();
+
+        var resfile2 = resFileType.getResourceFile("fr-FR");
+
+        expect(resfile2).toBeTruthy();
+
+        expect(resfile1).not.toBe(resfile2);
+    });
+});

--- a/packages/ilib-loctool-regex/test/RegexFileType.test.js
+++ b/packages/ilib-loctool-regex/test/RegexFileType.test.js
@@ -87,7 +87,7 @@ describe("javascriptfiletype", function() {
         var exts = rft.getExtensions();
         exts.sort();
         // should automatically calculate the extensions from the mappings
-        expect(exts).toEqual(["js", "tmpl"]);
+        expect(exts).toEqual([".js", ".tmpl"]);
     });
 
     test("RegexFileType handles JS files", function() {

--- a/packages/ilib-loctool-regex/test/testfiles/js/t1.js
+++ b/packages/ilib-loctool-regex/test/testfiles/js/t1.js
@@ -7,5 +7,5 @@ var t1 = function() {
 t1.prototype.tester = function() {
     $t("This is a test");
 
-    $("This is a test with a unique id");
+    $t("This is a test with a unique id");
 };

--- a/packages/ilib-loctool-regex/test/testfiles/js/t1.js
+++ b/packages/ilib-loctool-regex/test/testfiles/js/t1.js
@@ -1,0 +1,11 @@
+var fs = require("foobar");
+
+var t1 = function() {
+    console.log("If you find this, you found the wrong string!");
+}
+
+t1.prototype.tester = function() {
+    $t("This is a test");
+
+    $("This is a test with a unique id");
+};

--- a/packages/ilib-loctool-regex/test/testfiles/project.json
+++ b/packages/ilib-loctool-regex/test/testfiles/project.json
@@ -84,7 +84,7 @@
                     "expressions": [
                         {
                             "expression": "(\\{\\*.*@L10N\\s*(?<comment>[^*]*)\\*\\})?.*\\{.*'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*\\}",
-                            "flags": "gsv",
+                            "flags": "g",
                             "datatype": "template",
                             "resourceType": "string"
                         }

--- a/packages/ilib-loctool-regex/test/testfiles/project.json
+++ b/packages/ilib-loctool-regex/test/testfiles/project.json
@@ -1,0 +1,106 @@
+{
+    "name": "sample",
+    "id": "sample",
+    "version": "1.0.0",
+    "description": "Sample project for testing regular expressions against files",
+    "type": "custom",
+    "sourceLocale": "en",
+    "pseudoLocale": "zxx-XX",
+    "resourceDirs": {
+        "javascript": "target"
+    },
+    "includes": [
+        "**/*.js",
+        "**/*.tmpl"
+    ],
+    "excludes": [
+        ".git",
+        ".github",
+        "test",
+        "node_modules",
+        "xliffs",
+        "**/*.po",
+        "**/*.pot",
+        "**/*.mo",
+        "**/*.xliff"
+    ],
+    "settings": {
+        "locales":["en-GB", "de-DE", "fr-FR", "ja-JP"],
+        "regex": {
+            "mappings": {
+                "**/*.js": {
+                    "resourceFileType": "ilib-loctool-javascript-resource",
+                    "template": "resources/strings_[locale].json",
+                    "sourceLocale": "en-US",
+                    "expressions": [
+                        {
+                            "expression": "\\$t\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*\\)",
+                            "flags": "g",
+                            "datatype": "javascript",
+                            "resourceType": "string",
+                            "keyStrategy": "hash"
+                        },
+                        {
+                            "expression": "\\$p\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*,\\s*['\"](?<sourcePlural>[^'\"]*)['\"]\\s*\\)",
+                            "flags": "g",
+                            "datatype": "javascript",
+                            "resourceType": "plural",
+                            "keyStrategy": "hash"
+                        },
+                        {
+                            "expression": "\\$a\\s*\\(\\s*\\[(?<source>[^\\]]*)\\s*\\]\\s*\\)",
+                            "flags": "g",
+                            "datatype": "javascript",
+                            "resourceType": "array",
+                            "keyStrategy": "hash"
+                        },
+                        {
+                            "expression": "\\$wholekey\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*\\)",
+                            "flags": "g",
+                            "datatype": "javascript",
+                            "resourceType": "string",
+                            "keyStrategy": "source"
+                        },
+                        {
+                            "expression": "\\$truncatedkey\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*\\)",
+                            "flags": "g",
+                            "datatype": "javascript",
+                            "resourceType": "string",
+                            "keyStrategy": "truncate"
+                        },
+                        {
+                            "expression": "\\$u\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*\\)",
+                            "flags": "gu",
+                            "datatype": "javascript",
+                            "resourceType": "string",
+                            "keyStrategy": "hash"
+                        }
+                    ]
+                },
+                "**/*.tmpl": {
+                    "resourceFileType": "ilib-loctool-javascript-resource",
+                    "template": "resources/Translation[locale].json",
+                    "sourceLocale": "en-US",
+                    "expressions": [
+                        {
+                            "expression": "(\\{\\*.*@L10N\\s*(?<comment>[^*]*)\\*\\})?.*\\{.*'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*\\}",
+                            "flags": "gsv",
+                            "datatype": "template",
+                            "resourceType": "string"
+                        }
+                    ]
+                }
+            }
+        },
+        "php": {
+            "localeMap": {
+                "en-US": "EnUS",
+                "en-GB": "EnGB",
+                "de-DE": "DeDE",
+                "fr-FR": "FrFR",
+                "ja-JP": "JaJP"
+            },
+            "sourceLocale": "en-US"
+        }
+    }
+}

--- a/packages/ilib-loctool-regex/test/testfiles/project.json
+++ b/packages/ilib-loctool-regex/test/testfiles/project.json
@@ -83,7 +83,19 @@
                     "sourceLocale": "en-US",
                     "expressions": [
                         {
-                            "expression": "(\\{\\*.*@L10N\\s*(?<comment>[^*]*)\\*\\})?.*\\{.*'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*\\}",
+                            "expression": "\\{\\*.*@L10N\\s*(?<comment>[^*]*)\\*\\}.*\\n.*\\{.*'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*\\}",
+                            "flags": "g",
+                            "datatype": "template",
+                            "resourceType": "string"
+                        },
+                        {
+                            "expression": "\\{\\*.*@L10N\\s*(?<comment>[^*]*)\\*\\}.*\\{.*'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*\\}",
+                            "flags": "g",
+                            "datatype": "template",
+                            "resourceType": "string"
+                        },
+                        {
+                            "expression": "\\{.*'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*\\}",
                             "flags": "g",
                             "datatype": "template",
                             "resourceType": "string"

--- a/packages/ilib-loctool-regex/test/testfiles/tmpl/topic_types.tmpl
+++ b/packages/ilib-loctool-regex/test/testfiles/tmpl/topic_types.tmpl
@@ -90,9 +90,11 @@
                     <%
                     if (list.length > 3) {
                     %>
+                    <button class="cancel">
+                        {'Cancel' | f:'cancel'}
+                    </button>
                     <a href="#" class="seemoreButton">
-                        {* @L10N label for the button that shows more items *}
-                        {'See more' | f:'see_more'}
+                        {* @L10N label for the button that shows more items *} {'See more' | f:'see_more'}
                     </a>
                     <%
                     }

--- a/packages/ilib-loctool-regex/test/testfiles/tmpl/topic_types.tmpl
+++ b/packages/ilib-loctool-regex/test/testfiles/tmpl/topic_types.tmpl
@@ -1,0 +1,107 @@
+<div class="topicTypes">
+    <div class="topbarContainer">
+        <div class="topbar">
+            <a class="item description" topic_chooser="#description">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>
+                    {* @L10N topic type label for the icon *}
+                    {'Description' | f:'description'}
+                </div>
+            </a>
+            <a class="item conditions" topic_chooser="#participants">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>
+                    {* @L10N topic type label for the icon *}
+                    {'Participants' | f:'participants'}
+                    (<span class="number"></span>)
+                </div>
+            </a>
+            <a class="item symptoms" topic_chooser="#visitors">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>
+                    {* @L10N topic type label for the icon *}
+                    {'Visitors' | f:'visitors'}
+                    (<span class="number"></span>)
+                </div>
+            </a>
+            <a class="item treatments" topic_chooser="#spectators">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>
+                    {* @L10N topic type label for the icon *}
+                    {'Spectators' | f:'spectators'}
+                    (<span class="number"></span>)
+                </div>
+            </a>
+            <a class="item tests" topic_chooser="#tests">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>
+                    {* @L10N topic type label for the icon *}
+                    {'Tests' | f:'tests'}
+                    (<span class="number"></span>)
+                </div>
+            </a>
+            <a class="item riskFactors" topic_chooser="#activities">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>
+                    {* @L10N topic type label for the icon *}
+                    {'Activities and Events' | f:'activities'}
+                    (<span class="number"></span>)
+                </div>
+            </a>
+            <a class="item resolution" topic_chooser="#solutions">
+                <div class="iconContainer"><div class="icon"></div></div>
+                <div>
+                    {* @L10N topic type label for the icon *}
+                    {'Solutions' | f:'solutions'}
+                    (<span class="number"></span>)
+                </div>
+            </a>
+        </div>
+        <a href="#" class="left arrow"></a>
+        <a href="#" class="right arrow"></a>
+    </div>
+
+    <div class="content">
+        <div class="section devices" id="devices">
+            <%
+            var listsOver4 = false;
+            var seemoreLen = 0;
+            var subcats = [$t('Tablets'), $t('Smart Watches'), $t('Hand-held Devices'), $t('Other')];
+            _.each(subcats, function(subcat, j){
+                var list = topic.attribute.kb_attribute_relationships[subcat] || [];
+                if (list.length > 0) {
+            %>
+                    <div class="subcatTitle"><div class="icon <%= subcat %>"></div><%= subcat %></div>
+                    <%
+                    _.each(list, function(item, i){
+                        var more = i > 2 ? 'more m' + Math.floor(i/100) : '';
+                    %>
+                    <a href="<%= item.url.toHashFragment() %>" class="topicBasic <%= more %>">
+                        <%= App.image_tag( item.image_url_low_res, {'class' : 'topicImg'}) %>
+                        <div class="name"><%= item.name %></div>
+                        <div class="salesContainer">
+                            <div class="salesBullet <%= item.sales %>"></div>
+                            <div class="sales"><%= item.sales %></div>
+                        </div>
+                    </a>
+                    <%
+                    });
+                    %>
+                    <%
+                    if (list.length > 3) {
+                    %>
+                    <a href="#" class="seemoreButton">
+                        {* @L10N label for the button that shows more items *}
+                        {'See more' | f:'see_more'}
+                    </a>
+                    <%
+                    }
+                    %>
+            <%
+                }
+            });
+            %>
+        </div>
+
+    </div>
+</div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1628,13 +1628,13 @@ importers:
   packages/ilib-loctool-regex:
     devDependencies:
       ilib-loctool-javascript-resource:
-        specifier: ^1.0.6
-        version: 1.0.6
+        specifier: workspace:^
+        version: link:../ilib-loctool-javascript-resource
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.17.4)(node-notifier@8.0.2)
       loctool:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../loctool
 
   packages/ilib-loctool-ruby-ilib:
@@ -5428,10 +5428,6 @@ packages:
 
   ilib-localematcher@1.3.1:
     resolution: {integrity: sha512-sDqSdYfAouyGH9OPKPuXk2Lyb4+HU3Gz05bLTJ5fn3FRn/IzG5sUQjSrhfmQAsklQ6WLlJE3nL5wbpV0fpX8Lw==}
-
-  ilib-loctool-javascript-resource@1.0.6:
-    resolution: {integrity: sha512-0Jp8xCL0XkTNCkcDO7qlSE1VVT16Ty/mhSSdfEZZ0gSl6+ZsLHBeStsnOx93o02z15Q0eANT/Lm9IuP7/nxDaw==}
-    engines: {node: '>=6.0'}
 
   ilib-loctool-mock-json@file:packages/loctool/test/ilib-loctool-mock-json/ilib-loctool-mock-json-1.0.0.tgz:
     resolution: {integrity: sha512-G/20MuXksGohqBfMoHLeuME4u3JwqW8qmAzDoUUCVmalQQYg7dARztde6cxx7VrOoilo4kwS4bt0L+yGs5u0PA==, tarball: file:packages/loctool/test/ilib-loctool-mock-json/ilib-loctool-mock-json-1.0.0.tgz}
@@ -12472,10 +12468,6 @@ snapshots:
     dependencies:
       ilib-common: 1.1.3
       ilib-locale: 1.2.2
-
-  ilib-loctool-javascript-resource@1.0.6:
-    dependencies:
-      ilib: 14.20.0
 
   ilib-loctool-mock-json@file:packages/loctool/test/ilib-loctool-mock-json/ilib-loctool-mock-json-1.0.0.tgz:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1203,7 +1203,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
+        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1637,9 +1637,6 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8
     devDependencies:
-      flatted:
-        specifier: ^3.3.2
-        version: 3.3.2
       ilib-loctool-javascript-resource:
         specifier: workspace:^
         version: link:../ilib-loctool-javascript-resource
@@ -2107,7 +2104,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
+        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -4884,9 +4881,6 @@ packages:
 
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
-
-  flatted@3.3.2:
-    resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
   follow-redirects@1.0.0:
     resolution: {integrity: sha512-7s+wBk4z5xTwVJuozRBAyRofWKjD3uG2CUjZfZTrw9f+f+z8ZSxOjAqfIDLtc0Hnz+wGK2Y8qd93nGGjXBYKsQ==}
@@ -11719,8 +11713,6 @@ snapshots:
   flatmap@0.0.3: {}
 
   flatted@3.3.1: {}
-
-  flatted@3.3.2: {}
 
   follow-redirects@1.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1203,7 +1203,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
+        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1628,11 +1628,11 @@ importers:
   packages/ilib-loctool-regex:
     dependencies:
       ilib-istring:
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: workspace:^
+        version: link:../ilib-istring
       ilib-locale:
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: workspace:^
+        version: link:../ilib-locale
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
@@ -4051,11 +4051,11 @@ packages:
   cjs-module-lexer@1.4.1:
     resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
 
-  cldr-core@46.1.0:
-    resolution: {integrity: sha512-YWIbxgpO6fUais+FIm6Stl/KoAAhNJx4wDg2sg06QxK6GQ+i1iwdpCiyIJ7CTWduRuqUmRoaYpL/n5/8Q8ywxg==}
-
   cldr-core@44.1.0:
     resolution: {integrity: sha512-ssbJaXu3pCkc4YqNC6xHhgleZG7YqnOFZ9laMlJfHOfnspoA9waI4AH54gKB3Fe/+wI4i3cVxKFdCTVGTRw+UA==}
+
+  cldr-core@46.1.0:
+    resolution: {integrity: sha512-YWIbxgpO6fUais+FIm6Stl/KoAAhNJx4wDg2sg06QxK6GQ+i1iwdpCiyIJ7CTWduRuqUmRoaYpL/n5/8Q8ywxg==}
 
   cldr-segmentation@2.2.1:
     resolution: {integrity: sha512-0XAXy22htsxXgdSbXxJzzyAsBrBUvFhUho3eRonfcP/zvromwjBe5yDji9/y4XaV9YszEZswKv3WYhgd+JA8CA==}
@@ -10421,7 +10421,7 @@ snapshots:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.95.0
+      webpack: 5.95.0(webpack-cli@5.1.4)
 
   babel-plugin-add-module-exports@1.0.4: {}
 
@@ -10784,9 +10784,9 @@ snapshots:
 
   cjs-module-lexer@1.4.1: {}
 
-  cldr-core@46.1.0: {}
-
   cldr-core@44.1.0: {}
+
+  cldr-core@46.1.0: {}
 
   cldr-segmentation@2.2.1:
     dependencies:
@@ -11978,15 +11978,6 @@ snapshots:
       chalk: 4.1.2
       hooker: 0.2.3
       jshint: 2.13.6
-
-  grunt-contrib-nodeunit@4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      nodeunit-x: 0.15.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
-    transitivePeerDependencies:
-      - flow-remove-types
-      - supports-color
-      - ts-node
-      - typescript
 
   grunt-contrib-nodeunit@4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
@@ -14227,16 +14218,6 @@ snapshots:
       socks: 1.1.9
     optional: true
 
-  nodeunit-x@0.15.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      ejs: 3.1.10
-      tap: 15.2.3(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
-    transitivePeerDependencies:
-      - flow-remove-types
-      - supports-color
-      - ts-node
-      - typescript
-
   nodeunit-x@0.15.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
       ejs: 3.1.10
@@ -15753,36 +15734,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  tap@15.2.3(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      chokidar: 3.6.0
-      coveralls: 3.1.1
-      findit: 2.0.0
-      foreground-child: 2.0.0
-      fs-exists-cached: 1.0.0
-      glob: 7.2.3
-      isexe: 2.0.0
-      istanbul-lib-processinfo: 2.0.3
-      jackspeak: 1.4.2
-      libtap: 1.4.1
-      minipass: 3.3.6
-      mkdirp: 1.0.4
-      nyc: 15.1.0
-      opener: 1.5.2
-      rimraf: 3.0.2
-      signal-exit: 3.0.7
-      source-map-support: 0.5.21
-      tap-mocha-reporter: 5.0.4
-      tap-parser: 11.0.2
-      tap-yaml: 1.0.2
-      tcompare: 5.0.7
-      which: 2.0.2
-    optionalDependencies:
-      ts-node: 8.10.2(typescript@3.9.10)
-      typescript: 3.9.10
-    transitivePeerDependencies:
-      - supports-color
-
   tap@15.2.3(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
       chokidar: 3.6.0
@@ -16457,36 +16408,6 @@ snapshots:
       wildcard: 2.0.1
 
   webpack-sources@3.2.3: {}
-
-  webpack@5.95.0:
-    dependencies:
-      '@types/estree': 1.0.6
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.14.0
-      acorn-import-attributes: 1.9.5(acorn@8.14.0)
-      browserslist: 4.24.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
-      es-module-lexer: 1.5.4
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.95.0)
-      watchpack: 2.4.2
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   webpack@5.95.0(webpack-cli@4.10.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1203,7 +1203,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
+        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1626,7 +1626,17 @@ importers:
         version: link:../loctool
 
   packages/ilib-loctool-regex:
+    dependencies:
+      ilib-locale:
+        specifier: ^1.2.2
+        version: 1.2.2
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
     devDependencies:
+      flatted:
+        specifier: ^3.3.2
+        version: 3.3.2
       ilib-loctool-javascript-resource:
         specifier: workspace:^
         version: link:../ilib-loctool-javascript-resource
@@ -2094,7 +2104,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
+        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -4871,6 +4881,9 @@ packages:
 
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+
+  flatted@3.3.2:
+    resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
   follow-redirects@1.0.0:
     resolution: {integrity: sha512-7s+wBk4z5xTwVJuozRBAyRofWKjD3uG2CUjZfZTrw9f+f+z8ZSxOjAqfIDLtc0Hnz+wGK2Y8qd93nGGjXBYKsQ==}
@@ -11703,6 +11716,8 @@ snapshots:
   flatmap@0.0.3: {}
 
   flatted@3.3.1: {}
+
+  flatted@3.3.2: {}
 
   follow-redirects@1.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1627,6 +1627,9 @@ importers:
 
   packages/ilib-loctool-regex:
     dependencies:
+      ilib-istring:
+        specifier: ^1.1.0
+        version: 1.1.0
       ilib-locale:
         specifier: ^1.2.2
         version: 1.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1625,6 +1625,18 @@ importers:
         specifier: workspace:^
         version: link:../loctool
 
+  packages/ilib-loctool-regex:
+    devDependencies:
+      ilib-loctool-javascript-resource:
+        specifier: ^1.0.6
+        version: 1.0.6
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.4)(node-notifier@8.0.2)
+      loctool:
+        specifier: workspace:*
+        version: link:../loctool
+
   packages/ilib-loctool-ruby-ilib:
     dependencies:
       ilib:
@@ -5416,6 +5428,10 @@ packages:
 
   ilib-localematcher@1.3.1:
     resolution: {integrity: sha512-sDqSdYfAouyGH9OPKPuXk2Lyb4+HU3Gz05bLTJ5fn3FRn/IzG5sUQjSrhfmQAsklQ6WLlJE3nL5wbpV0fpX8Lw==}
+
+  ilib-loctool-javascript-resource@1.0.6:
+    resolution: {integrity: sha512-0Jp8xCL0XkTNCkcDO7qlSE1VVT16Ty/mhSSdfEZZ0gSl6+ZsLHBeStsnOx93o02z15Q0eANT/Lm9IuP7/nxDaw==}
+    engines: {node: '>=6.0'}
 
   ilib-loctool-mock-json@file:packages/loctool/test/ilib-loctool-mock-json/ilib-loctool-mock-json-1.0.0.tgz:
     resolution: {integrity: sha512-G/20MuXksGohqBfMoHLeuME4u3JwqW8qmAzDoUUCVmalQQYg7dARztde6cxx7VrOoilo4kwS4bt0L+yGs5u0PA==, tarball: file:packages/loctool/test/ilib-loctool-mock-json/ilib-loctool-mock-json-1.0.0.tgz}
@@ -12456,6 +12472,10 @@ snapshots:
     dependencies:
       ilib-common: 1.1.3
       ilib-locale: 1.2.2
+
+  ilib-loctool-javascript-resource@1.0.6:
+    dependencies:
+      ilib: 14.20.0
 
   ilib-loctool-mock-json@file:packages/loctool/test/ilib-loctool-mock-json/ilib-loctool-mock-json-1.0.0.tgz:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1642,7 +1642,7 @@ importers:
         version: link:../ilib-loctool-javascript-resource
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.17.4)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool


### PR DESCRIPTION
- intended for file formats that are simple enough that they can be parsed with regular expressions
- settings in the project config file allow you to specify the regular expressions and how to handle the parts that they match
- outputs regular Resource instances
- cannot write any file format, so must be used with a resource file type