### PR TITLE
ilib-loctool-regex: Add escaping support

### DIFF
--- a/.changeset/mighty-foxes-breathe.md
+++ b/.changeset/mighty-foxes-breathe.md
@@ -1,0 +1,9 @@
+---
+"ilib-loctool-regex": minor
+---
+
+- Added the ability to specify the escaping style for
+  strings that are extracted by the regular expressions
+  - supports all escaping styles published by
+    ilib-tools-common
+  - supports extra "none" style to turn off unescaping

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-files=$(git diff --cached --name-only --diff-filter=ACM main)
+files=$(git diff --cached --name-only --diff-filter=ACM main | grep '\.js$')
 
 # Check for debugger statements in JavaScript files
-lines=$(grep -n 'debugger' $files)
+lines=$(grep -n 'debugger;' $files)
 if [ "$lines" != "" ]
 then
   echo "Debugger statement found in:"

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -48,6 +48,14 @@ used within the `regex` property:
       how to use path name templates.
     - sourceLocale - the locale of the source strings. This is the
       locale in which the strings are written in the source files.
+    - escapeStyle - the style of unescaping when collecting strings
+      for translations and the type of escaping to use when writing the
+      localized strings to the resource file. The valid styles incude
+      "csharp" and "js" (the default), as well as many others. The
+      full list of styles available is given in the documentation
+      for the [ilib-tools-common library](https://github.com/iLib-js/ilib-mono/blob/main/packages/ilib-tools-common/docs/ilibToolsCommon.md#escaperFactory).
+      In addition to the styles listed there, the escapeStyle setting
+      can also be set to "none" to disable escaping altogether.
     - expressions - an array of objects that document the regular
       expressions to use to extract strings from the source file
       and some additional information. The strings

--- a/packages/ilib-loctool-regex/README.md
+++ b/packages/ilib-loctool-regex/README.md
@@ -48,14 +48,6 @@ used within the `regex` property:
       how to use path name templates.
     - sourceLocale - the locale of the source strings. This is the
       locale in which the strings are written in the source files.
-    - escapeStyle - the style of unescaping when collecting strings
-      for translations and the type of escaping to use when writing the
-      localized strings to the resource file. The valid styles incude
-      "csharp" and "js" (the default), as well as many others. The
-      full list of styles available is given in the documentation
-      for the [ilib-tools-common library](https://github.com/iLib-js/ilib-mono/blob/main/packages/ilib-tools-common/docs/ilibToolsCommon.md#escaperFactory).
-      In addition to the styles listed there, the escapeStyle setting
-      can also be set to "none" to disable escaping altogether.
     - expressions - an array of objects that document the regular
       expressions to use to extract strings from the source file
       and some additional information. The strings
@@ -122,6 +114,14 @@ used within the `regex` property:
               quite long, but it is always unique.
             - "truncate" - use the first 32 characters of the source
               string as the key. This fixed-length key is usually unique.
+        - escapeStyle - the style of unescaping to use when the regular expression
+          matches. The valid styles incude
+          "csharp" and "js" (the default), as well as many others. The
+          full list of styles available is given in the documentation
+          for the [ilib-tools-common library](https://github.com/iLib-js/ilib-mono/blob/main/packages/ilib-tools-common/docs/ilibToolsCommon.md#escaperFactory).
+          In addition to the styles listed there, the escapeStyle setting
+          can also be set to "none" to disable escaping altogether for strings
+          that are extracted using this regular expression.
 
 ### Example Configuration
 
@@ -143,29 +143,41 @@ Example configuration for a web project with PHP and JavaScript files:
                     "sourceLocale": "en-US",
                     "expressions": [
                         {
-                            "expression": "translate\\s*(\\s*['\"](?<source>[^'\"]*)['\"]\\s*\\)",
+                            "expression": "translate\\s*(\\s*\"(?<source>[^\"]*)\"\\s*\\)",
                             "flags": "g",
                             "datatype": "php",
                             "resourceType": "string",
-                            "keyStrategy": "source"
+                            "keyStrategy": "source",
+                            "escapeStyle": "php-double"
                         },
                         {
-                            "expression": "translate\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*,\\s*['\"](?<key>[^'\"]*)['\"]\\s*\\)",
+                            "expression": "translate\\s*(\\s*'(?<source>[^']*)'\\s*\\)",
                             "flags": "g",
                             "datatype": "php",
-                            "resourceType": "string"
+                            "resourceType": "string",
+                            "keyStrategy": "source",
+                            "escapeStyle": "php-single"
                         },
                         {
-                            "expression": "translateArray\\s*\\(\\s*\\[\\s*(?<source>['\"][^'\"]*['\"](\\s*,\\s*['\"][^'\"]*['\"])*)\\s*\\]\\s*\\)",
+                            "expression": "translate\\s*\\(\\s*\"(?<source>[^\"]*)\"\\s*,\\s*\"(?<key>[^\"]*)\"\\s*\\)",
                             "flags": "g",
                             "datatype": "php",
-                            "resourceType": "array"
+                            "resourceType": "string",
+                            "escapeStyle": "php-double"
                         },
                         {
-                            "expression": "translatePlural\\s*\\(\\s*['\"](?<source>[^'\"]*)['\"]\\s*,\\s*['\"](?<sourcePlural>[^'\"]*)['\"]",
+                            "expression": "translateArray\\s*\\(\\s*\\[\\s*(?<source>\"[^\"]*\"(\\s*,\\s*\"[^\"]*\")*)\\s*\\]\\s*\\)",
                             "flags": "g",
                             "datatype": "php",
-                            "resourceType": "plural"
+                            "resourceType": "array",
+                            "escapeStyle": "php-double"
+                        },
+                        {
+                            "expression": "translatePlural\\s*\\(\\s*\"(?<source>[^\"]*)\"]\\s*,\\s*\"(?<sourcePlural>[^\"]*)\"",
+                            "flags": "g",
+                            "datatype": "php",
+                            "resourceType": "plural",
+                            "escapeStyle": "php-double"
                         }
                     ]
                 },
@@ -196,15 +208,21 @@ given regular expressions. Explanation of the above regexes:
 that are passed as the first parameter to the `translate` function. It will match
 a string like `translate("string to translate")`. Since the string does not have
 a unique id, one is generated using the `source` strategy. That is, the source
-string itself is re-used as its own unique id.
-1. The second regular expression extracts strings that are passed as the first
+string itself is re-used as its own unique id. Note that this regular expression
+extracts strings with double quotes around them. The `escapeStyle` setting is
+used to specify that the `php-double` style should be used to unescape the string.
+1. The second regular expression is similar to the first, but extracts strings
+that use single quotes instead of double quotes. The `escapeStyle` setting is
+used to specify that the `php-single` style should be used to unescape the string.
+(Unescaping is different between single and double quoted strings in PHP.)
+1. The third regular expression extracts strings that are passed as the first
 parameter to the `translate` function and the second parameter is the
 key of the string. It will match a string like `translate("string to translate", "unique.id")`.
-1. The third regular expression is an example of an array translation. The
+1. The fourth regular expression is an example of an array translation. The
 `source` capturing group will have a value like `"a", "b", "c"` which this plugin
 will transform into an array of 3 strings. This will match a string like
 `translateArray(["a", "b", "c"])`.
-1. The fourth regular expression is an example of a plural translation. The
+1. The fifth regular expression is an example of a plural translation. The
 first parameter to the `translatePlural` function is the singular string and is
 assigned to the `source` capturing group. The second parameter is the plural
 string and is assigned to the `sourcePlural` capturing group. This creates a plural
@@ -232,6 +250,9 @@ from js files does not have its own unique id, one is generated using
 the `hash` strategy. That is, the hash of the source string is calculated
 and prepended with an "r" for "resource" (eg. "r34523234") and that is used
 as the unique id for that string.
+
+Note that the default escape style is `js` which is used when the `escapeStyle`
+setting is not given, which is why it is not specified in the last mapping example.
 
 ### Resource Type Field Mapping
 

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -68,6 +68,7 @@
     "dependencies": {
         "ilib-istring": "workspace:^",
         "ilib-locale": "workspace:^",
+        "ilib-tools-common": "workspace:^",
         "micromatch": "^4.0.8"
     }
 }

--- a/packages/ilib-loctool-regex/test/RegexFile.test.js
+++ b/packages/ilib-loctool-regex/test/RegexFile.test.js
@@ -330,7 +330,7 @@ describe("regex file tests", function() {
 
         var set = rf.getTranslationSet();
         expect(set).toBeTruthy();
-debugger;
+
         var resources = set.getBy({
             reskey: "r523019971"
         });
@@ -905,5 +905,50 @@ debugger;
         expect(() => rf.parse("$t('This is a test');")).toThrow(
             new Error("No expressions found in project.json for ./testfiles/js/t1.js")
         );
+    });
+
+    test("RegexFile gets the right unescaped source string in a javascript file", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: "./testfiles/js/t1.js",
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("$t('foob`\\n\\r\\t\\\\a\\u317Dr\\u{1D11E}');");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        // javascript escaping is the default, so it doesn't need to be
+        // specified in the mapping
+        var r = set.getBySource("foob`\n\r\t\\a\u317Dr\u{1D11E}");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("foob`\n\r\t\\a\u317Dr\u{1D11E}");
+        expect(r.getKey()).toBe("r157823627");
+    });
+
+    test("RegexFile gets the right unescaped source string in a Smarty template file", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: "./testfiles/templates/t1.tmpl",
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("{\'abc \\\"e\\\" \\$\\n\\r\\t\\f\\vT \\u{317D}r\\u{1D11E}\'|f:\'key\'}");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        // smarty escaping doesn't do Unicode characters
+        var r = set.getBySource("abc \"e\" $\n\r\t\f\vT \\u{317D}r\\u{1D11E}");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("abc \"e\" $\n\r\t\f\vT \\u{317D}r\\u{1D11E}");
+        expect(r.getKey()).toBe("key");
     });
 });

