### PR TITLE
loctool: Fix a bug where recursive search of xliff dirs did not work right

### DIFF
--- a/.changeset/tiny-hairs-love.md
+++ b/.changeset/tiny-hairs-love.md
@@ -1,0 +1,12 @@
+---
+"loctool": patch
+---
+
+Fix a bug reading multi-level xliff dirs
+
+- if the xliff dir named in the config or the command
+  line contained multiple directory levels (as opposed to
+  everything being in the root of that xliff dir), the code
+  miscalculated the relative path those those resource
+  files and therefore could not load them. This is now
+  fixed.

--- a/packages/ilib-tools-common/src/DirectoryWalk.js
+++ b/packages/ilib-tools-common/src/DirectoryWalk.js
@@ -28,7 +28,8 @@ function hasItems(list) {
 /**
  * Does the actual directory walk and return a list of files and directories.
  *
- * @param {String} dirPath The path to the directory to walk
+ * @param {String} root The path to the directory to walk
+ * @param {String} dirPath The path to the directory to walk, relative to root
  * @param {Array<String>} includes A list of micromatch patterns to include in the walk.
  *   If a pattern matches both an exclude and an include, the
  *   include will override the exclude.
@@ -144,6 +145,7 @@ function walkDir(root, dirPath, includes, excludes) {
  * property that contains an array of the children of that directory. The path property is the full path
  * to the file or directory relative to the root directory.
  *
+ * @param {String} root The path to the directory to walk
  * @param {Array<String>} includes A list of micromatch patterns to include in the walk.
  * If a pattern matches both an exclude and an include, the
  * include will override the exclude.

--- a/packages/loctool/lib/LocalRepository.js
+++ b/packages/loctool/lib/LocalRepository.js
@@ -80,20 +80,33 @@ var poFileFilter = /(^|[^a-z])([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A-
 var numericRegionCode = /^[0-9][0-9][0-9]$/;
 
 /**
- * Take a file list returned from the walk() function and return a list of
- * full path names for each file. We do not need the names of the directories.
+ * Flatten a file list tree returned from the walk() function into a single array.
  * @private
- * @param {Array.<File>} fileList the list of files to filter
+ * @param {Array.<File>} fileList a tree of files to flatten
+ * @returns {Array.<String>} the list of files flattened into a single array
+ */
+function getAllFiles(fileList) {
+    return fileList.flatMap(function(file) {
+        if (file.type === "directory") {
+            return getAllFiles(file.children);
+        }
+        return file.path;
+    });
+}
+
+/**
+ * Take a file list tree returned from the walk() function and return a list of
+ * full path names for each file. The tree is flattened into a single array and
+ * the directory is prepended to each file name.
+ * @private
+ * @param {Array.<File>} fileList a tree of files to filter
  * @param {String} directory the directory to prepend to each file name
- * @returns {Array.<String>} the list of full path names
+ * @returns {Array.<String>} the list of full path names flattened into a single array
+ * and with the directory prepended to each file name
  */
 function getFullPaths(fileList, directory) {
-    return fileList.flatMap(function(file) {
-        var pathName = path.join(directory, file.path);
-        if (file.type === "directory") {
-            return getFullPaths(file.children, pathName);
-        }
-        return pathName;
+    return getAllFiles(fileList).map(function(relativePath) {
+        return path.join(directory, relativePath);
     });
 }
 

--- a/packages/loctool/test/LocalRepository.test.js
+++ b/packages/loctool/test/LocalRepository.test.js
@@ -205,6 +205,69 @@ describe("localrepository", function() {
         })
     });
 
+    test("LocalRepository test constructor with an xliffs dir that is deep", function() {
+        expect.assertions(31);
+
+        // should recursively read all xliffs from the deep directory structure
+        var repo = new LocalRepository({
+            sourceLocale: "en-US",
+            xliffsDir: "./test/testfiles/xliffsdeep"
+        });
+
+        expect(repo).toBeTruthy();
+
+        repo.init(function(){
+            repo.getBy({
+                reskey: "foobar"
+            }, function(err, resources) {
+                expect(resources).toBeTruthy();
+                expect(resources.length).toBe(4);
+
+                resources.sort(function(left, right) {
+                    var leftLocale = left.getTargetLocale();
+                    var rightLocale = right.getTargetLocale();
+                    return leftLocale < rightLocale ? -1 : (leftLocale > rightLocale ? 1 : 0);
+                });
+
+                expect(resources[0].getKey()).toBe("foobar");
+                expect(resources[0].getProject()).toBe("webapp");
+                expect(resources[0].getSourceLocale()).toBe("en-US");
+                expect(resources[0].getSource()).toBe("Asdf asdf");
+                expect(resources[0].getTargetLocale()).toBe("de-DE");
+                expect(resources[0].getTarget()).toBe("foobarfoo");
+                expect(resources[0].getComment()).toBe("foobar is where it's at!");
+
+                expect(resources[1].getKey()).toBe("foobar");
+                expect(resources[1].getProject()).toBe("webapp");
+                expect(resources[1].getSourceLocale()).toBe("en-US");
+                expect(resources[1].getSource()).toBe("Asdf asdf");
+                expect(resources[1].getTargetLocale()).toBe("es-419");
+                expect(resources[1].getTarget()).toBe("El asdf");
+                expect(resources[1].getComment()).toBe("foobar is where it's at!");
+
+                expect(resources[2].getKey()).toBe("foobar");
+                expect(resources[2].getProject()).toBe("webapp");
+                expect(resources[2].getSourceLocale()).toBe("en-US");
+                expect(resources[2].getSource()).toBe("Asdf asdf");
+                expect(resources[2].getTargetLocale()).toBe("fr-FR");
+                expect(resources[2].getTarget()).toBe("La asdf");
+                expect(resources[2].getComment()).toBe("foobar is where it's at!");
+
+                expect(resources[3].getKey()).toBe("foobar");
+                expect(resources[3].getProject()).toBe("webapp");
+                expect(resources[3].getSourceLocale()).toBe("en-US");
+                expect(resources[3].getSource()).toBe("Asdf asdf");
+                expect(resources[3].getTargetLocale()).toBe("nl-NL");
+                expect(resources[3].getTarget()).toBe("Het asdf");
+                expect(resources[3].getComment()).toBe("foobar is where it's at!");
+
+
+                repo.close(function() {
+                });
+            });
+        })
+    });
+
     test("LocalRepositoryGetEmpty", function() {
         expect.assertions(2);
 

--- a/packages/loctool/test/Project.test.js
+++ b/packages/loctool/test/Project.test.js
@@ -134,7 +134,10 @@ describe("project", function() {
         expect(!fs.existsSync("./test/testfiles/loctest-new-es-US.xliff")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/loctest-new-ja-JP.xliff")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/loctest-new-zh-Hans-CN.xliff")).toBeTruthy();
-        var project = ProjectFactory('./test/testfiles', {'locales': ['ja-JP']});
+        var project = ProjectFactory('./test/testfiles', {
+            'xliffsDir': "xliffs",
+            'locales': ['ja-JP']
+        });
         project.addPath("md/test1.md");
         project.init(function() {
             project.extract(function() {
@@ -159,6 +162,7 @@ describe("project", function() {
         expect(!fs.existsSync("./test/testfiles/loctest-new-ja-JP.po")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/loctest-new-zh-Hans-CN.pot")).toBeTruthy();
         var project = ProjectFactory('./test/testfiles', {
+            'xliffsDir': "xliffs",
             'locales': ['ja-JP'],
             'intermediateFormat': 'po'
         });

--- a/packages/loctool/test/testfiles/xliffsdeep/de/project-german.xliff
+++ b/packages/loctool/test/testfiles/xliffsdeep/de/project-german.xliff
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">
+    <body>
+      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
+        <source>Asdf asdf</source>
+        <target>foobarfoo</target>
+        <note annotates="source">foobar is where it&apos;s at!</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/packages/loctool/test/testfiles/xliffsdeep/es/419/strings.xliff
+++ b/packages/loctool/test/testfiles/xliffsdeep/es/419/strings.xliff
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="foo/bar/j.java" source-language="en-US" target-language="es-419" product-name="webapp">
+    <body>
+      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
+        <source>Asdf asdf</source>
+        <target>El asdf</target>
+        <note annotates="source">foobar is where it&apos;s at!</note>
+      </trans-unit>
+      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">
+        <source>baby baby</source>
+        <target>bebe bebe</target>
+        <note annotates="source">come &amp; enjoy it with us</note>
+      </trans-unit>
+      <trans-unit id="3" resname="ohhuzzah" restype="string" datatype="plaintext">
+        <source x-key="oh">baby baby</source>
+        <target>Los bebes</target>
+        <note annotates="source">come &amp; enjoy it with them</note>
+      </trans-unit>
+      <trans-unit id="4">
+        <source x-key="asdfasdf">Hello</source>
+        <target>Buenas dias</target>
+        <note annotates="source">come &amp; enjoy it with them</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/packages/loctool/test/testfiles/xliffsdeep/fr/project-french.xliff
+++ b/packages/loctool/test/testfiles/xliffsdeep/fr/project-french.xliff
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">
+    <body>
+      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
+        <source>Asdf asdf</source>
+        <target>La asdf</target>
+        <note annotates="source">foobar is where it&apos;s at!</note>
+      </trans-unit>
+      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">
+        <source>baby baby</source>
+        <target>bebe bebe</target>
+        <note annotates="source">come &amp; enjoy it with us</note>
+      </trans-unit>
+      <trans-unit id="3" resname="ohhuzzah" restype="string" datatype="plaintext">
+        <source x-key="oh">baby baby</source>
+        <target>oh bebe bebe</target>
+        <note annotates="source">come &amp; enjoy it with them</note>
+      </trans-unit>
+      <trans-unit id="4">
+        <source x-key="asdfasdf">Hello</source>
+        <target>Hallo</target>
+        <note annotates="source">come &amp; enjoy it with them</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/packages/loctool/test/testfiles/xliffsdeep/nl/NL/strings.xliff
+++ b/packages/loctool/test/testfiles/xliffsdeep/nl/NL/strings.xliff
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="foo/bar/j.java" source-language="en-US" target-language="nl-NL" product-name="webapp">
+    <body>
+      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">
+        <source>Asdf asdf</source>
+        <target>Het asdf</target>
+        <note annotates="source">foobar is where it&apos;s at!</note>
+      </trans-unit>
+      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">
+        <source>baby baby</source>
+        <target>bebe bebe</target>
+        <note annotates="source">come &amp; enjoy it with us</note>
+      </trans-unit>
+      <trans-unit id="3" resname="ohhuzzah" restype="string" datatype="plaintext">
+        <source x-key="oh">baby baby</source>
+        <target>de bebe bebe</target>
+        <note annotates="source">come &amp; enjoy it with them</note>
+      </trans-unit>
+      <trans-unit id="4">
+        <source x-key="asdfasdf">Hello</source>
+        <target>Hallo mijnheer</target>
+        <note annotates="source">come &amp; enjoy it with them</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
- quick fix
- added a unit tests for a deep xliff dir and verified that the bug was fixed
- updated ilib-tools-common to add missing jsdoc descriptions for some parameters. Does not need need a new version. This can go out with the next tools update.