### PR TITLE
loctool: Support reading and writing .pot files

### DIFF
--- a/.changeset/real-months-arrive.md
+++ b/.changeset/real-months-arrive.md
@@ -1,0 +1,9 @@
+---
+"loctool": minor
+---
+
+- added the ability to read and write .pot files as
+  intermediate file format and as translation file
+  format.
+- Also, .po file can still be read and written if necessary
+  as the format for po and pot files are the same.

--- a/packages/loctool/lib/GenerateMode.js
+++ b/packages/loctool/lib/GenerateMode.js
@@ -24,8 +24,9 @@ var ilib = require("ilib");
 
 var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
-var getIntermediateFile = require("./IntermediateFileFactory.js");
+var iff = require("./IntermediateFileFactory.js");
 
+var getIntermediateFile = iff.getIntermediateFile;
 var logger = log4js.getLogger("loctool.lib.GenerateMode");
 
 /**

--- a/packages/loctool/lib/IntermediateFileFactory.js
+++ b/packages/loctool/lib/IntermediateFileFactory.js
@@ -60,4 +60,16 @@ var getIntermediateFile = function(options) {
     }
 };
 
-module.exports = getIntermediateFile;
+var intFormatToFileExtensionMap = {
+    "xliff": "xliff",
+    "po": "pot"
+};
+
+var getIntermediateFileExtension = function(type) {
+    return intFormatToFileExtensionMap[type] || type;
+};
+
+module.exports = {
+    getIntermediateFile,
+    getIntermediateFileExtension
+};

--- a/packages/loctool/lib/LocalRepository.js
+++ b/packages/loctool/lib/LocalRepository.js
@@ -24,10 +24,11 @@ var ilib = require("ilib");
 
 var utils = require("./utils.js");
 var TranslationSet = require("./TranslationSet.js");
-var getIntermediateFile = require("./IntermediateFileFactory.js");
+var iff = require("./IntermediateFileFactory.js");
 
 var logger = log4js.getLogger("loctool.lib.LocalRepository");
 
+var getIntermediateFile = iff.getIntermediateFile;
 
 /**
  * @class A class that represents the local story of a set of
@@ -69,7 +70,7 @@ var LocalRepository = function (options) {
 // - Script the 4 letter ISO 15924 code for the script with only the first letter capitalized. This part is optional.
 // - REGION is the 2 letter upper-case ISO 3166 code for the region, OR the 3-digit UN.49 region code. This part is also optional.
 var xliffFileFilter = /(^|[^a-z])([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A-Z][A-Z]|[0-9][0-9][0-9]))?\.xliff$/;
-var poFileFilter = /(^|[^a-z])([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A-Z][A-Z]|[0-9][0-9][0-9]))?\.po$/;
+var poFileFilter = /(^|[^a-z])([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A-Z][A-Z]|[0-9][0-9][0-9]))?\.pot?$/;
 
 // recognize the UN.49 3-digit region codes
 var numericRegionCode = /^[0-9][0-9][0-9]$/;

--- a/packages/loctool/lib/Project.js
+++ b/packages/loctool/lib/Project.js
@@ -34,7 +34,10 @@ var utils = require("./utils.js");
 var conversions = require("./ResourceConvert.js");
 var pluralCategories = require("../db/pluralCategories.json");
 var log4js = require("log4js");
-var getIntermediateFile = require("./IntermediateFileFactory.js");
+var iff = require("./IntermediateFileFactory.js");
+
+var getIntermediateFile = iff.getIntermediateFile;
+var getIntermediateFileExtension = iff.getIntermediateFileExtension;
 
 var logger = log4js.getLogger("loctool.lib.Project");
 
@@ -724,7 +727,7 @@ Project.prototype.close = function(cb) {
         var dir = this.xliffsOut;
         var base = this.options.id;
         var fileFormat = this.settings.intermediateFormat || "xliff";
-        var extractedPath = path.join(dir, base + "-extracted." + fileFormat);
+        var extractedPath = path.join(dir, base + "-extracted." + getIntermediateFileExtension(fileFormat));
         var extracted = new TranslationSet(this.sourceLocale);
 
         // make sure the output dir exists before we attempt to write anything there!
@@ -792,7 +795,7 @@ Project.prototype.close = function(cb) {
             for (var i = 0; i < newLocales.length; i++) {
                 var locale = newLocales[i];
                 if (!this.isSourceLocale(locale) && !PseudoFactory.isPseudoLocale(locale, this)) {
-                    var newPath = path.join(dir, base + "-new-" + locale + "." + fileFormat);
+                    var newPath = path.join(dir, base + "-new-" + locale + "." + getIntermediateFileExtension(fileFormat));
                     var resources = newres.getAll().filter(function(res) {
                         return res.getTargetLocale() === locale && !res.dnt &&
                             (res.source || res.sourceArray || res.sourceStrings);

--- a/packages/loctool/test/IntermediateFile.test.js
+++ b/packages/loctool/test/IntermediateFile.test.js
@@ -19,9 +19,12 @@
 var fs = require("fs");
 var ToolsCommon = require("ilib-tools-common");
 
-var getIntermediateFile = require("../lib/IntermediateFileFactory.js");
+var iff = require("../lib/IntermediateFileFactory.js");
 var TranslationSet = require("../lib/TranslationSet.js");
 var ResourceFactory = require("../lib/ResourceFactory.js");
+
+var getIntermediateFile = iff.getIntermediateFile;
+var getIntermediateFileExtension = iff.getIntermediateFileExtension;
 
 describe("intermediate file", function() {
     afterEach(function() {
@@ -31,6 +34,23 @@ describe("intermediate file", function() {
         if (fs.existsSync("test/testfiles/foo.po")) {
             fs.unlinkSync("test/testfiles/foo.po");
         }
+    });
+
+    test("get the right intermediate file extension for xliff format files", function() {
+        expect.assertions(1);
+
+        expect(getIntermediateFileExtension("xliff")).toBe("xliff");
+    });
+
+    test("get the right intermediate file extension for po format files", function() {
+        expect.assertions(1);
+        expect(getIntermediateFileExtension("po")).toBe("pot");
+    });
+
+    test("get the right intermediate file extension for unknown format files", function() {
+        expect.assertions(1);
+        // should return the format name if it is not recognized
+        expect(getIntermediateFileExtension("foo")).toBe("foo");
     });
 
     test("test writing an intermediate file in xliff format", function() {

--- a/packages/loctool/test/Project.test.js
+++ b/packages/loctool/test/Project.test.js
@@ -35,10 +35,12 @@ describe("project", function() {
             "./test/testfiles/loctest-new-es-US.xliff",
             "./test/testfiles/loctest-new-ja-JP.xliff",
             "./test/testfiles/loctest-new-zh-Hans-CN.xliff",
+            "./test/testfiles/de-DE/md/test1.md",
+            "./test/testfiles/en-GB/md/test1.md",
             "./test/testfiles/es-US/md/test1.md",
             "./test/testfiles/ja-JP/md/test1.md",
             "./test/testfiles/zh-Hans-CN/md/test1.md",
-            "./test/testfiles/loctest-new-en-GB.po",
+            "./test/testfiles/loctest-new-en-GB.pot",
             "./test/testfiles/loctest-new-en-GB.xliff",
             "./test/testfiles/project2/loctest-extracted.xliff",
             "./test/testfiles/project2/loctest-new-es-US.xliff",
@@ -46,6 +48,16 @@ describe("project", function() {
             "./test/testfiles/project2/loctest-new-ru-RU.xliff",
             "./test/testfiles/project2/loctest-new-en-GB.xliff",
             "./test/testfiles/project2/loctest.xliff",
+            "./test/testfiles/project2/res/values-en/arrays.xml",
+            "./test/testfiles/project2/res/values-en/plurals.xml",
+            "./test/testfiles/project2/res/values-es/arrays.xml",
+            "./test/testfiles/project2/res/values-es/plurals.xml",
+            "./test/testfiles/project2/res/values-ja/arrays.xml",
+            "./test/testfiles/project2/res/values-ja/plurals.xml",
+            "./test/testfiles/project2/res/values-ps-rDO/arrays.xml",
+            "./test/testfiles/project2/res/values-ps-rDO/plurals.xml",
+            "./test/testfiles/project2/res/values-ru/arrays.xml",
+            "./test/testfiles/project2/res/values-ru/plurals.xml",
             "./test/testfiles/translations/loctest.xliff",
             "./test/testfiles/project3/loctest-extracted.xliff",
             "./test/testfiles/project3/loctest-new-es-US.xliff",
@@ -54,14 +66,14 @@ describe("project", function() {
             "./test/testfiles/project3/es-US.mock",
             "./test/testfiles/project3/ja-JP.mock",
             "./test/testfiles/project3/zh-Hans-CN.mock",
-            "./test/testfiles/loctest-extracted.po",
-            "./test/testfiles/loctest-new-es-US.po",
-            "./test/testfiles/loctest-new-ja-JP.po",
-            "./test/testfiles/loctest-new-zh-Hans-CN.po",
-            "./test/testfiles/project3/loctest-extracted.po",
-            "./test/testfiles/project3/loctest-new-es-US.po",
-            "./test/testfiles/project3/loctest-new-ja-JP.po",
-            "./test/testfiles/project3/loctest-new-zh-Hans-CN.po"
+            "./test/testfiles/loctest-extracted.pot",
+            "./test/testfiles/loctest-new-es-US.pot",
+            "./test/testfiles/loctest-new-ja-JP.pot",
+            "./test/testfiles/loctest-new-zh-Hans-CN.pot",
+            "./test/testfiles/project3/loctest-extracted.pot",
+            "./test/testfiles/project3/loctest-new-es-US.pot",
+            "./test/testfiles/project3/loctest-new-ja-JP.pot",
+            "./test/testfiles/project3/loctest-new-zh-Hans-CN.pot"
         ].forEach(rmrf);
     });
 
@@ -96,7 +108,7 @@ describe("project", function() {
         expect.assertions(2);
 
         // set up first
-        expect(!fs.existsSync("./test/testfiles/loctest-extracted.po")).toBeTruthy();
+        expect(!fs.existsSync("./test/testfiles/loctest-extracted.pot")).toBeTruthy();
         var project = ProjectFactory('./test/testfiles', {
             'locales': ['ja-JP'],
             'intermediateFormat': 'po'
@@ -108,7 +120,7 @@ describe("project", function() {
                 project.write(function() {
                     project.save(function() {
                         project.close(function() {
-                            expect(fs.existsSync("./test/testfiles/loctest-extracted.po")).toBeTruthy();
+                            expect(fs.existsSync("./test/testfiles/loctest-extracted.pot")).toBeTruthy();
                         });
                     });
                 });
@@ -145,7 +157,7 @@ describe("project", function() {
         // set up first
         expect(!fs.existsSync("./test/testfiles/loctest-new-es-US.po")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/loctest-new-ja-JP.po")).toBeTruthy();
-        expect(!fs.existsSync("./test/testfiles/loctest-new-zh-Hans-CN.po")).toBeTruthy();
+        expect(!fs.existsSync("./test/testfiles/loctest-new-zh-Hans-CN.pot")).toBeTruthy();
         var project = ProjectFactory('./test/testfiles', {
             'locales': ['ja-JP'],
             'intermediateFormat': 'po'
@@ -157,9 +169,9 @@ describe("project", function() {
                 project.write(function() {
                     project.save(function() {
                         project.close(function() {
-                            expect(fs.existsSync("./test/testfiles/loctest-new-es-US.po")).toBeTruthy();
-                            expect(fs.existsSync("./test/testfiles/loctest-new-ja-JP.po")).toBeTruthy();
-                            expect(fs.existsSync("./test/testfiles/loctest-new-zh-Hans-CN.po")).toBeTruthy();
+                            expect(fs.existsSync("./test/testfiles/loctest-new-es-US.pot")).toBeTruthy();
+                            expect(fs.existsSync("./test/testfiles/loctest-new-ja-JP.pot")).toBeTruthy();
+                            expect(fs.existsSync("./test/testfiles/loctest-new-zh-Hans-CN.pot")).toBeTruthy();
                         });
                     });
                 });
@@ -465,9 +477,9 @@ describe("project", function() {
     test("Project localize a mock file with plurals using no plural conversions, right content, using po files", function() {
         expect.assertions(18);
         // set up first
-        expect(!fs.existsSync("./test/testfiles/project3/loctest-new-es-US.po")).toBeTruthy();
-        expect(!fs.existsSync("./test/testfiles/project3/loctest-new-ja-JP.po")).toBeTruthy();
-        expect(!fs.existsSync("./test/testfiles/project3/loctest-new-zh-Hans-CN.po")).toBeTruthy();
+        expect(!fs.existsSync("./test/testfiles/project3/loctest-new-es-US.pot")).toBeTruthy();
+        expect(!fs.existsSync("./test/testfiles/project3/loctest-new-ja-JP.pot")).toBeTruthy();
+        expect(!fs.existsSync("./test/testfiles/project3/loctest-new-zh-Hans-CN.pot")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/project3/es-US.mock")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/project3/ja-JP.mock")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/project3/zh-Hans-CN.mock")).toBeTruthy();
@@ -483,13 +495,13 @@ describe("project", function() {
                 project.write(function() {
                     project.save(function() {
                         project.close(function() {
-                            var filename = "./test/testfiles/project3/loctest-new-es-US.po";
+                            var filename = "./test/testfiles/project3/loctest-new-es-US.pot";
                             expect(fs.existsSync(filename)).toBeTruthy();
                             var actual = fs.readFileSync(filename, "utf8");
                             var expected =
                                 'msgid ""\n' +
                                 'msgstr ""\n' +
-                                '"#-#-#-#-#  test/testfiles/project3/loctest-new-es-US.po  #-#-#-#-#\\n"\n' +
+                                '"#-#-#-#-#  test/testfiles/project3/loctest-new-es-US.pot  #-#-#-#-#\\n"\n' +
                                 '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
                                 '"Content-Transfer-Encoding: 8bit\\n"\n' +
                                 '"Generated-By: loctool\\n"\n' +
@@ -507,13 +519,13 @@ describe("project", function() {
                                 'msgstr[1] ""\n';
                             expect(actual).toBe(expected);
 
-                            filename = "./test/testfiles/project3/loctest-new-ja-JP.po";
+                            filename = "./test/testfiles/project3/loctest-new-ja-JP.pot";
                             expect(fs.existsSync(filename)).toBeTruthy();
                             var actual = fs.readFileSync(filename, "utf8");
                             var expected =
                                 'msgid ""\n' +
                                 'msgstr ""\n' +
-                                '"#-#-#-#-#  test/testfiles/project3/loctest-new-ja-JP.po  #-#-#-#-#\\n"\n' +
+                                '"#-#-#-#-#  test/testfiles/project3/loctest-new-ja-JP.pot  #-#-#-#-#\\n"\n' +
                                 '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
                                 '"Content-Transfer-Encoding: 8bit\\n"\n' +
                                 '"Generated-By: loctool\\n"\n' +
@@ -530,13 +542,13 @@ describe("project", function() {
                                 'msgstr[0] ""\n';
                             expect(actual).toBe(expected);
 
-                            filename = "./test/testfiles/project3/loctest-new-zh-Hans-CN.po";
+                            filename = "./test/testfiles/project3/loctest-new-zh-Hans-CN.pot";
                             expect(fs.existsSync(filename)).toBeTruthy();
                             var actual = fs.readFileSync(filename, "utf8");
                             var expected =
                                 'msgid ""\n' +
                                 'msgstr ""\n' +
-                                '"#-#-#-#-#  test/testfiles/project3/loctest-new-zh-Hans-CN.po  #-#-#-#-#\\n"\n' +
+                                '"#-#-#-#-#  test/testfiles/project3/loctest-new-zh-Hans-CN.pot  #-#-#-#-#\\n"\n' +
                                 '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
                                 '"Content-Transfer-Encoding: 8bit\\n"\n' +
                                 '"Generated-By: loctool\\n"\n' +


### PR DESCRIPTION
- can now write out intermediate files with the .pot extension
- can read in translated files with the .pot extension
- cleaned up more unit test artifacts that shouldn't be there after running the tests