--- a/packages/ilib-loctool-regex/test/RegexFile.test.js
+++ b/packages/ilib-loctool-regex/test/RegexFile.test.js
@@ -116,21 +116,21 @@ var p = new CustomProject({
                     },
                     {
                         // example:
-                        // {'Your password was changed. Please log in again.'|f:'login_success_password_changed'}
-                        "expression": "\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*?\\}",
-                        "flags": "g",
-                        "datatype": "template",
-                        "resourceType": "string",
-                        "escapeStyle": "smarty"
-                    },
-                    {
-                        // example:
                         // {'Your password was changed. Please log in again.'|f:'login_success_password_changed'|noescape}
                         "expression": "\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'\\s*\\|\\s*noescape\\s*\\}",
                         "flags": "g",
                         "datatype": "template",
                         "resourceType": "string",
                         "escapeStyle": "none"
+                    },
+                    {
+                        // example:
+                        // {'Your password was changed. Please log in again.'|f:'login_success_password_changed'}
+                        "expression": "\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*?\\}",
+                        "flags": "g",
+                        "datatype": "template",
+                        "resourceType": "string",
+                        "escapeStyle": "smarty"
                     }
                 ]
             }

--- a/packages/ilib-loctool-regex/test/RegexFile.test.js
+++ b/packages/ilib-loctool-regex/test/RegexFile.test.js
@@ -94,11 +94,12 @@ var p = new CustomProject({
                 "resourceFileType": "javascript",
                 "template": "resources/Translation[locale].json",
                 "sourceLocale": "en-US",
+                "escapeStyle": "smarty",
                 "expressions": [
                     {
                         // example:
                         // {* @L10N This comment is on the same line *} {'Your password change is cancelled.'|f:'login_password_change_cancelled'}
-                        "expression": "\\{\\*.*?@L10N\\s*(?<comment>[^*]*)\\*\\}.*\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*?\\}",
+                        "expression": "\\{\\*.*?@L10N\\s*(?<comment>[^*]*?)\\s*\\*\\}.*\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*?\\}",
                         "flags": "g",
                         "datatype": "template",
                         "resourceType": "string"
@@ -107,7 +108,7 @@ var p = new CustomProject({
                         // example:
                         // {* @L10N The message shown to users whose passwords have just been changed *}
                         // {'Your password was changed. Please log in again.'|f:'login_success_password_changed'}
-                        "expression": "\\{\\*.*?@L10N\\s*(?<comment>[^*]*)\\*\\}.*\\n.*\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*?\\}",
+                        "expression": "\\{\\*.*?@L10N\\s*(?<comment>[^*]*?)\\s*\\*\\}.*\\n.*\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*?\\}",
                         "flags": "g",
                         "datatype": "template",
                         "resourceType": "string"
@@ -329,7 +330,7 @@ describe("regex file tests", function() {
 
         var set = rf.getTranslationSet();
         expect(set).toBeTruthy();
-
+debugger;
         var resources = set.getBy({
             reskey: "r523019971"
         });

--- a/packages/ilib-loctool-regex/test/RegexFile.test.js
+++ b/packages/ilib-loctool-regex/test/RegexFile.test.js
@@ -94,7 +94,6 @@ var p = new CustomProject({
                 "resourceFileType": "javascript",
                 "template": "resources/Translation[locale].json",
                 "sourceLocale": "en-US",
-                "escapeStyle": "smarty",
                 "expressions": [
                     {
                         // example:
@@ -102,7 +101,8 @@ var p = new CustomProject({
                         "expression": "\\{\\*.*?@L10N\\s*(?<comment>[^*]*?)\\s*\\*\\}.*\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*?\\}",
                         "flags": "g",
                         "datatype": "template",
-                        "resourceType": "string"
+                        "resourceType": "string",
+                        "escapeStyle": "smarty"
                     },
                     {
                         // example:
@@ -111,7 +111,8 @@ var p = new CustomProject({
                         "expression": "\\{\\*.*?@L10N\\s*(?<comment>[^*]*?)\\s*\\*\\}.*\\n.*\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*?\\}",
                         "flags": "g",
                         "datatype": "template",
-                        "resourceType": "string"
+                        "resourceType": "string",
+                        "escapeStyle": "smarty"
                     },
                     {
                         // example:
@@ -119,7 +120,17 @@ var p = new CustomProject({
                         "expression": "\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'.*?\\}",
                         "flags": "g",
                         "datatype": "template",
-                        "resourceType": "string"
+                        "resourceType": "string",
+                        "escapeStyle": "smarty"
+                    },
+                    {
+                        // example:
+                        // {'Your password was changed. Please log in again.'|f:'login_success_password_changed'|noescape}
+                        "expression": "\\{.*?'(?<source>[^']*)'\\s*\\|\\s*f:\\s*'(?<key>[^']*)'\\s*\\|\\s*noescape\\s*\\}",
+                        "flags": "g",
+                        "datatype": "template",
+                        "resourceType": "string",
+                        "escapeStyle": "none"
                     }
                 ]
             }
@@ -949,6 +960,28 @@ describe("regex file tests", function() {
         var r = set.getBySource("abc \"e\" $\n\r\t\f\vT \\u{317D}r\\u{1D11E}");
         expect(r).toBeTruthy();
         expect(r.getSource()).toBe("abc \"e\" $\n\r\t\f\vT \\u{317D}r\\u{1D11E}");
+        expect(r.getKey()).toBe("key");
+    });
+
+    test("RegexFile does not unescape the string if the escapeStyle is set to none", function() {
+        expect.assertions(5);
+
+        var rf = new RegexFile({
+            project: p,
+            pathName: "./testfiles/templates/t1.tmpl",
+            type: rft
+        });
+        expect(rf).toBeTruthy();
+
+        rf.parse("{\'abc \\\"e\\\" \\$\\n\\r\\t\\f\\vT \\u{317D}r\\u{1D11E}\'|f:\'key\'|noescape}");
+
+        var set = rf.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        // noescape means don't unescape anything
+        var r = set.getBySource("abc \\\"e\\\" \\$\\n\\r\\t\\f\\vT \\u{317D}r\\u{1D11E}");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("abc \\\"e\\\" \\$\\n\\r\\t\\f\\vT \\u{317D}r\\u{1D11E}");
         expect(r.getKey()).toBe("key");
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1636,6 +1636,9 @@ importers:
       ilib-locale:
         specifier: workspace:^
         version: link:../ilib-locale
+      ilib-tools-common:
+        specifier: workspace:^
+        version: link:../ilib-tools-common
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8


### PR DESCRIPTION
- add a new setting `escapeStyle` to each expression
- when strings are extracted for files that match that expression, the named escape style is applied as an unescaper