### PR TITLE
Allow ilib-istring to be loaded by require()

### DIFF
--- a/packages/ilib-istring/package.json
+++ b/packages/ilib-istring/package.json
@@ -99,7 +99,6 @@
         "nodeunit": "^0.11.3",
         "npm-run-all": "^4.1.5",
         "open-cli": "^7.2.0",
-        "regenerator-runtime": "^0.14.0",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4"
     },
@@ -108,6 +107,7 @@
         "ilib-common": "workspace:^",
         "ilib-env": "workspace:^",
         "ilib-locale": "workspace:^",
-        "ilib-localedata": "workspace:^"
+        "ilib-localedata": "workspace:^",
+        "regenerator-runtime": "^0.14.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -626,6 +626,9 @@ importers:
       ilib-localedata:
         specifier: workspace:^
         version: link:../ilib-localedata
+      regenerator-runtime:
+        specifier: ^0.14.0
+        version: 0.14.1
     devDependencies:
       '@babel/core':
         specifier: ^7.23.3
@@ -711,9 +714,6 @@ importers:
       open-cli:
         specifier: ^7.2.0
         version: 7.2.0
-      regenerator-runtime:
-        specifier: ^0.14.0
-        version: 0.14.1
       webpack:
         specifier: ^5.89.0
         version: 5.95.0(webpack-cli@5.1.4)
@@ -1203,7 +1203,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
+        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -11957,15 +11957,6 @@ snapshots:
       hooker: 0.2.3
       jshint: 2.13.6
 
-  grunt-contrib-nodeunit@4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      nodeunit-x: 0.15.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
-    transitivePeerDependencies:
-      - flow-remove-types
-      - supports-color
-      - ts-node
-      - typescript
-
   grunt-contrib-nodeunit@4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
       nodeunit-x: 0.15.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
@@ -14205,16 +14196,6 @@ snapshots:
       socks: 1.1.9
     optional: true
 
-  nodeunit-x@0.15.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      ejs: 3.1.10
-      tap: 15.2.3(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
-    transitivePeerDependencies:
-      - flow-remove-types
-      - supports-color
-      - ts-node
-      - typescript
-
   nodeunit-x@0.15.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
       ejs: 3.1.10
@@ -15728,36 +15709,6 @@ snapshots:
       typescript: 3.9.10
       write-file-atomic: 2.4.3
       yapool: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  tap@15.2.3(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      chokidar: 3.6.0
-      coveralls: 3.1.1
-      findit: 2.0.0
-      foreground-child: 2.0.0
-      fs-exists-cached: 1.0.0
-      glob: 7.2.3
-      isexe: 2.0.0
-      istanbul-lib-processinfo: 2.0.3
-      jackspeak: 1.4.2
-      libtap: 1.4.1
-      minipass: 3.3.6
-      mkdirp: 1.0.4
-      nyc: 15.1.0
-      opener: 1.5.2
-      rimraf: 3.0.2
-      signal-exit: 3.0.7
-      source-map-support: 0.5.21
-      tap-mocha-reporter: 5.0.4
-      tap-parser: 11.0.2
-      tap-yaml: 1.0.2
-      tcompare: 5.0.7
-      which: 2.0.2
-    optionalDependencies:
-      ts-node: 8.10.2(typescript@3.9.10)
-      typescript: 3.9.10
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
- when you load the transpiled code, it requires regenerator-runtime which was not in the regular dependencies