### PR TITLE
Move plural conversions from loctool to ilib-tools-common

### DIFF
--- a/.changeset/honest-icons-brake.md
+++ b/.changeset/honest-icons-brake.md
@@ -1,0 +1,7 @@
+---
+"ilib-tools-common": minor
+---
+
+Added functions convertPluralResToICU and convertICUToPluralRes to convert
+ICU-style plural strings encoded in ResourceString instances into ResourcePlural
+instances and vice-versa

--- a/.changeset/rotten-pears-kick.md
+++ b/.changeset/rotten-pears-kick.md
@@ -1,0 +1,6 @@
+---
+"loctool": patch
+---
+
+Now uses ICU<->Plural conversion code from the ilib-tools-common library instead of its
+own implementation. This way, the code can be shared between tools.

--- a/packages/ilib-tools-common/package.json
+++ b/packages/ilib-tools-common/package.json
@@ -90,6 +90,7 @@
         "ilib-ctype": "workspace:^",
         "ilib-locale": "workspace:^",
         "ilib-xliff": "workspace:^",
+        "intl-messageformat": "^10.7.11",
         "micromatch": "^4.0.8"
     }
 }

--- a/packages/ilib-tools-common/src/Resource.js
+++ b/packages/ilib-tools-common/src/Resource.js
@@ -43,6 +43,24 @@ const translationImportant = [
  */
 class Resource {
     /**
+     * The type of this resource instance.
+     * @type {String | undefined}
+     */
+    resType;
+
+    /**
+     * The source string or strings for the resource.
+     * @type {String|Array.<String>|Object}
+     */
+    source;
+
+    /**
+     * The target string or strings for the resource.
+     * @type {String|Array.<String>|Object}
+     */
+    target;
+
+    /**
      * Construct a new Resource instance.
      * The props may contain any
      * of the following properties:
@@ -138,7 +156,7 @@ class Resource {
     /**
      * Return the target string or strings for this resource.
      *
-     * @returns {String|Array.<String>|Object} the source string or
+     * @returns {String|Array.<String>|Object|undefined} the source string or
      * strings of this resource
      */
     getTarget() {
@@ -437,7 +455,7 @@ class Resource {
      * properties, it is not added to the list of instances. This
      * can be checked easily by calling the isInstance() method.
      *
-     * @param {Resource} an instance of the current resource to
+     * @param {Resource} resource an instance of the current resource to
      * record
      * @returns {boolean} true if the instance was added, and
      * and false otherwise
@@ -463,7 +481,7 @@ class Resource {
      * affect the possible translation match between the given and
      * the current resource.
      *
-     * @param {Resource} a resource to check
+     * @param {Resource} resource a resource to check
      * @returns {boolean} true if this is an instance of
      * the current resource, false otherwise.
      */

--- a/packages/ilib-tools-common/src/ResourceArray.js
+++ b/packages/ilib-tools-common/src/ResourceArray.js
@@ -101,7 +101,6 @@ class ResourceArray extends Resource {
     /**
      * Set the array of source strings for this resource.
      *
-     * @override
      * @param {Array.<String>} arr the array of strings to set
      * as the source array
      */
@@ -379,7 +378,7 @@ class ResourceArray extends Resource {
      * resource.
      *
      * @override
-     * @param {Resource} a resource to check
+     * @param {Resource} resource a resource to check
      * @returns {boolean} true if this is an instance of
      * the current resource, false otherwise.
      */

--- a/packages/ilib-tools-common/src/ResourceConvert.js
+++ b/packages/ilib-tools-common/src/ResourceConvert.js
@@ -1,0 +1,202 @@
+/*
+ * ResourceConvert.js - functions to convert between resource types
+ *
+ * Copyright © 2024-2025 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ResourceString from "./ResourceString.js";
+import ResourcePlural from "./ResourcePlural.js";
+import { IntlMessageFormat } from "intl-messageformat";
+
+function getPluralCategories(plurals) {
+    if (!plurals) return "";
+    return Object.keys(plurals).map(category => {
+        return `${category} {${plurals[category]}}`;
+    }).join(" ");
+}
+
+/**
+ * Enum for the type of node in an AST, as defined by the IntlMessageFormat `declare enum TYPE`.
+ * Source: formatjs/icu-messageformat-parser/types.d.ts: 6
+ *
+ * @private
+ * @readonly
+ * @enum {number}
+ */
+
+const NodeType = {
+    'literal': 0,
+    'argument': 1,
+    'number': 2,
+    'date': 3,
+    'time': 4,
+    'select': 5,
+    'plural': 6,
+    'pound': 7,
+    'tag': 8,
+};
+
+/**
+ * Reconstruct the string that this node in an AST represents.
+ *
+ * @private
+ * @param {Node} node the node to reconstruct
+ * @returns {string} the reconstructed string
+ */
+function reconstructString(node) {
+    if (Array.isArray(node)) {
+        return node.map(reconstructString).join('');
+    }
+
+    switch (node.type) {
+        case NodeType.literal:
+            return node.value;
+        case NodeType.argument:
+            return `{${node.value}}`;
+        case NodeType.number:
+            return `{${node.value}, number}`;
+        case NodeType.date:
+            return `{${node.value}, date}`;
+        case NodeType.time:
+            return `{${node.value}, time}`;
+        case NodeType.select: {
+            const options = Object.entries(node.options).
+                map(entry => `${entry[0]} {${reconstructString(entry[1].value)}}`).join(' ');
+
+            return `{${node.value}, select, ${options}}`;
+        }
+        case NodeType.plural: {
+            const options = Object.entries(node.options).
+                map(entry => `${entry[0]} {${reconstructString(entry[1].value)}}`).join(' ');
+
+            return `{${node.value}, plural, ${options}}`;
+        }
+        case NodeType.tag:
+            const children = reconstructString(node.children);
+
+            return `<${node.value}>${children}</${node.value}>`;
+        default:
+            throw new Error(`Unsupported AST node type: ${node.type}`);
+    }
+}
+
+/**
+ * Convert a plural resource to an ICU-style plural string resource.
+ * This allows for shoe-horning plurals into systems that do not
+ * support plurals, or at least don't offer a way to import them
+ * properly. All other fields are copied from the plural resource
+ * parameter into the returned resource string unchanged.
+ * The complement function is convertICUToPluralRes() which does
+ * the opposite.
+ *
+ * @param {ResourcePlural} resource the resource to convert into an
+ * ICU-style plural resource string
+ * @returns {ResourceString|undefined} the plural resource converted into a
+ * string resource, or undefined if the resource is not a plural resource
+ */
+export function convertPluralResToICU(resource) {
+    if (resource.getType() === "plural") {
+        var targetPlurals = resource.getTarget();
+        return new ResourceString({
+            key: resource.getKey(),
+            sourceLocale: resource.getSourceLocale(),
+            source: `{count, plural, ${getPluralCategories(resource.getSource())}}`,
+            targetLocale: resource.getTargetLocale(),
+            target: targetPlurals ? `{count, plural, ${getPluralCategories(targetPlurals)}}` : undefined,
+            project: resource.getProject(),
+            pathName: resource.getPath(),
+            datatype: resource.getDataType(),
+            flavor: resource.getFlavor(),
+            comment: resource.getComment(),
+            state: resource.getState()
+        });
+    }
+    return undefined;
+};
+
+/**
+ * Convert a an ICU-style plural string resource into plural resource.
+ * This allows for shoe-horning plurals into systems that do not
+ * support plurals, or at least don't offer a way to export them
+ * properly. All other fields are copied from the string resource
+ * parameter into the returned resource plural unchanged.
+ * The complement function is convertPluralResToICU() which does
+ * the opposite.
+ *
+ * @param {ResourceString} resource the ICU-style plural resource string
+ * to convert into a plural resource
+ * @returns {ResourcePlural|undefined} the resource string converted into a
+ * plural resource, or undefined if the resource is not a string resource
+ */
+export function convertICUToPluralRes(resource) {
+    if (resource.getType() === "string") {
+        try {
+            let i, opts;
+            let imf = new IntlMessageFormat(resource.getSource(), resource.getSourceLocale());
+            let ast = imf.getAst();
+            let sources = {};
+            let foundPlural = false;
+            for (i = 0; i < ast.length; i++) {
+                if (ast[i].type === NodeType.plural) {
+                    foundPlural = true;
+                    opts = ast[i].options;
+                    if (opts) {
+                        Object.keys(opts).forEach(category => {
+                            sources[category] = reconstructString(opts[category].value);
+                        });
+                    }
+                }
+            }
+
+            if (!foundPlural) {
+                // this is a regular non-plural string, so don't convert anything
+                return undefined;
+            }
+            const targetString = resource.getTarget();
+            let targets;
+            if (targetString) {
+                imf = new IntlMessageFormat(resource.getTarget(), resource.getTargetLocale());
+                ast = imf.getAst();
+                targets = {};
+                for (i = 0; i < ast.length; i++) {
+                    opts = ast[i].options;
+                    if (opts) {
+                        Object.keys(opts).forEach(category => {
+                            targets[category] = reconstructString(opts[category].value);
+                        });
+                    }
+                }
+            }
+            return new ResourcePlural({
+                key: resource.getKey(),
+                sourceLocale: resource.getSourceLocale(),
+                source: sources,
+                targetLocale: resource.getTargetLocale(),
+                target: targets,
+                project: resource.getProject(),
+                pathName: resource.getPath(),
+                datatype: resource.getDataType(),
+                flavor: resource.getFlavor(),
+                comment: resource.getComment(),
+                state: resource.getState()
+            });
+        } catch (e) {
+            console.log(e);
+        }
+    }
+    return undefined;
+};
+

--- a/packages/ilib-tools-common/src/ResourceConvert.js
+++ b/packages/ilib-tools-common/src/ResourceConvert.js
@@ -117,17 +117,17 @@ const NodeType = {
 };
 
 /**
- * Reconstruct the string that this node in an AST represents.
+ * Serialize the AST to the string that this node represents.
  * Formatjs does not publish a function that does this, so we
- * have to reconstruct it ourselves.
+ * have to reconstruct/serialize the tree ourselves.
  *
  * @private
  * @param {Node | Node[]} node the node to reconstruct
  * @returns {string} the reconstructed string
  */
-function reconstructString(node) {
+function serializeToIcuMessage(node) {
     if (Array.isArray(node)) {
-        return node.map(reconstructString).join('');
+        return node.map(serializeToIcuMessage).join('');
     }
 
     switch (node.type) {
@@ -145,18 +145,18 @@ function reconstructString(node) {
             return `{${node.value}, time}`;
         case NodeType.select: {
             const options = Object.entries(node.options).
-                map(entry => `${entry[0]} {${reconstructString(entry[1].value)}}`).join(' ');
+                map(entry => `${entry[0]} {${serializeToIcuMessage(entry[1].value)}}`).join(' ');
 
             return `{${node.value}, select, ${options}}`;
         }
         case NodeType.plural: {
             const options = Object.entries(node.options).
-                map(entry => `${entry[0]} {${reconstructString(entry[1].value)}}`).join(' ');
+                map(entry => `${entry[0]} {${serializeToIcuMessage(entry[1].value)}}`).join(' ');
 
             return `{${node.value}, plural, ${options}}`;
         }
         case NodeType.tag:
-            const children = reconstructString(node.children);
+            const children = serializeToIcuMessage(node.children);
 
             return `<${node.value}>${children}</${node.value}>`;
         default:
@@ -426,7 +426,7 @@ function convertASTToPluralChoices(ast, pivot = undefined, categories = []) {
     } else {
         // leaf node, so add it to the choices directly using the multi-key syntax
         const category = categories.join(',');
-        choices[category] = reconstructString(ast);
+        choices[category] = serializeToIcuMessage(ast);
     }
 
     return choices;

--- a/packages/ilib-tools-common/src/ResourcePlural.js
+++ b/packages/ilib-tools-common/src/ResourcePlural.js
@@ -197,13 +197,16 @@ class ResourcePlural extends Resource {
 
     /**
      * Return an array of names of source categories of plurals
-     * that are used in this resource.
+     * that are used in this resource, either in the source or
+     * target.
      *
      * @returns {Array.<string>} an array of source categories
      */
     getCategories() {
-        return (this.target && Object.keys(this.target)) ||
-            (this.source && Object.keys(this.source));
+        const categories = (this.target ? Object.keys(this.target) : []).concat(
+            this.source ? Object.keys(this.source) : []);
+        const set = new Set(categories);
+        return set.size > 0 ? Array.from(set) : [];
     }
 
     /**

--- a/packages/ilib-tools-common/src/ResourcePlural.js
+++ b/packages/ilib-tools-common/src/ResourcePlural.js
@@ -30,6 +30,13 @@ const logger = log4js.getLogger("tools-common.ResourcePlural");
  */
 class ResourcePlural extends Resource {
     /**
+     * The names of the pivot variables for the plural or plurals in this resource.
+     * @property {Array.<String>}
+     * @private
+     */
+    pivots = [];
+
+    /**
      * Construct a new instance of a plural resource.
      *
      * Hashes of strings are used in Android apps to specify translations
@@ -79,6 +86,10 @@ class ResourcePlural extends Resource {
                 for (let p in target) {
                     this.target[p] = target[p];
                 }
+            }
+
+            if (props.pivots) {
+                this.pivots = props.pivots;
             }
         }
 
@@ -191,7 +202,8 @@ class ResourcePlural extends Resource {
      * @returns {Array.<string>} an array of source categories
      */
     getCategories() {
-        return this.source && Object.keys(this.source);
+        return (this.target && Object.keys(this.target)) ||
+            (this.source && Object.keys(this.source));
     }
 
     /**
@@ -383,6 +395,12 @@ class ResourcePlural extends Resource {
         return Object.keys(this.source).every(prop => {
             return cleanString(this.source[prop]) === cleanString(resource.source[prop]);
         });
+    }
+
+    /**
+     */
+    getPivots() {
+        return this.pivots;
     }
 }
 

--- a/packages/ilib-tools-common/src/index.js
+++ b/packages/ilib-tools-common/src/index.js
@@ -27,6 +27,8 @@ import TranslationUnit from './TranslationUnit.js';
 import TranslationVariant from './TranslationVariant.js';
 import Location from './Location.js';
 import walk from './DirectoryWalk.js';
+import {convertPluralResToICU, convertICUToPluralRes} from './ResourceConvert.js';
+
 import {
     formatPath,
     parsePath,
@@ -66,5 +68,7 @@ export {
     ignoreTags,
     localizableAttributes,
     Location,
-    walk
+    walk,
+    convertPluralResToICU,
+    convertICUToPluralRes
 };

--- a/packages/ilib-tools-common/test/ResourceConvert.test.js
+++ b/packages/ilib-tools-common/test/ResourceConvert.test.js
@@ -1,0 +1,481 @@
+/*
+ * ResourceConvert.test.js - test the resource conversion functions.
+ *
+ * Copyright © 2024-2025 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ResourcePlural from "../src/ResourcePlural.js";
+import ResourceString from "../src/ResourceString.js";
+import ResourceArray from "../src/ResourceArray.js";
+import { convertPluralResToICU, convertICUToPluralRes } from "../src/ResourceConvert.js";
+
+describe("resource conversion functions", function() {
+    test("convert plural source to string", function() {
+        expect.assertions(2);
+
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                one: "There is {n} string.",
+                other: "There are {n} strings."
+            },
+            targetLocale: "de-DE",
+            target: {
+                one: "Es gibt {n} Zeichenfolge.",
+                other: "Es gibt {n} Zeichenfolgen.",
+            }
+        });
+
+        const string = convertPluralResToICU(plural);
+        const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getSource()).toBe(expected);
+    });
+
+    test("convert plural source to string in a source-only resource", function() {
+        expect.assertions(5);
+
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                one: "There is {n} string.",
+                other: "There are {n} strings."
+            }
+        });
+
+        const string = convertPluralResToICU(plural);
+        const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getSource()).toBe(expected);
+        expect(string.getSourceLocale()).toBe("en-US");
+
+        expect(string.getTarget()).toBeUndefined();
+        expect(string.getTargetLocale()).toBeUndefined();
+    });
+
+    test("convert plural target to string", function() {
+        expect.assertions(2);
+
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                one: "There is {n} string.",
+                other: "There are {n} strings."
+            },
+            targetLocale: "de-DE",
+            target: {
+                one: "Es gibt {n} Zeichenfolge.",
+                other: "Es gibt {n} Zeichenfolgen.",
+            }
+        });
+
+        const string = convertPluralResToICU(plural);
+        const expected = "{count, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getTarget()).toBe(expected);
+    });
+
+    test("convert plural source to string when the target has more plural categories than the source", function() {
+        expect.assertions(2);
+
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                one: "There is {n} item.",
+                other: "There are {n} items."
+            },
+            targetLocale: "pl-PL",
+            target: {
+                one: "Jest {n} pozycja.",
+                few: "Jest {n} pozycje.",
+                other: "Jest {n} pozycji.",
+            }
+        });
+
+        const string = convertPluralResToICU(plural);
+        const expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getSource()).toBe(expected);
+    });
+
+    test("convert plural target to string when the target has more plural categories than the source", function() {
+        expect.assertions(2);
+
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                one: "There is {n} item.",
+                other: "There are {n} items."
+            },
+            targetLocale: "pl-PL",
+            target: {
+                one: "Jest {n} pozycja.",
+                few: "Jest {n} pozycje.",
+                other: "Jest {n} pozycji.",
+            }
+        });
+
+        const string = convertPluralResToICU(plural);
+        const expected = "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getTarget()).toBe(expected);
+    });
+
+    test("convert plural source to string when the target has less plural categories than the source", function() {
+        expect.assertions(2);
+
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                one: "There is {n} item.",
+                other: "There are {n} items."
+            },
+            targetLocale: "ja-JP",
+            target: {
+                other: "{n}1件の商品があります。",
+            }
+        });
+
+        const string = convertPluralResToICU(plural);
+        const expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getSource()).toBe(expected);
+    });
+
+    test("convert plural target to string when the target has less plural categories than the source", function() {
+        expect.assertions(2);
+
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                one: "There is {n} item.",
+                other: "There are {n} items."
+            },
+            targetLocale: "ja-JP",
+            target: {
+                other: "{n}1件の商品があります。",
+            }
+        });
+
+        const string = convertPluralResToICU(plural);
+        const expected = "{count, plural, other {{n}1件の商品があります。}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getTarget()).toBe(expected);
+    });
+
+    test("don't convert array resources to a string", function() {
+        expect.assertions(1);
+
+        const plural = new ResourceArray({
+            sourceLocale: "en-US",
+            sourceArray: [
+                "There is 1 string.",
+                "There are 2 strings."
+            ],
+            targetLocale: "de-DE",
+            targetArray: [
+                "Es gibt 1 Zeichenfolge.",
+                "Es gibt 2 Zeichenfolgen.",
+            ]
+        });
+
+        const string = convertPluralResToICU(plural);
+
+        expect(string).toBeUndefined(); // no conversino
+    });
+
+    test("don't convert string resources to a different string", function() {
+        expect.assertions(1);
+
+        const plural = new ResourceString({
+            sourceLocale: "en-US",
+            source: "There is 1 string.",
+            targetLocale: "de-DE",
+            target: "Es gibt 1 Zeichenfolge."
+        });
+
+        const string = convertPluralResToICU(plural);
+
+        expect(string).toBeUndefined(); // no conversino
+    });
+
+    test("convert string source to plural", function() {
+        expect.assertions(2);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            targetLocale: "de-DE",
+            target: "{count, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
+        });
+
+        const expected = {
+            one: "There is {n} string.",
+            other: "There are {n} strings."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getSourcePlurals()).toStrictEqual(expected);
+    });
+
+    test("convert string source to plural in a source-only resource", function() {
+        expect.assertions(5);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}"
+        });
+
+        const expected = {
+            one: "There is {n} string.",
+            other: "There are {n} strings."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getSourcePlurals()).toStrictEqual(expected);
+        expect(plural.getSourceLocale()).toBe("en-US");
+
+        expect(plural.getTargetPlurals()).toBeUndefined();
+        expect(plural.getTargetLocale()).toBeUndefined();
+    });
+
+    test("convert plural source to string preserves all other fields", function() {
+        expect.assertions(9);
+
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                one: "There is {n} string.",
+                other: "There are {n} strings."
+            },
+            targetLocale: "de-DE",
+            target: {
+                one: "Es gibt {n} Zeichenfolge.",
+                other: "Es gibt {n} Zeichenfolgen.",
+            },
+            key: "asdf",
+            project: "project",
+            pathName: "a/b/c.xliff",
+            datatype: "json",
+            flavor: "chocolate",
+            comment: "no comment",
+            state: "new"
+        });
+
+        const string = convertPluralResToICU(plural);
+        const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getSource()).toBe(expected);
+        expect(string.getKey()).toBe("asdf");
+        expect(string.getProject()).toBe("project");
+        expect(string.getPath()).toBe("a/b/c.xliff");
+        expect(string.getDataType()).toBe("json");
+        expect(string.getFlavor()).toBe("chocolate");
+        expect(string.getComment()).toBe("no comment");
+        expect(string.getState()).toBe("new");
+    });
+
+    test("convert string target to plural", function() {
+        expect.assertions(2);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            targetLocale: "de-DE",
+            target: "{count, plural,  one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
+        });
+
+        const expected = {
+            one: "Es gibt {n} Zeichenfolge.",
+            other: "Es gibt {n} Zeichenfolgen.",
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getTargetPlurals()).toStrictEqual(expected);
+    });
+
+    test("convert string source to plural when the target has more plural categories than the source", function() {
+        expect.assertions(2);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            targetLocale: "pl-PL",
+            target: "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}"
+        });
+
+        const expected = {
+            one: "There is {n} string.",
+            other: "There are {n} strings."
+        };
+
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getSourcePlurals()).toStrictEqual(expected);
+    });
+
+    test("convert string target to plural when the target has more plural categories than the source", function() {
+        expect.assertions(2);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            targetLocale: "pl-PL",
+            target: "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}"
+        });
+
+        const expected = {
+            one: "Jest {n} pozycja.",
+            few: "Jest {n} pozycje.",
+            other: "Jest {n} pozycji.",
+        };
+
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getTargetPlurals()).toStrictEqual(expected);
+    });
+
+    test("convert string source to plural when the target has less plural categories than the source", function() {
+        expect.assertions(2);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            targetLocale: "ja-JP",
+            target: "{count, plural, other {{n}1件の商品があります。}}"
+        });
+
+        const expected = {
+            one: "There is {n} string.",
+            other: "There are {n} strings."
+        };
+
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getSourcePlurals()).toStrictEqual(expected);
+    });
+
+    test("convert string target to plural when the target has less plural categories than the source", function() {
+        expect.assertions(2);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            targetLocale: "ja-JP",
+            target: "{count, plural, other {{n}1件の商品があります。}}"
+        });
+
+        const expected = {
+            other: "{n}1件の商品があります。",
+        };
+
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getTargetPlurals()).toStrictEqual(expected);
+    });
+
+    test("convert string target to plural, preserving all other fields", function() {
+        expect.assertions(9);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            targetLocale: "de-DE",
+            target: "{count, plural,  one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
+            key: "asdf",
+            project: "project",
+            pathName: "a/b/c.xliff",
+            datatype: "json",
+            flavor: "chocolate",
+            comment: "no comment",
+            state: "new"
+        });
+
+        const expected = {
+            one: "Es gibt {n} Zeichenfolge.",
+            other: "Es gibt {n} Zeichenfolgen.",
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getTargetPlurals()).toStrictEqual(expected);
+        expect(string.getKey()).toBe("asdf");
+        expect(string.getProject()).toBe("project");
+        expect(string.getPath()).toBe("a/b/c.xliff");
+        expect(string.getDataType()).toBe("json");
+        expect(string.getFlavor()).toBe("chocolate");
+        expect(string.getComment()).toBe("no comment");
+        expect(string.getState()).toBe("new");
+    });
+
+    test("don't convert non-plural string to plural", function() {
+        expect.assertions(1);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "There is 1 string.",
+            targetLocale: "de-DE",
+            target: "Es gibt 1 Zeichenfolge."
+        });
+
+        const plural = convertICUToPluralRes(string);
+        expect(plural).toBeUndefined();
+    });
+
+    test("don't convert array to plural", function() {
+        expect.assertions(1);
+
+        const array = new ResourceArray({
+            key: "c",
+            sourceLocale: "en-US",
+            sourceArray: [
+                "one",
+                "two",
+                "three"
+            ],
+            targetLocale: "de-DE",
+            targetArray: [
+                "eins",
+                "zwei",
+                "drei"
+            ]
+        });
+
+        const plural = convertICUToPluralRes(array);
+        expect(plural).toBeUndefined();
+    });
+
+    test("don't convert plural to another plural", function() {
+        expect.assertions(1);
+
+        const plural = new ResourcePlural({
+            key: "a",
+            sourceLocale: "en-US",
+            source: {
+                one: "There is {n} string.",
+                other: "There are {n} strings."
+            },
+            targetLocale: "de-DE",
+            target: {
+                one: "Es gibt {n} Zeichenfolge.",
+                other: "Es gibt {n} Zeichenfolgen.",
+            }
+        });
+
+        const plural2 = convertICUToPluralRes(plural);
+        expect(plural2).toBeUndefined();
+    });
+});
+

--- a/packages/ilib-tools-common/test/ResourceConvert.test.js
+++ b/packages/ilib-tools-common/test/ResourceConvert.test.js
@@ -244,7 +244,7 @@ describe("resource conversion functions", function() {
 
     test("convert string source to plural", function() {
         expect.assertions(3);
-debugger;
+
         const string = new ResourceString({
             sourceLocale: "en-US",
             source: "{count, plural, one {There is {count} string.} other {There are {count} strings.}}",

--- a/packages/ilib-tools-common/test/ResourceConvert.test.js
+++ b/packages/ilib-tools-common/test/ResourceConvert.test.js
@@ -36,10 +36,34 @@ describe("resource conversion functions", function() {
             target: {
                 one: "Es gibt {n} Zeichenfolge.",
                 other: "Es gibt {n} Zeichenfolgen.",
+            },
+            pivots: ["n"]
+        });
+
+        const string = convertPluralResToICU(plural);
+        const expected = "{n, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getSource()).toBe(expected);
+    });
+
+    test("convert plural source to string without pivots", function() {
+        expect.assertions(2);
+
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                one: "There is {n} string.",
+                other: "There are {n} strings."
+            },
+            targetLocale: "de-DE",
+            target: {
+                one: "Es gibt {n} Zeichenfolge.",
+                other: "Es gibt {n} Zeichenfolgen.",
             }
         });
 
         const string = convertPluralResToICU(plural);
+        // "count" is the default pivot name
         const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
@@ -53,11 +77,12 @@ describe("resource conversion functions", function() {
             source: {
                 one: "There is {n} string.",
                 other: "There are {n} strings."
-            }
+            },
+            pivots: ["n"]
         });
 
         const string = convertPluralResToICU(plural);
-        const expected = "{count, plural, one {There is {n} string.} other {There are {n} strings.}}";
+        const expected = "{n, plural, one {There is {n} string.} other {There are {n} strings.}}";
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
         expect(string.getSourceLocale()).toBe("en-US");
@@ -79,11 +104,12 @@ describe("resource conversion functions", function() {
             target: {
                 one: "Es gibt {n} Zeichenfolge.",
                 other: "Es gibt {n} Zeichenfolgen.",
-            }
+            },
+            pivots: ["n"]
         });
 
         const string = convertPluralResToICU(plural);
-        const expected = "{count, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}";
+        const expected = "{n, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}";
         expect(string.getType()).toBe("string");
         expect(string.getTarget()).toBe(expected);
     });
@@ -102,11 +128,12 @@ describe("resource conversion functions", function() {
                 one: "Jest {n} pozycja.",
                 few: "Jest {n} pozycje.",
                 other: "Jest {n} pozycji.",
-            }
+            },
+            pivots: ["n"]
         });
 
         const string = convertPluralResToICU(plural);
-        const expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
+        const expected = "{n, plural, one {There is {n} item.} other {There are {n} items.}}";
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
     });
@@ -125,11 +152,12 @@ describe("resource conversion functions", function() {
                 one: "Jest {n} pozycja.",
                 few: "Jest {n} pozycje.",
                 other: "Jest {n} pozycji.",
-            }
+            },
+            pivots: ["n"]
         });
 
         const string = convertPluralResToICU(plural);
-        const expected = "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}";
+        const expected = "{n, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}";
         expect(string.getType()).toBe("string");
         expect(string.getTarget()).toBe(expected);
     });
@@ -146,11 +174,12 @@ describe("resource conversion functions", function() {
             targetLocale: "ja-JP",
             target: {
                 other: "{n}1件の商品があります。",
-            }
+            },
+            pivots: ["n"]
         });
 
         const string = convertPluralResToICU(plural);
-        const expected = "{count, plural, one {There is {n} item.} other {There are {n} items.}}";
+        const expected = "{n, plural, one {There is {n} item.} other {There are {n} items.}}";
         expect(string.getType()).toBe("string");
         expect(string.getSource()).toBe(expected);
     });
@@ -167,11 +196,12 @@ describe("resource conversion functions", function() {
             targetLocale: "ja-JP",
             target: {
                 other: "{n}1件の商品があります。",
-            }
+            },
+            pivots: ["n"]
         });
 
         const string = convertPluralResToICU(plural);
-        const expected = "{count, plural, other {{n}1件の商品があります。}}";
+        const expected = "{n, plural, other {{n}1件の商品があります。}}";
         expect(string.getType()).toBe("string");
         expect(string.getTarget()).toBe(expected);
     });
@@ -213,22 +243,23 @@ describe("resource conversion functions", function() {
     });
 
     test("convert string source to plural", function() {
-        expect.assertions(2);
-
+        expect.assertions(3);
+debugger;
         const string = new ResourceString({
             sourceLocale: "en-US",
-            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            source: "{count, plural, one {There is {count} string.} other {There are {count} strings.}}",
             targetLocale: "de-DE",
-            target: "{count, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
+            target: "{count, plural, one {Es gibt {count} Zeichenfolge.} other {Es gibt {count} Zeichenfolgen.}}",
         });
 
         const expected = {
-            one: "There is {n} string.",
-            other: "There are {n} strings."
+            one: "There is {count} string.",
+            other: "There are {count} strings."
         };
         const plural = convertICUToPluralRes(string);
         expect(plural.getType()).toBe("plural");
-        expect(plural.getSourcePlurals()).toStrictEqual(expected);
+        expect(plural.getSource()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["count"]);
     });
 
     test("convert string source to plural in a source-only resource", function() {
@@ -236,7 +267,7 @@ describe("resource conversion functions", function() {
 
         const string = new ResourceString({
             sourceLocale: "en-US",
-            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}"
+            source: "{n, plural, one {There is {n} string.} other {There are {n} strings.}}"
         });
 
         const expected = {
@@ -245,10 +276,10 @@ describe("resource conversion functions", function() {
         };
         const plural = convertICUToPluralRes(string);
         expect(plural.getType()).toBe("plural");
-        expect(plural.getSourcePlurals()).toStrictEqual(expected);
+        expect(plural.getSource()).toStrictEqual(expected);
         expect(plural.getSourceLocale()).toBe("en-US");
 
-        expect(plural.getTargetPlurals()).toBeUndefined();
+        expect(plural.getTarget()).toBeUndefined();
         expect(plural.getTargetLocale()).toBeUndefined();
     });
 
@@ -293,9 +324,10 @@ describe("resource conversion functions", function() {
 
         const string = new ResourceString({
             sourceLocale: "en-US",
-            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            source: "{n, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "de-DE",
-            target: "{count, plural,  one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
+            target: "{n, plural, one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
+            pivots: ["n"]
         });
 
         const expected = {
@@ -304,17 +336,17 @@ describe("resource conversion functions", function() {
         };
         const plural = convertICUToPluralRes(string);
         expect(plural.getType()).toBe("plural");
-        expect(plural.getTargetPlurals()).toStrictEqual(expected);
+        expect(plural.getTarget()).toStrictEqual(expected);
     });
 
     test("convert string source to plural when the target has more plural categories than the source", function() {
-        expect.assertions(2);
+        expect.assertions(3);
 
         const string = new ResourceString({
             sourceLocale: "en-US",
-            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            source: "{n, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "pl-PL",
-            target: "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}"
+            target: "{n, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}"
         });
 
         const expected = {
@@ -324,7 +356,8 @@ describe("resource conversion functions", function() {
 
         const plural = convertICUToPluralRes(string);
         expect(plural.getType()).toBe("plural");
-        expect(plural.getSourcePlurals()).toStrictEqual(expected);
+        expect(plural.getSource()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["n"]);
     });
 
     test("convert string target to plural when the target has more plural categories than the source", function() {
@@ -332,9 +365,9 @@ describe("resource conversion functions", function() {
 
         const string = new ResourceString({
             sourceLocale: "en-US",
-            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            source: "{n, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "pl-PL",
-            target: "{count, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}"
+            target: "{n, plural, one {Jest {n} pozycja.} few {Jest {n} pozycje.} other {Jest {n} pozycji.}}"
         });
 
         const expected = {
@@ -345,7 +378,7 @@ describe("resource conversion functions", function() {
 
         const plural = convertICUToPluralRes(string);
         expect(plural.getType()).toBe("plural");
-        expect(plural.getTargetPlurals()).toStrictEqual(expected);
+        expect(plural.getTarget()).toStrictEqual(expected);
     });
 
     test("convert string source to plural when the target has less plural categories than the source", function() {
@@ -353,9 +386,9 @@ describe("resource conversion functions", function() {
 
         const string = new ResourceString({
             sourceLocale: "en-US",
-            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            source: "{n, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "ja-JP",
-            target: "{count, plural, other {{n}1件の商品があります。}}"
+            target: "{n, plural, other {{n}1件の商品があります。}}"
         });
 
         const expected = {
@@ -365,7 +398,7 @@ describe("resource conversion functions", function() {
 
         const plural = convertICUToPluralRes(string);
         expect(plural.getType()).toBe("plural");
-        expect(plural.getSourcePlurals()).toStrictEqual(expected);
+        expect(plural.getSource()).toStrictEqual(expected);
     });
 
     test("convert string target to plural when the target has less plural categories than the source", function() {
@@ -373,9 +406,9 @@ describe("resource conversion functions", function() {
 
         const string = new ResourceString({
             sourceLocale: "en-US",
-            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            source: "{n, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "ja-JP",
-            target: "{count, plural, other {{n}1件の商品があります。}}"
+            target: "{n, plural, other {{n}1件の商品があります。}}"
         });
 
         const expected = {
@@ -384,7 +417,7 @@ describe("resource conversion functions", function() {
 
         const plural = convertICUToPluralRes(string);
         expect(plural.getType()).toBe("plural");
-        expect(plural.getTargetPlurals()).toStrictEqual(expected);
+        expect(plural.getTarget()).toStrictEqual(expected);
     });
 
     test("convert string target to plural, preserving all other fields", function() {
@@ -392,9 +425,9 @@ describe("resource conversion functions", function() {
 
         const string = new ResourceString({
             sourceLocale: "en-US",
-            source: "{count, plural, one {There is {n} string.} other {There are {n} strings.}}",
+            source: "{n, plural, one {There is {n} string.} other {There are {n} strings.}}",
             targetLocale: "de-DE",
-            target: "{count, plural,  one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
+            target: "{n, plural,  one {Es gibt {n} Zeichenfolge.} other {Es gibt {n} Zeichenfolgen.}}",
             key: "asdf",
             project: "project",
             pathName: "a/b/c.xliff",
@@ -410,7 +443,7 @@ describe("resource conversion functions", function() {
         };
         const plural = convertICUToPluralRes(string);
         expect(plural.getType()).toBe("plural");
-        expect(plural.getTargetPlurals()).toStrictEqual(expected);
+        expect(plural.getTarget()).toStrictEqual(expected);
         expect(string.getKey()).toBe("asdf");
         expect(string.getProject()).toBe("project");
         expect(string.getPath()).toBe("a/b/c.xliff");
@@ -476,6 +509,227 @@ describe("resource conversion functions", function() {
 
         const plural2 = convertICUToPluralRes(plural);
         expect(plural2).toBeUndefined();
+    });
+
+    test("convert an ICU plural source string with text outside the plural into a plural resource", function() {
+        expect.assertions(3);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "There {count, plural, one {is # item} other {are # items}} in your cart."
+        });
+        const expected = {
+            one: "There is {count} item in your cart.",
+            other: "There are {count} items in your cart."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getSource()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["count"]);
+    });
+
+    test("convert an ICU plural target string with text outside the plural into a plural resource", function() {
+        expect.assertions(3);
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "There {count, plural, one {is # item} other {are # items}} in your cart.",
+            targetLocale: "de-DE",
+            target: "Es gibt {count, plural, one {# Objekt} other {# Objekte}} in Ihrem Warenkorb."
+        });
+        const expected = {
+            one: "Es gibt {count} Objekt in Ihrem Warenkorb.",
+            other: "Es gibt {count} Objekte in Ihrem Warenkorb."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getTarget()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["count"]);
+    });
+
+    test("convert an ICU plural source string with other nodes outside the plural into a plural resource", function() {
+        expect.assertions(2);
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "Hello {username}, total files: {count, number}. There {count, plural, one {is # file} other {are # files}} ready for download.",
+            key: "asdf",
+        });
+        const expected = {
+            one: "Hello {username}, total files: {count, number}. There is {count} file ready for download.",
+            other: "Hello {username}, total files: {count, number}. There are {count} files ready for download."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getSource()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["count"]);
+    });
+
+    test("convert an ICU plural target string with other nodes outside the plural into a plural resource", function() {
+        expect.assertions(2);
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "Hello {username}, total files: {count, number}. There {count, plural, one {is # file} other {are # files}} ready for download.",
+            targetLocale: "de-DE",
+            target: "Hallo {username}, Gesamtdateien: {count, number}. Es gibt {count, plural, one {# Datei} other {# Dateien}} zum Herunterladen.",
+            key: "asdf",
+        });
+        const expected = {
+            one: "Hallo {username}, Gesamtdateien: {count, number}. Es gibt {count} Datei zum Herunterladen.",
+            other: "Hallo {username}, Gesamtdateien: {count, number}. Es gibt {count} Dateien zum Herunterladen."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getTarget()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["count"]);
+    });
+
+    test("convert an ICU plural source string with stuff outside the plural into a plural resource, preserving all other fields", function() {
+        expect.assertions(9);
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "Hello {username}, total files: {count, number}. There {count, plural, one {is # file} other {are # files}} ready for download.",
+            targetLocale: "de-DE",
+            target: "Hallo {username}, Gesamtdateien: {count, number}. Es gibt {count, plural, one {# Datei} other {# Dateien}} zum Herunterladen.",
+            key: "asdf",
+            project: "project",
+            pathName: "a/b/c.xliff",
+            datatype: "json",
+            flavor: "chocolate",
+            comment: "no comment",
+            state: "new"
+        });
+        const expected = {
+            one: "Hello {username}, total files: {count, number}. There is {count} file ready for download.",
+            other: "Hello {username}, total files: {count, number}. There are {count} files ready for download."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getSource()).toStrictEqual(expected);
+        expect(string.getKey()).toBe("asdf");
+        expect(string.getProject()).toBe("project");
+        expect(string.getPath()).toBe("a/b/c.xliff");
+        expect(string.getDataType()).toBe("json");
+        expect(string.getFlavor()).toBe("chocolate");
+        expect(string.getComment()).toBe("no comment");
+        expect(string.getState()).toBe("new");
+    });
+
+    test("convert an ICU plural source string with two plurals and text outside of each into a plural resource", function() {
+        expect.assertions(2);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "Hello {username}, total files: {count, number}. There {filesCount, plural, one {is {filesCount} file} other {are {filesCount} files}} ready for download. You have {notificationCount, plural, one {{notificationCount} notification} other {{notificationCount} notifications}}."
+        });
+        // use a multi-key plural resource
+        const expected = {
+            "one,one": "Hello {username}, total files: {count, number}. There is {filesCount} file ready for download. You have {notificationCount} notification.",
+            "one,other": "Hello {username}, total files: {count, number}. There is {filesCount} file ready for download. You have {notificationCount} notifications.",
+            "other,one": "Hello {username}, total files: {count, number}. There are {filesCount} files ready for download. You have {notificationCount} notification.",
+            "other,other": "Hello {username}, total files: {count, number}. There are {filesCount} files ready for download. You have {notificationCount} notifications."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getSource()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["filesCount", "notificationCount"]);
+    });
+
+    test("convert an ICU plural source string with two plurals and text outside of each with hash replacement parameters into a plural resource", function() {
+        expect.assertions(2);
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "Hello {username}, total files: {count, number}. There {filesCount, plural, one {is # file} other {are # files}} ready for download. You have {notificationCount, plural, one {# notification} other {# notifications}}."
+        });
+        // use a multi-key plural resource, and make sure to convert the # into {variable} so that we can distinguish between the two plural variables
+        const expected = {
+            "one,one": "Hello {username}, total files: {count, number}. There is {filesCount} file ready for download. You have {notificationCount} notification.",
+            "one,other": "Hello {username}, total files: {count, number}. There is {filesCount} file ready for download. You have {notificationCount} notifications.",
+            "other,one": "Hello {username}, total files: {count, number}. There are {filesCount} files ready for download. You have {notificationCount} notification.",
+            "other,other": "Hello {username}, total files: {count, number}. There are {filesCount} files ready for download. You have {notificationCount} notifications."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getSource()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["filesCount", "notificationCount"]);
+    });
+
+    test("convert an ICU plural source string with one plurals nested inside of the other into a plural resource", function() {
+        expect.assertions(2);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "Hello {username}, there {fileCount, plural, one {is # file and {dirCount, plural, one {# directory} other {# directories}}} other {are # files and {dirCount, plural, one {# directory} other {# directories}}}} ready for download."
+        });
+
+        // convert to two serial plurals, and then use a multi-key plural resource
+        const expected = {
+            "one,one": "Hello {username}, there is {fileCount} file and {dirCount} directory ready for download.",
+            "one,other": "Hello {username}, there is {fileCount} file and {dirCount} directories ready for download.",
+            "other,one": "Hello {username}, there are {fileCount} files and {dirCount} directory ready for download.",
+            "other,other": "Hello {username}, there are {fileCount} files and {dirCount} directories ready for download."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getSource()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["fileCount", "dirCount"]);
+    });
+
+    test("Convert a multi-key source-only plural resource to an ICU plural string", function() {
+        expect.assertions(2);
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                "one,one": "There is {fileCount} file and {dirCount} directory.",
+                "one,other": "There is {fileCount} file and {dirCount} directories.",
+                "other,one": "There are {fileCount} files and {dirCount} directory.",
+                "other,other": "There are {fileCount} files and {dirCount} directories."
+            },
+            pivots: ["fileCount", "dirCount"]
+        });
+        const string = convertPluralResToICU(plural);
+        const expected = "{fileCount, plural, one {{dirCount, plural, one {There is {fileCount} file and {dirCount} directory.} other {There is {fileCount} file and {dirCount} directories.}}} other {{dirCount, plural, one {There are {fileCount} files and {dirCount} directory.} other {There are {fileCount} files and {dirCount} directories.}}}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getSource()).toBe(expected);
+    });
+
+    test("Convert a multi-key source-only plural resource to an ICU plural string with missing pivots", function() {
+        expect.assertions(2);
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                "one,one": "There is {fileCount} file and {dirCount} directory.",
+                "one,other": "There is {fileCount} file and {dirCount} directories.",
+                "other,one": "There are {fileCount} files and {dirCount} directory.",
+                "other,other": "There are {fileCount} files and {dirCount} directories."
+            }
+        });
+        const string = convertPluralResToICU(plural);
+        const expected = "{count, plural, one {{count, plural, one {There is {fileCount} file and {dirCount} directory.} other {There is {fileCount} file and {dirCount} directories.}}} other {{count, plural, one {There are {fileCount} files and {dirCount} directory.} other {There are {fileCount} files and {dirCount} directories.}}}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getSource()).toBe(expected);
+    });
+
+    test("Convert a multi-key full plural resource to an ICU plural string", function() {
+        expect.assertions(3);
+
+        const plural = new ResourcePlural({
+            sourceLocale: "en-US",
+            source: {
+                "one,one": "There is {fileCount} file and {dirCount} directory.",
+                "one,other": "There is {fileCount} file and {dirCount} directories.",
+                "other,one": "There are {fileCount} files and {dirCount} directory.",
+                "other,other": "There are {fileCount} files and {dirCount} directories."
+            },
+            targetLocale: "de-DE",
+            target: {
+                "one,one": "Es gibt {fileCount} Datei und {dirCount} Verzeichnis.",
+                "one,other": "Es gibt {fileCount} Datei und {dirCount} Verzeichnisse.",
+                "other,one": "Es gibt {fileCount} Dateien und {dirCount} Verzeichnis.",
+                "other,other": "Es gibt {fileCount} Dateien und {dirCount} Verzeichnisse."
+            },
+            pivots: ["fileCount", "dirCount"]
+        });
+        const string = convertPluralResToICU(plural);
+        let expected = "{fileCount, plural, one {{dirCount, plural, one {There is {fileCount} file and {dirCount} directory.} other {There is {fileCount} file and {dirCount} directories.}}} other {{dirCount, plural, one {There are {fileCount} files and {dirCount} directory.} other {There are {fileCount} files and {dirCount} directories.}}}}";
+        expect(string.getType()).toBe("string");
+        expect(string.getSource()).toBe(expected);
+
+        expected = "{fileCount, plural, one {{dirCount, plural, one {Es gibt {fileCount} Datei und {dirCount} Verzeichnis.} other {Es gibt {fileCount} Datei und {dirCount} Verzeichnisse.}}} other {{dirCount, plural, one {Es gibt {fileCount} Dateien und {dirCount} Verzeichnis.} other {Es gibt {fileCount} Dateien und {dirCount} Verzeichnisse.}}}}";
+        expect(string.getTarget()).toBe(expected);
     });
 });
 

--- a/packages/ilib-tools-common/test/ResourceConvert.test.js
+++ b/packages/ilib-tools-common/test/ResourceConvert.test.js
@@ -528,6 +528,40 @@ describe("resource conversion functions", function() {
         expect(plural.getPivots()).toStrictEqual(["count"]);
     });
 
+    test("convert an ICU plural source string into a plural resource with text before the plural but not after ", function() {
+        expect.assertions(3);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "There {count, plural, one {is # item in your cart.} other {are # items in your cart.}}"
+        });
+        const expected = {
+            one: "There is {count} item in your cart.",
+            other: "There are {count} items in your cart."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getSource()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["count"]);
+    });
+
+    test("convert an ICU plural source string into a plural resource with text after the plural but not before", function() {
+        expect.assertions(3);
+
+        const string = new ResourceString({
+            sourceLocale: "en-US",
+            source: "{count, plural, one {There is # item} other {There are # items}} in your cart."
+        });
+        const expected = {
+            one: "There is {count} item in your cart.",
+            other: "There are {count} items in your cart."
+        };
+        const plural = convertICUToPluralRes(string);
+        expect(plural.getType()).toBe("plural");
+        expect(plural.getSource()).toStrictEqual(expected);
+        expect(plural.getPivots()).toStrictEqual(["count"]);
+    });
+
     test("convert an ICU plural target string with text outside the plural into a plural resource", function() {
         expect.assertions(3);
         const string = new ResourceString({

--- a/packages/ilib-tools-common/test/ResourcePlural.test.js
+++ b/packages/ilib-tools-common/test/ResourcePlural.test.js
@@ -1579,9 +1579,9 @@ describe("testResourcePlural", () => {
                 "one,one": "Jest {countFiles} plik i {countDirs} katalog",
                 "one,few": "Jest {countFiles} plik i {countDirs} katalogi",
                 "one,other": "Jest {countFiles} plik i {countDirs} katalogów",
-                "few,one": "Jest {countFiles} pliki i {countDirs} katalog",
-                "few,few": "Jest {countFiles} pliki i {countDirs} katalogi",
-                "few,other": "Jest {countFiles} pliki i {countDirs} katalogów",
+                "few,one": "Są {countFiles} pliki i {countDirs} katalog",
+                "few,few": "Są {countFiles} pliki i {countDirs} katalogi",
+                "few,other": "Są {countFiles} pliki i {countDirs} katalogów",
                 "other,one": "Jest {countFiles} plików i {countDirs} katalog",
                 "other,few": "Jest {countFiles} plików i {countDirs} katalogi",
                 "other,other": "Jest {countFiles} plików i {countDirs} katalogów"
@@ -1603,9 +1603,9 @@ describe("testResourcePlural", () => {
             "one,one": "Jest {countFiles} plik i {countDirs} katalog",
             "one,few": "Jest {countFiles} plik i {countDirs} katalogi",
             "one,other": "Jest {countFiles} plik i {countDirs} katalogów",
-            "few,one": "Jest {countFiles} pliki i {countDirs} katalog",
-            "few,few": "Jest {countFiles} pliki i {countDirs} katalogi",
-            "few,other": "Jest {countFiles} pliki i {countDirs} katalogów",
+            "few,one": "Są {countFiles} pliki i {countDirs} katalog",
+            "few,few": "Są {countFiles} pliki i {countDirs} katalogi",
+            "few,other": "Są {countFiles} pliki i {countDirs} katalogów",
             "other,one": "Jest {countFiles} plików i {countDirs} katalog",
             "other,few": "Jest {countFiles} plików i {countDirs} katalogi",
             "other,other": "Jest {countFiles} plików i {countDirs} katalogów"
@@ -1767,6 +1767,7 @@ describe("testResourcePlural", () => {
             sourceLocale: "en-US",
             key: "asdf",
             source: {
+                "zero,zero": "There are no files and no directories",
                 "one,one": "There is {countFiles} file and {countDirs} directory",
                 "one,other": "There are {countFiles} files and {countDirs} directories",
                 "other,one": "There is {countFiles} file and {countDirs} directory",
@@ -1777,9 +1778,9 @@ describe("testResourcePlural", () => {
                 "one,one": "Jest {countFiles} plik i {countDirs} katalog",
                 "one,few": "Jest {countFiles} plik i {countDirs} katalogi",
                 "one,other": "Jest {countFiles} plik i {countDirs} katalogów",
-                "few,one": "Jest {countFiles} pliki i {countDirs} katalog",
-                "few,few": "Jest {countFiles} pliki i {countDirs} katalogi",
-                "few,other": "Jest {countFiles} pliki i {countDirs} katalogów",
+                "few,one": "Są {countFiles} pliki i {countDirs} katalog",
+                "few,few": "Są {countFiles} pliki i {countDirs} katalogi",
+                "few,other": "Są {countFiles} pliki i {countDirs} katalogów",
                 "other,one": "Jest {countFiles} plików i {countDirs} katalog",
                 "other,few": "Jest {countFiles} plików i {countDirs} katalogi",
                 "other,other": "Jest {countFiles} plików i {countDirs} katalogów"
@@ -1792,7 +1793,7 @@ describe("testResourcePlural", () => {
 
         expect(rs).toBeTruthy();
 
-        // should give the categories of the target plural
-        expect(rs.getCategories()).toStrictEqual(["one,one", "one,few", "one,other", "few,one", "few,few", "few,other", "other,one", "other,few", "other,other"]);
+        // should give a superset of the source and target categories
+        expect(rs.getCategories().sort()).toStrictEqual(["zero,zero", "one,one", "one,few", "one,other", "few,one", "few,few", "few,other", "other,one", "other,few", "other,other"].sort());
     });
 });

--- a/packages/ilib-tools-common/test/ResourcePlural.test.js
+++ b/packages/ilib-tools-common/test/ResourcePlural.test.js
@@ -1486,4 +1486,313 @@ describe("testResourcePlural", () => {
         expect(rs.isDirty()).toBeTruthy();
     });
 
+    test("ResourcePlural constructor with multi-key plural", () => {
+        expect.assertions(3);
+
+        const rs = new ResourcePlural({
+            project: "foo",
+            context: "blah",
+            sourceLocale: "en-US",
+            key: "asdf",
+            source: {
+                "one,one": "There is {countFiles} file and {countDirs} directory",
+                "one,other": "There are {countFiles} files and {countDirs} directories",
+                "other,one": "There is {countFiles} file and {countDirs} directory",
+                "other,other": "There are {countFiles} files and {countDirs} directories"
+            },
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted",
+            pivots: [ "countFiles", "countDirs" ]
+        });
+
+        expect(rs).toBeTruthy();
+        expect(rs.getSource()).toStrictEqual({
+            "one,one": "There is {countFiles} file and {countDirs} directory",
+            "one,other": "There are {countFiles} files and {countDirs} directories",
+            "other,one": "There is {countFiles} file and {countDirs} directory",
+            "other,other": "There are {countFiles} files and {countDirs} directories"
+        });
+        expect(rs.getPivots()).toStrictEqual([ "countFiles", "countDirs" ]);
+    });
+
+    test("ResourcePlural constructor with multi-key source and target plural and pivots", () => {
+        expect.assertions(4);
+
+        const rs = new ResourcePlural({
+            project: "foo",
+            context: "blah",
+            sourceLocale: "en-US",
+            key: "asdf",
+            source: {
+                "one,one": "There is {countFiles} file and {countDirs} directory",
+                "one,other": "There are {countFiles} files and {countDirs} directories",
+                "other,one": "There is {countFiles} file and {countDirs} directory",
+                "other,other": "There are {countFiles} files and {countDirs} directories"
+            },
+            targetLocale: "de-DE",
+            target: {
+                "one,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+                "one,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse",
+                "other,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+                "other,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse"
+            },
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted",
+            pivots: ["countFiles", "countDirs"]
+        });
+
+        expect(rs).toBeTruthy();
+        expect(rs.getSource()).toStrictEqual({
+            "one,one": "There is {countFiles} file and {countDirs} directory",
+            "one,other": "There are {countFiles} files and {countDirs} directories",
+            "other,one": "There is {countFiles} file and {countDirs} directory",
+            "other,other": "There are {countFiles} files and {countDirs} directories"
+        });
+        expect(rs.getTarget()).toStrictEqual({
+            "one,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+            "one,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse",
+            "other,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+            "other,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse"
+        });
+        expect(rs.getPivots()).toStrictEqual(["countFiles", "countDirs"]);
+    });
+
+    test("ResourcePlural constructor with multi-key source and target plural and pivots in Polish", () => {
+        expect.assertions(4);
+
+        const rs = new ResourcePlural({
+
+            project: "foo",
+            context: "blah",
+            sourceLocale: "pl-PL",
+            key: "asdf",
+            source: {
+                "one,one": "There is {countFiles} file and {countDirs} directory",
+                "one,other": "There are {countFiles} files and {countDirs} directories",
+                "other,one": "There is {countFiles} file and {countDirs} directory",
+                "other,other": "There are {countFiles} files and {countDirs} directories"
+            },
+            targetLocale: "pl-PL",
+            target: {
+                "one,one": "Jest {countFiles} plik i {countDirs} katalog",
+                "one,few": "Jest {countFiles} plik i {countDirs} katalogi",
+                "one,other": "Jest {countFiles} plik i {countDirs} katalogów",
+                "few,one": "Jest {countFiles} pliki i {countDirs} katalog",
+                "few,few": "Jest {countFiles} pliki i {countDirs} katalogi",
+                "few,other": "Jest {countFiles} pliki i {countDirs} katalogów",
+                "other,one": "Jest {countFiles} plików i {countDirs} katalog",
+                "other,few": "Jest {countFiles} plików i {countDirs} katalogi",
+                "other,other": "Jest {countFiles} plików i {countDirs} katalogów"
+            },
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted",
+            pivots: ["countFiles", "countDirs"]
+        });
+
+        expect(rs).toBeTruthy();
+        expect(rs.getSource()).toStrictEqual({
+            "one,one": "There is {countFiles} file and {countDirs} directory",
+            "one,other": "There are {countFiles} files and {countDirs} directories",
+            "other,one": "There is {countFiles} file and {countDirs} directory",
+            "other,other": "There are {countFiles} files and {countDirs} directories"
+        });
+        expect(rs.getTarget()).toStrictEqual({
+            "one,one": "Jest {countFiles} plik i {countDirs} katalog",
+            "one,few": "Jest {countFiles} plik i {countDirs} katalogi",
+            "one,other": "Jest {countFiles} plik i {countDirs} katalogów",
+            "few,one": "Jest {countFiles} pliki i {countDirs} katalog",
+            "few,few": "Jest {countFiles} pliki i {countDirs} katalogi",
+            "few,other": "Jest {countFiles} pliki i {countDirs} katalogów",
+            "other,one": "Jest {countFiles} plików i {countDirs} katalog",
+            "other,few": "Jest {countFiles} plików i {countDirs} katalogi",
+            "other,other": "Jest {countFiles} plików i {countDirs} katalogów"
+        });
+        expect(rs.getPivots()).toStrictEqual(["countFiles", "countDirs"]);
+    });
+
+    test("ResourcePlural copy constructor with multi-key source and target plural and pivots", () => {
+        expect.assertions(4);
+
+        const rs = new ResourcePlural({
+            project: "foo",
+            context: "blah",
+            sourceLocale: "en-US",
+            key: "asdf",
+            source: {
+                "one,one": "There is {countFiles} file and {countDirs} directory",
+                "one,other": "There are {countFiles} files and {countDirs} directories",
+                "other,one": "There is {countFiles} file and {countDirs} directory",
+                "other,other": "There are {countFiles} files and {countDirs} directories"
+            },
+            targetLocale: "de-DE",
+            target: {
+                "one,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+                "one,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse",
+                "other,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+                "other,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse"
+            },
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted",
+            pivots: ["countFiles", "countDirs"]
+        });
+
+        const rs2 = new ResourcePlural(rs);
+
+        expect(rs2).toBeTruthy();
+        expect(rs2.getSource()).toStrictEqual({
+            "one,one": "There is {countFiles} file and {countDirs} directory",
+            "one,other": "There are {countFiles} files and {countDirs} directories",
+            "other,one": "There is {countFiles} file and {countDirs} directory",
+            "other,other": "There are {countFiles} files and {countDirs} directories"
+        });
+        expect(rs2.getTarget()).toStrictEqual({
+            "one,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+            "one,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse",
+            "other,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+            "other,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse"
+        });
+        expect(rs2.getPivots()).toStrictEqual(["countFiles", "countDirs"]);
+    });
+
+    test("ResourcePlural getClone() with multi-key source and target plural and pivots", () => {
+        expect.assertions(4);
+
+        const rs = new ResourcePlural({
+            project: "foo",
+            context: "blah",
+            sourceLocale: "en-US",
+            key: "asdf",
+            source: {
+                "one,one": "There is {countFiles} file and {countDirs} directory",
+                "one,other": "There are {countFiles} files and {countDirs} directories",
+                "other,one": "There is {countFiles} file and {countDirs} directory",
+                "other,other": "There are {countFiles} files and {countDirs} directories"
+            },
+            targetLocale: "de-DE",
+            target: {
+                "one,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+                "one,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse",
+                "other,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+                "other,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse"
+            },
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted",
+            pivots: ["countFiles", "countDirs"]
+        });
+
+        const rs2 = rs.clone();
+
+        expect(rs2).toBeTruthy();
+        expect(rs2.getSource()).toStrictEqual({
+            "one,one": "There is {countFiles} file and {countDirs} directory",
+            "one,other": "There are {countFiles} files and {countDirs} directories",
+            "other,one": "There is {countFiles} file and {countDirs} directory",
+            "other,other": "There are {countFiles} files and {countDirs} directories"
+        });
+        expect(rs2.getTarget()).toStrictEqual({
+            "one,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+            "one,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse",
+            "other,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+            "other,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse"
+        });
+        expect(rs2.getPivots()).toStrictEqual(["countFiles", "countDirs"]);
+    });
+
+    test("ResourcePlural getCategories() with multi-key source plural", () => {
+        expect.assertions(1);
+
+        const rs = new ResourcePlural({
+            project: "foo",
+            context: "blah",
+            sourceLocale: "en-US",
+            key: "asdf",
+            source: {
+                "one,one": "There is {countFiles} file and {countDirs} directory",
+                "one,other": "There are {countFiles} files and {countDirs} directories",
+                "other,one": "There is {countFiles} file and {countDirs} directory",
+                "other,other": "There are {countFiles} files and {countDirs} directories"
+            },
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted",
+            pivots: ["countFiles", "countDirs"]
+        });
+
+        // no target, so this should give the categories of the source plural
+        expect(rs.getCategories()).toStrictEqual(["one,one", "one,other", "other,one", "other,other"]);
+    });
+
+    test("ResourcePlural getCategories() with multi-key source and target plural", () => {
+        expect.assertions(1);
+
+        const rs = new ResourcePlural({
+
+            project: "foo",
+            context: "blah",
+            sourceLocale: "en-US",
+            key: "asdf",
+            source: {
+                "one,one": "There is {countFiles} file and {countDirs} directory",
+                "one,other": "There are {countFiles} files and {countDirs} directories",
+                "other,one": "There is {countFiles} file and {countDirs} directory",
+                "other,other": "There are {countFiles} files and {countDirs} directories"
+            },
+            targetLocale: "de-DE",
+            target: {
+                "one,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+                "one,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse",
+                "other,one": "Es gibt {countFiles} Datei und {countDirs} Verzeichnis",
+                "other,other": "Es gibt {countFiles} Dateien und {countDirs} Verzeichnisse"
+            },
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted",
+            pivots: ["countFiles", "countDirs"]
+        });
+
+        expect(rs.getCategories()).toStrictEqual(["one,one", "one,other", "other,one", "other,other"]);
+    });
+
+    test("ResourcePlural getCategories with multi-key source and target plural with pivots in Polish", () => {
+        expect.assertions(2);
+
+        const rs = new ResourcePlural({
+            project: "foo",
+            context: "blah",
+            sourceLocale: "en-US",
+            key: "asdf",
+            source: {
+                "one,one": "There is {countFiles} file and {countDirs} directory",
+                "one,other": "There are {countFiles} files and {countDirs} directories",
+                "other,one": "There is {countFiles} file and {countDirs} directory",
+                "other,other": "There are {countFiles} files and {countDirs} directories"
+            },
+            targetLocale: "pl-PL",
+            target: {
+                "one,one": "Jest {countFiles} plik i {countDirs} katalog",
+                "one,few": "Jest {countFiles} plik i {countDirs} katalogi",
+                "one,other": "Jest {countFiles} plik i {countDirs} katalogów",
+                "few,one": "Jest {countFiles} pliki i {countDirs} katalog",
+                "few,few": "Jest {countFiles} pliki i {countDirs} katalogi",
+                "few,other": "Jest {countFiles} pliki i {countDirs} katalogów",
+                "other,one": "Jest {countFiles} plików i {countDirs} katalog",
+                "other,few": "Jest {countFiles} plików i {countDirs} katalogi",
+                "other,other": "Jest {countFiles} plików i {countDirs} katalogów"
+            },
+            pathName: "a/b/c.java",
+            comment: "foobar foo",
+            state: "accepted",
+            pivots: ["countFiles", "countDirs"]
+        });
+
+        expect(rs).toBeTruthy();
+
+        // should give the categories of the target plural
+        expect(rs.getCategories()).toStrictEqual(["one,one", "one,few", "one,other", "few,one", "few,few", "few,other", "other,one", "other,few", "other,other"]);
+    });
 });

--- a/packages/loctool/lib/convertResources.js
+++ b/packages/loctool/lib/convertResources.js
@@ -26,9 +26,11 @@ var ResourceFactory = require("./ResourceFactory.js");
  * the loctool internal representation.
  *
  * @param {Resource} resource the resource to convert in tools common representation
- * @returns {Resource} the converted resource in loctool representation
+ * @returns {Resource|undefined} the converted resource in loctool representation,
+ * or undefined if the resource is undefined
  */
 var convertResourceToLoctool = function(resource) {
+    if (!resource) return undefined;
     var type = resource.getType();
     var options = {
         resType: type,
@@ -41,7 +43,8 @@ var convertResourceToLoctool = function(resource) {
         reskey: resource.getKey(),
         state: resource.getState(),
         comment: resource.getComment(),
-        autoKey: resource.autoKey
+        autoKey: resource.autoKey,
+        flavor: resource.getFlavor()
     };
     if (type === "string") {
         options.source = resource.getSource();
@@ -61,9 +64,11 @@ var convertResourceToLoctool = function(resource) {
  * the tools common representation.
  *
  * @param {Resource} resource the resource to convert in loctool representation
- * @returns {Resource} the converted resource in tools common representation
+ * @returns {Resource|undefined} the converted resource in tools common
+ * representation, or undefined if the resource is undefined
  */
 var convertResourceToCommon = function(resource) {
+    if (!resource) return undefined;
     var constructor =
         resource.getType() === "array" ? ToolsCommon.ResourceArray :
         resource.getType() === "plural" ? ToolsCommon.ResourcePlural :
@@ -80,7 +85,8 @@ var convertResourceToCommon = function(resource) {
         comment: resource.getComment(),
         datatype: resource.getDataType(),
         context: resource.getContext(),
-        autoKey: resource.autoKey
+        autoKey: resource.autoKey,
+        flavor: resource.getFlavor()
     });
 };
 

--- a/packages/loctool/package.json
+++ b/packages/loctool/package.json
@@ -72,7 +72,6 @@
         "ilib-po": "workspace:^",
         "ilib-tools-common": "workspace:^",
         "ilib-tree-node": "workspace:^",
-        "intl-messageformat": "^10.5.14",
         "js-stl": "^0.0.6",
         "js-yaml": "^4.1.0",
         "log4js": "^6.9.1",

--- a/packages/loctool/test/ConvertResources.test.js
+++ b/packages/loctool/test/ConvertResources.test.js
@@ -2,7 +2,7 @@
  * ConvertResources.test.js - test the utility functions for converting resources
  * from one representation to another.
  *
- * Copyright © 2024 Box, Inc.
+ * Copyright © 2024-2025 Box, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,22 @@ var ToolsCommon = require("ilib-tools-common");
 var ResourceFactory = require("../lib/ResourceFactory.js");
 
 describe("test conversions", function() {
+    test("Calling the convertResourceToCommon function with no params should return undefined", function() {
+        expect.assertions(1);
+
+        var converted = conv.convertResourceToCommon();
+        expect(converted).toBeUndefined();
+    });
+
+    test("Calling the convertResourceToLoctool function with no params should return undefined", function() {
+        expect.assertions(1);
+
+        var converted = conv.convertResourceToLoctool();
+        expect(converted).toBeUndefined();
+    });
+
     test("test converting string from common to loctool", function() {
-        expect.assertions(14);
+        expect.assertions(15);
 
         var resource = new ToolsCommon.ResourceString({
             project: "foo",
@@ -38,7 +52,8 @@ describe("test conversions", function() {
             target: "baz",
             state: "new",
             comment: "foo bar",
-            autoKey: false
+            autoKey: false,
+            flavor: "ios"
         });
 
         var converted = conv.convertResourceToLoctool(resource);
@@ -57,10 +72,11 @@ describe("test conversions", function() {
         expect(converted.getComment()).toBe("foo bar");
         expect(converted.autoKey).toBe(false);
         expect(converted.getType()).toBe("string");
+        expect(converted.getFlavor()).toBe("ios");
     });
 
     test("test converting a plural from common to loctool", function() {
-        expect.assertions(14);
+        expect.assertions(15);
 
         var resource = new ToolsCommon.ResourcePlural({
             project: "foo",
@@ -80,7 +96,8 @@ describe("test conversions", function() {
             },
             state: "new",
             comment: "foo bar",
-            autoKey: false
+            autoKey: false,
+            flavor: "ios"
         });
 
         var converted = conv.convertResourceToLoctool(resource);
@@ -105,10 +122,11 @@ describe("test conversions", function() {
         expect(converted.getState()).toBe("new");
         expect(converted.getComment()).toBe("foo bar");
         expect(converted.autoKey).toBe(false);
+        expect(converted.getFlavor()).toBe("ios");
     });
 
     test("test converting an array from common to loctool", function() {
-        expect.assertions(14);
+        expect.assertions(15);
 
         var resource = new ToolsCommon.ResourceArray({
             project: "foo",
@@ -122,7 +140,8 @@ describe("test conversions", function() {
             target: ["foobar", "foobaz"],
             state: "new",
             comment: "foo bar",
-            autoKey: false
+            autoKey: false,
+            flavor: "ios"
         });
 
         var converted = conv.convertResourceToLoctool(resource);
@@ -141,10 +160,11 @@ describe("test conversions", function() {
         expect(converted.getState()).toBe("new");
         expect(converted.getComment()).toBe("foo bar");
         expect(converted.autoKey).toBe(false);
+        expect(converted.getFlavor()).toBe("ios");
     });
 
     test("test converting a string resource from loctool to common", function() {
-        expect.assertions(14);
+        expect.assertions(15);
 
         var resource = ResourceFactory({
             resType: "string",
@@ -159,7 +179,8 @@ describe("test conversions", function() {
             target: "baz",
             state: "new",
             comment: "foo bar",
-            autoKey: false
+            autoKey: false,
+            flavor: "ios"
         });
 
         var converted = conv.convertResourceToCommon(resource);
@@ -178,10 +199,11 @@ describe("test conversions", function() {
         expect(converted.getComment()).toBe("foo bar");
         expect(converted.autoKey).toBe(false);
         expect(converted.getType()).toBe("string");
+        expect(converted.getFlavor()).toBe("ios");
     });
 
     test("test converting a plural resource from loctool to common", function() {
-        expect.assertions(14);
+        expect.assertions(15);
 
         var resource = ResourceFactory({
             resType: "plural",
@@ -202,7 +224,8 @@ describe("test conversions", function() {
             },
             state: "new",
             comment: "foo bar",
-            autoKey: false
+            autoKey: false,
+            flavor: "ios"
         });
 
         var converted = conv.convertResourceToCommon(resource);
@@ -227,10 +250,11 @@ describe("test conversions", function() {
         expect(converted.getState()).toBe("new");
         expect(converted.getComment()).toBe("foo bar");
         expect(converted.autoKey).toBe(false);
+        expect(converted.getFlavor()).toBe("ios");
     });
 
     test("test converting an array resource from loctool to common", function() {
-        expect.assertions(14);
+        expect.assertions(15);
 
         var resource = ResourceFactory({
             resType: "array",
@@ -245,7 +269,8 @@ describe("test conversions", function() {
             targetArray: ["foobar", "foobaz"],
             state: "new",
             comment: "foo bar",
-            autoKey: false
+            autoKey: false,
+            flavor: "ios"
         });
 
         var converted = conv.convertResourceToCommon(resource);
@@ -264,5 +289,6 @@ describe("test conversions", function() {
         expect(converted.getState()).toBe("new");
         expect(converted.getComment()).toBe("foo bar");
         expect(converted.autoKey).toBe(false);
+        expect(converted.getFlavor()).toBe("ios");
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2219,9 +2219,6 @@ importers:
       ilib-tree-node:
         specifier: workspace:^
         version: link:../ilib-tree-node
-      intl-messageformat:
-        specifier: ^10.5.14
-        version: 10.7.3
       js-stl:
         specifier: ^0.0.6
         version: 0.0.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1895,6 +1895,9 @@ importers:
       ilib-xliff:
         specifier: workspace:^
         version: link:../ilib-xliff
+      intl-messageformat:
+        specifier: ^10.7.11
+        version: 10.7.11
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
@@ -3063,17 +3066,29 @@ packages:
   '@formatjs/ecma402-abstract@2.2.3':
     resolution: {integrity: sha512-aElGmleuReGnk2wtYOzYFmNWYoiWWmf1pPPCYg0oiIQSJj0mjc4eUfzUXaSOJ4S8WzI/cLqnCTWjqz904FT2OQ==}
 
+  '@formatjs/ecma402-abstract@2.3.2':
+    resolution: {integrity: sha512-6sE5nyvDloULiyOMbOTJEEgWL32w+VHkZQs8S02Lnn8Y/O5aQhjOEXwWzvR7SsBE/exxlSpY2EsWZgqHbtLatg==}
+
   '@formatjs/fast-memoize@2.2.2':
     resolution: {integrity: sha512-mzxZcS0g1pOzwZTslJOBTmLzDXseMLLvnh25ymRilCm8QLMObsQ7x/rj9GNrH0iUhZMlFisVOD6J1n6WQqpKPQ==}
 
   '@formatjs/fast-memoize@2.2.3':
     resolution: {integrity: sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==}
 
+  '@formatjs/fast-memoize@2.2.6':
+    resolution: {integrity: sha512-luIXeE2LJbQnnzotY1f2U2m7xuQNj2DA8Vq4ce1BY9ebRZaoPB1+8eZ6nXpLzsxuW5spQxr7LdCg+CApZwkqkw==}
+
   '@formatjs/icu-messageformat-parser@2.9.1':
     resolution: {integrity: sha512-7AYk4tjnLi5wBkxst2w7qFj38JLMJoqzj7BhdEl7oTlsWMlqwgx4p9oMmmvpXWTSDGNwOKBRc1SfwMh5MOHeNg==}
 
   '@formatjs/icu-messageformat-parser@2.9.3':
     resolution: {integrity: sha512-9L99QsH14XjOCIp4TmbT8wxuffJxGK8uLNO1zNhLtcZaVXvv626N0s4A2qgRCKG3dfYWx9psvGlFmvyVBa6u/w==}
+
+  '@formatjs/icu-messageformat-parser@2.9.8':
+    resolution: {integrity: sha512-hZlLNI3+Lev8IAXuwehLoN7QTKqbx3XXwFW1jh0AdIA9XJdzn9Uzr+2LLBspPm/PX0+NLIfykj/8IKxQqHUcUQ==}
+
+  '@formatjs/icu-skeleton-parser@1.8.12':
+    resolution: {integrity: sha512-QRAY2jC1BomFQHYDMcZtClqHR55EEnB96V7Xbk/UiBodsuFc5kujybzt87+qj1KqmJozFhk6n4KiT1HKwAkcfg==}
 
   '@formatjs/icu-skeleton-parser@1.8.5':
     resolution: {integrity: sha512-zRZ/e3B5qY2+JCLs7puTzWS1Jb+t/K+8Jur/gEZpA2EjWeLDE17nsx8thyo9P48Mno7UmafnPupV2NCJXX17Dg==}
@@ -3086,6 +3101,9 @@ packages:
 
   '@formatjs/intl-listformat@7.7.1':
     resolution: {integrity: sha512-bjBxWaUhYAbJFUlFSMWZGn3r2mglXwk+BLyGRu8dY8Q83ZPsqmmVQzjQKENHE3lV6eoQGHT2oZHxUaVndJlk6Q==}
+
+  '@formatjs/intl-localematcher@0.5.10':
+    resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
 
   '@formatjs/intl-localematcher@0.5.6':
     resolution: {integrity: sha512-roz1+Ba5e23AHX6KUAWmLEyTRZegM5YDuxuvkHCyK3RJddf/UXB2f+s7pOMm9ktfPGla0g+mQXOn5vsuYirnaA==}
@@ -4331,6 +4349,9 @@ packages:
     resolution: {integrity: sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  decimal.js@10.4.3:
+    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
+
   dedent@1.5.3:
     resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
     peerDependencies:
@@ -5508,6 +5529,9 @@ packages:
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
+
+  intl-messageformat@10.7.11:
+    resolution: {integrity: sha512-IB2N1tmI24k2EFH3PWjU7ivJsnWyLwOWOva0jnXFa29WzB6fb0JZ5EMQGu+XN5lDtjHYFo0/UooP67zBwUg7rQ==}
 
   intl-messageformat@10.7.3:
     resolution: {integrity: sha512-AAo/3oyh7ROfPhDuh7DxTTydh97OC+lv7h1Eq5LuHWuLsUMKOhtzTYuyXlUReuwZ9vANDHo4CS1bGRrn7TZRtg==}
@@ -9563,11 +9587,22 @@ snapshots:
       '@formatjs/intl-localematcher': 0.5.7
       tslib: 2.8.0
 
+  '@formatjs/ecma402-abstract@2.3.2':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.6
+      '@formatjs/intl-localematcher': 0.5.10
+      decimal.js: 10.4.3
+      tslib: 2.8.0
+
   '@formatjs/fast-memoize@2.2.2':
     dependencies:
       tslib: 2.8.0
 
   '@formatjs/fast-memoize@2.2.3':
+    dependencies:
+      tslib: 2.8.0
+
+  '@formatjs/fast-memoize@2.2.6':
     dependencies:
       tslib: 2.8.0
 
@@ -9581,6 +9616,17 @@ snapshots:
     dependencies:
       '@formatjs/ecma402-abstract': 2.2.3
       '@formatjs/icu-skeleton-parser': 1.8.7
+      tslib: 2.8.0
+
+  '@formatjs/icu-messageformat-parser@2.9.8':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.2
+      '@formatjs/icu-skeleton-parser': 1.8.12
+      tslib: 2.8.0
+
+  '@formatjs/icu-skeleton-parser@1.8.12':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.2
       tslib: 2.8.0
 
   '@formatjs/icu-skeleton-parser@1.8.5':
@@ -9603,6 +9649,10 @@ snapshots:
     dependencies:
       '@formatjs/ecma402-abstract': 2.2.1
       '@formatjs/intl-localematcher': 0.5.6
+      tslib: 2.8.0
+
+  '@formatjs/intl-localematcher@0.5.10':
+    dependencies:
       tslib: 2.8.0
 
   '@formatjs/intl-localematcher@0.5.6':
@@ -11112,6 +11162,8 @@ snapshots:
 
   decamelize@6.0.0: {}
 
+  decimal.js@10.4.3: {}
+
   dedent@1.5.3: {}
 
   deep-assign@2.0.0:
@@ -12538,6 +12590,13 @@ snapshots:
   interpret@2.2.0: {}
 
   interpret@3.1.1: {}
+
+  intl-messageformat@10.7.11:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.2
+      '@formatjs/fast-memoize': 2.2.6
+      '@formatjs/icu-messageformat-parser': 2.9.8
+      tslib: 2.8.0
 
   intl-messageformat@10.7.3:
     dependencies:


### PR DESCRIPTION
- moved out of the loctool and into the library so that our conversion tool can also call it.
- also will be available for the plugins should they need it
- updated loctool to call the library instead of using its own implementation directly. (ie. the loctool behaviour hasn't changed.)