### PR TITLE
Don't load translations from xliffsDir during a convert

### DIFF
--- a/.changeset/lovely-peaches-obey.md
+++ b/.changeset/lovely-peaches-obey.md
@@ -1,0 +1,15 @@
+---
+"loctool": patch
+---
+
+- Fixed a problem where the project that convert needs to
+  instantiate in order to run tried to find and load every
+  single xliff file in the current directory recursively as
+  translations file in the xliffDir. The problem comes in
+  if there are many xliff files in the current directory
+  or there are many directories underneath the current
+  working directory. That caused start-up to take a really
+  long time.
+  - The fix is to for the convert action to turn off
+    loading translation files when instantiating a project.
+    They are not needed anyways.

--- a/packages/loctool/lib/convert.js
+++ b/packages/loctool/lib/convert.js
@@ -27,6 +27,9 @@ var TMX = require("./TMX.js");
 var logger = log4js.getLogger("loctool.lib.convert");
 
 function convert(settings) {
+    // don't need to load all the translations because we are just converting
+    // some files and need a project to do it
+    settings.loadTranslations = false;
     var project = ProjectFactory(".", settings);
     if (!project) project = new CustomProject({
         name: settings.id,


### PR DESCRIPTION
- we need a Project instance in order to do a convert
- when the project instance was created, it attempts to load translations from the xliffsDir. However, now that translation loading from the xliffsDir happens recursively, the new Project attempted to load every xliff file in the xliffsDir directory (default: ".") which was waaaaay too big
- now we pass in a flag to the project constructor that turns off loading of translations for a project that is only needed for convert.