### PR TITLE
Fix packaging of the new escaper classes

### DIFF
--- a/packages/ilib-tools-common/Gruntfile.js
+++ b/packages/ilib-tools-common/Gruntfile.js
@@ -31,7 +31,7 @@ module.exports = function(grunt) {
                 banner: '/*! <%= pkg.name %> <%= grunt.template.today("yyyy-mm-dd") %> */\n'
             },
             build: {
-                src: 'src/*.js',
+                src: 'src/**/*.js',
                 dest: 'lib/'
             }
         },
@@ -54,7 +54,7 @@ module.exports = function(grunt) {
                 files: [{
                     expand: true,
                     cwd: 'src',
-                    src: ['*.js'],
+                    src: ['**/*.js'],
                     dest: 'lib/',
                     ext: '.js'
                 }]

--- a/packages/ilib-tools-common/src/index.js
+++ b/packages/ilib-tools-common/src/index.js
@@ -28,6 +28,7 @@ import TranslationVariant from './TranslationVariant.js';
 import Location from './Location.js';
 import walk from './DirectoryWalk.js';
 import {convertPluralResToICU, convertICUToPluralRes} from './ResourceConvert.js';
+import escaperFactory from './EscaperFactory.js';
 
 import {
     formatPath,
@@ -70,5 +71,6 @@ export {
     Location,
     walk,
     convertPluralResToICU,
-    convertICUToPluralRes
+    convertICUToPluralRes,
+    escaperFactory
 };


### PR DESCRIPTION
Found these problems while attempting to use the new escapers from the regex plugin:

- escapers weren't processed properly with babel so there were no transpiled js files for them
- they weren't included as part of the package
- escaperFactory wasn't exported from the index.js so you couldn't use it

Fortunately, the escapers changes in ilib-tools-common are not published yet, so we can just merge this and it will go out with the next publish.