### PR TITLE
Add a JsonFormatter built-in plugin

### DIFF
--- a/.changeset/brave-papayas-joke.md
+++ b/.changeset/brave-papayas-joke.md
@@ -1,0 +1,8 @@
+---
+"ilib-lint": minor
+---
+
+- add a built-in JsonFormatter to format results in json form for the
+  purposes of graphing the results across your localization batches.
+  This leaves out a lot of the details such as the source string or
+  description, as these are not needed for graphing.

--- a/packages/ilib-lint/package.json
+++ b/packages/ilib-lint/package.json
@@ -64,6 +64,7 @@
         "@tsconfig/node14": "^14.1.2",
         "@types/jest": "^29.5.14",
         "@types/node": "^14.0.0",
+        "dedent": "^1.5.3",
         "docdash": "^2.0.2",
         "i18nlint-plugin-test-old": "file:test/i18nlint-plugin-test-old",
         "ilib-lint-plugin-obsolete": "file:test/ilib-lint-plugin-obsolete",

--- a/packages/ilib-lint/src/FormatterManager.js
+++ b/packages/ilib-lint/src/FormatterManager.js
@@ -1,7 +1,7 @@
 /*
  * FormatterManager.js - Factory to create and return the right formatter
  *
- * Copyright © 2022-2024 JEDLSoft
+ * Copyright © 2022-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import log4js from 'log4js';
 
 import { Formatter } from 'ilib-lint-common';
 
-import AnsiConsoleFormatter from './formatters/AnsiConsoleFormatter.js';
 import { ConfigBasedFormatter } from './formatters/ConfigBasedFormatter.js';
 
 const logger = log4js.getLogger("ilib-lint.FormatterManager");
@@ -39,7 +38,6 @@ class FormatterManager {
     constructor(options) {
         this.formatterCache = {};
         this.descriptions = {};
-        this.add([AnsiConsoleFormatter]);
         if (options) {
             if (options.formatters) {
                 this.add(options.formatters);
@@ -52,9 +50,10 @@ class FormatterManager {
      * formatting the output.
      *
      * @param {String} name name of the formatter to return
-     * @param {Object|undefined} options options for this instance of the
+     * @param {Object|undefined} [options] options for this instance of the
      * formatter from the config file, if any
-     * @returns {Formatter} the formatter to use
+     * @returns {Formatter|undefined} the formatter to use or undefined if
+     * no formatter with that name exists
      */
     get(name, options) {
         const formatConfig = this.formatterCache[name];

--- a/packages/ilib-lint/src/formatters/JsonFormatter.js
+++ b/packages/ilib-lint/src/formatters/JsonFormatter.js
@@ -1,0 +1,93 @@
+/*
+ * JsonFormatter.js - Formats result output as a JSON string
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import log4js from 'log4js';
+
+import { Formatter, Result } from 'ilib-lint-common';
+
+var logger = log4js.getLogger("ilib-lint.formatters.JsonFormatter");
+
+/**
+ * @class Represent an output formatter for JSON
+ */
+class JsonFormatter extends Formatter {
+    /**
+     * Construct an formatter instance.
+     * @constructor
+     */
+    constructor(options) {
+        super(options);
+        this.name = "json-formatter";
+        this.description = "Formats results in json for graphing statistics.";
+    }
+
+    /**
+     * Format the given result with the current formatter and return the
+     * formatted string.
+     *
+     * @param {Result} result the result to format
+     * @returns {String} the formatted result
+     */
+    format(result) {
+        if (!result) return "";
+        let obj = {
+            pathName: result.pathName,
+            rule: result.rule.getName(),
+            severity: result.severity
+        };
+
+        return JSON.stringify(obj, null, 4) + "\n";
+    }
+
+    /**
+     * Format the whole result set as a JSON string.
+     * @override
+     */
+    formatOutput(options = {}) {
+        const { name, fileStats, resultStats, results, score, totalTime, errorOnly } = options;
+        const obj = {};
+        obj[name] = {
+            stats: {
+            },
+            results: results.map((result) => {
+                return {
+                    pathName: result.pathName,
+                    rule: result.rule.getName(),
+                    severity: result.severity
+                };
+            })
+        };
+
+        if (resultStats) {
+            obj[name].stats.total = resultStats.total;
+            obj[name].stats.errors = resultStats.errors;
+            obj[name].stats.warnings = resultStats.warnings;
+            obj[name].stats.suggestions = resultStats.suggestions;
+        }
+        if (fileStats) {
+            obj[name].stats.files = fileStats.files;
+            obj[name].stats.lines = fileStats.lines;
+            obj[name].stats.bytes = fileStats.bytes;
+            obj[name].stats.modules = fileStats.modules;
+        }
+
+        return JSON.stringify(obj, null, 4) + "\n";
+    }
+}
+
+export default JsonFormatter;

--- a/packages/ilib-lint/src/plugins/BuiltinPlugin.js
+++ b/packages/ilib-lint/src/plugins/BuiltinPlugin.js
@@ -2,7 +2,7 @@
  * BuiltinPlugin.js - plugin that houses all of the built-in
  * rules and parsers
  *
- * Copyright © 2022-2024 JEDLSoft
+ * Copyright © 2022-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import StringParser from './string/StringParser.js';
 import ErrorFilterTransformer from './ErrorFilterTransformer.js';
 import StringSerializer from './string/StringSerializer.js';
 import AnsiConsoleFormatter from '../formatters/AnsiConsoleFormatter.js';
+import JsonFormatter from '../formatters/JsonFormatter.js';
 import ResourceICUPlurals from '../rules/ResourceICUPlurals.js';
 import ResourceICUPluralTranslation from '../rules/ResourceICUPluralTranslation.js';
 import ResourceQuoteStyle from '../rules/ResourceQuoteStyle.js';
@@ -360,7 +361,7 @@ class BuiltinPlugin extends Plugin {
      * @override
      */
     getFormatters() {
-        return [AnsiConsoleFormatter];
+        return [AnsiConsoleFormatter, JsonFormatter];
     }
 
     getFixers() {

--- a/packages/ilib-lint/test/FormatterManager.test.js
+++ b/packages/ilib-lint/test/FormatterManager.test.js
@@ -1,7 +1,7 @@
 /*
  * FormatterManager.test.js - test the formatter manager
  *
- * Copyright © 2022-2024 JEDLSoft
+ * Copyright © 2022-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,21 +20,35 @@ import { Formatter, Result } from 'ilib-lint-common';
 
 import FormatterManager from '../src/FormatterManager.js';
 import ResourceMatcher from '../src/rules/ResourceMatcher.js';
+import PluginManager from '../src/PluginManager.js';
 
 describe("testFormatterManager", () => {
-    test("FormatterManagerNormal", () => {
-        expect.assertions(3);
-
+    test("FormatterManager constructor works nicely", () => {
+        expect.assertions(1);
+        
         const mgr = new FormatterManager();
         expect(mgr).toBeTruthy();
+    });
 
-        const formatter = mgr.get("ansi-console-formatter");
+    test("FormatterManager make sure the default formatter is there", () => {
+        expect.assertions(5);
+
+        const pluginMgr = new PluginManager();
+        const mgr = pluginMgr.getFormatterManager();
+        expect(mgr).toBeTruthy();
+
+        let formatter = mgr.get("ansi-console-formatter");
+
+        expect(formatter).toBeTruthy();
+        expect(formatter instanceof Formatter).toBeTruthy();
+
+        formatter = mgr.get("json-formatter");
 
         expect(formatter).toBeTruthy();
         expect(formatter instanceof Formatter).toBeTruthy();
     });
 
-    test("FormatterManagerNotFound", () => {
+    test("FormatterManager does not find non-existent formatters", () => {
         expect.assertions(2);
 
         const mgr = new FormatterManager();
@@ -44,7 +58,7 @@ describe("testFormatterManager", () => {
         expect(!formatter).toBeTruthy();
     });
 
-    test("FormatterManagerAddDeclarative", () => {
+    test("FormatterManager add a declarative formatter", () => {
         expect.assertions(4);
 
         const mgr = new FormatterManager();
@@ -66,13 +80,13 @@ describe("testFormatterManager", () => {
         expect(formatter.getName()).toBe("minimal-formatter");
     });
 
-    test("FormatterManagerAddDeclarativeRightSize", () => {
+    test("FormatterManager make sure the manager has the right size after adding a declarative manager", () => {
         expect.assertions(3);
 
         const mgr = new FormatterManager();
         expect(mgr).toBeTruthy();
 
-        expect(mgr.size()).toBe(1);
+        expect(mgr.size()).toBe(0);
 
         mgr.add([{
             "name": "minimal-formatter",
@@ -82,10 +96,10 @@ describe("testFormatterManager", () => {
             "highlightEnd": "<<"
         }]);
 
-        expect(mgr.size()).toBe(2);
+        expect(mgr.size()).toBe(1);
     });
 
-    test("FormatterManagerAddDeclarativeRightFormatter", () => {
+    test("FormatterManager make sure the manager has the right formatter after adding a declarative formatter", () => {
         expect.assertions(4);
 
         const mgr = new FormatterManager();
@@ -125,7 +139,7 @@ describe("testFormatterManager", () => {
         expect(actual).toBe(expected);
     });
 
-    test("FormatterManagerFormatWithAllFields", () => {
+    test("FormatterManager format with all fields", () => {
         expect.assertions(4);
 
         const mgr = new FormatterManager();
@@ -166,7 +180,7 @@ describe("testFormatterManager", () => {
         expect(actual).toBe(expected);
     });
 
-    test("FormatterManagerFormatWithAllFieldsSomeBlank", () => {
+    test("FormatterManager format with all fields with some blank", () => {
         expect.assertions(4);
 
         const mgr = new FormatterManager();

--- a/packages/ilib-lint/test/formatters/JsonFormatter.test.js
+++ b/packages/ilib-lint/test/formatters/JsonFormatter.test.js
@@ -1,0 +1,304 @@
+/*
+ * JsonFormatter.test.js
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Result } from 'ilib-lint-common';
+import dedent from 'dedent';
+
+import JsonFormatter from '../../src/formatters/JsonFormatter.js';
+import ResourceMatcher from "../../src/rules/ResourceMatcher.js";
+
+describe('JsonFormatter', () => {
+    it.each([
+        {
+            testName: "format a single result",
+            name: "ios-app",
+            results: [
+                new Result({
+                    description: "A description for testing purposes",
+                    highlight: "This is just <e0>me</e0> testing.",
+                    id: "test.id",
+                    lineNumber: 123,
+                    pathName: "test.txt",
+                    rule: getTestRule(),
+                    severity: "error",
+                    source: "test"
+                })
+            ],
+            resultStats: undefined,
+            expected: dedent`
+                {
+                    "ios-app": {
+                        "stats": {},
+                        "results": [
+                            {
+                                "pathName": "test.txt",
+                                "rule": "testRule",
+                                "severity": "error"
+                            }
+                        ]
+                    }
+                }` + "\n"
+        },
+        {
+            testName: "format a single result with stats",
+            name: "ios-app",
+            results: [
+                new Result({
+                    description: "A description for testing purposes",
+                    highlight: "This is just <e0>me</e0> testing.",
+                    id: "test.id",
+                    lineNumber: 123,
+                    pathName: "test.txt",
+                    rule: getTestRule(),
+                    severity: "error",
+                    source: "test"
+                })
+            ],
+            resultStats: {
+                errors: 1,
+                warnings: 0,
+                suggestions: 0
+            },
+            expected: dedent`
+                {
+                    "ios-app": {
+                        "stats": {
+                            "errors": 1,
+                            "warnings": 0,
+                            "suggestions": 0
+                        },
+                        "results": [
+                            {
+                                "pathName": "test.txt",
+                                "rule": "testRule",
+                                "severity": "error"
+                            }
+                        ]
+                    }
+                }` + "\n"
+        },
+        {
+            testName: "format a single result with file stats",
+            name: "ios-app",
+            results: [
+                new Result({
+                    description: "A description for testing purposes",
+                    highlight: "This is just <e0>me</e0> testing.",
+                    id: "test.id",
+                    lineNumber: 123,
+                    pathName: "test.txt",
+                    rule: getTestRule(),
+                    severity: "error",
+                    source: "test"
+                })
+            ],
+            fileStats: {
+                files: 1,
+                lines: 10,
+                bytes: 100,
+                modules: 1
+            },
+            expected: dedent`
+                {
+                    "ios-app": {
+                        "stats": {
+                            "files": 1,
+                            "lines": 10,
+                            "bytes": 100,
+                            "modules": 1
+                        },
+                        "results": [
+                            {
+                                "pathName": "test.txt",
+                                "rule": "testRule",
+                                "severity": "error"
+                            }
+                        ]
+                    }
+                }` + "\n"
+        },
+        {
+            testName: "format a single result with file and result stats",
+            name: "ios-app",
+            results: [
+                new Result({
+                    description: "A description for testing purposes",
+                    highlight: "This is just <e0>me</e0> testing.",
+                    id: "test.id",
+                    lineNumber: 123,
+                    pathName: "test.txt",
+                    rule: getTestRule(),
+                    severity: "error",
+                    source: "test"
+                })
+            ],
+            resultStats: {
+                errors: 1,
+                warnings: 0,
+                suggestions: 0
+            },
+            fileStats: {
+                files: 1,
+                lines: 10,
+                bytes: 100,
+                modules: 1
+            },
+            expected: dedent`
+                {
+                    "ios-app": {
+                        "stats": {
+                            "errors": 1,
+                            "warnings": 0,
+                            "suggestions": 0,
+                            "files": 1,
+                            "lines": 10,
+                            "bytes": 100,
+                            "modules": 1
+                        },
+                        "results": [
+                            {
+                                "pathName": "test.txt",
+                                "rule": "testRule",
+                                "severity": "error"
+                            }
+                        ]
+                    }
+                }` + "\n"
+        },
+        {
+            testName: "format multiple results",
+            name: "ios-app",
+            results: [
+                new Result({
+                    description: "A description for testing purposes",
+                    highlight: "This is just <e0>me</e0> testing.",
+                    id: "test.id",
+                    lineNumber: 123,
+                    pathName: "test.txt",
+                    rule: getTestRule(),
+                    severity: "error",
+                    source: "test"
+                }),
+                new Result({
+                    description: "Another description for testing purposes",
+                    highlight: "This is just <e0>another</e0> test.",
+                    id: "test.id.2",
+                    lineNumber: 456,
+                    pathName: "test2.txt",
+                    rule: getTestRule(),
+                    severity: "warning",
+                    source: "test"
+                })
+            ],
+            expected: dedent`
+                {
+                    "ios-app": {
+                        "stats": {},
+                        "results": [
+                            {
+                                "pathName": "test.txt",
+                                "rule": "testRule",
+                                "severity": "error"
+                            },
+                            {
+                                "pathName": "test2.txt",
+                                "rule": "testRule",
+                                "severity": "warning"
+                            }
+                        ]
+                    }
+                }` + "\n"
+        },
+        {
+            testName: "format multiple results with stats",
+            name: "ios-app",
+            results: [
+                new Result({
+                    description: "A description for testing purposes",
+                    highlight: "This is just <e0>me</e0> testing.",
+                    id: "test.id",
+                    lineNumber: 123,
+                    pathName: "test.txt",
+                    rule: getTestRule(),
+                    severity: "error",
+                    source: "test"
+                }),
+                new Result({
+                    description: "Another description for testing purposes",
+                    highlight: "This is just <e0>another</e0> test.",
+                    id: "test.id.2",
+                    lineNumber: 456,
+                    pathName: "test2.txt",
+                    rule: getTestRule(),
+                    severity: "warning",
+                    source: "test"
+                })
+            ],
+            resultStats: {
+                errors: 1,
+                warnings: 1,
+                suggestions: 0
+            },
+            expected: dedent`
+                {
+                    "ios-app": {
+                        "stats": {
+                            "errors": 1,
+                            "warnings": 1,
+                            "suggestions": 0
+                        },
+                        "results": [
+                            {
+                                "pathName": "test.txt",
+                                "rule": "testRule",
+                                "severity": "error"
+                            },
+                            {
+                                "pathName": "test2.txt",
+                                "rule": "testRule",
+                                "severity": "warning"
+                            }
+                        ]
+                    }
+                }` + "\n"
+        }
+    ])('$testName', ({name, results, resultStats, fileStats, expected}) => {
+        const formatter = new JsonFormatter();
+
+        const actual = formatter.formatOutput({
+            name,
+            results,
+            resultStats,
+            fileStats
+        });
+
+        expect(actual).toBe(expected);
+    });
+});
+
+function getTestRule() {
+    return new ResourceMatcher({
+        "name": "testRule",
+        "description": "Rule for testing purposes",
+        "regexps": ["test"],
+        "note": "test",
+        "sourceLocale": "en-US",
+        "link": ""
+    });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
         version: file:packages/ilib-assemble/test/ilib-mock/ilib-mock-1.0.0.tgz
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -219,7 +219,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -319,7 +319,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -419,7 +419,7 @@ importers:
         version: link:../ilib-data-utils
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -498,7 +498,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -561,7 +561,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jest-mock:
         specifier: ^29.7.0
         version: 29.7.0
@@ -607,7 +607,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -772,6 +772,9 @@ importers:
       '@types/node':
         specifier: ^14.0.0
         version: 14.18.63
+      dedent:
+        specifier: ^1.5.3
+        version: 1.5.3
       docdash:
         specifier: ^2.0.2
         version: 2.0.2
@@ -844,7 +847,7 @@ importers:
         version: 2.0.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -875,7 +878,7 @@ importers:
         version: 2.0.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -933,7 +936,7 @@ importers:
         version: 10.7.6
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -1009,7 +1012,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jest-mock:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1100,7 +1103,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jest-mock:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1249,7 +1252,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1268,7 +1271,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1284,7 +1287,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1342,7 +1345,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1416,7 +1419,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1441,7 +1444,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1454,7 +1457,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1473,7 +1476,7 @@ importers:
         version: link:../ilib-loctool-json
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1489,7 +1492,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1508,7 +1511,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1530,7 +1533,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1543,7 +1546,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1568,7 +1571,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1581,7 +1584,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1597,7 +1600,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1613,7 +1616,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1626,7 +1629,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1651,7 +1654,7 @@ importers:
         version: link:../ilib-loctool-javascript-resource
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1664,7 +1667,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1686,7 +1689,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1699,7 +1702,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1712,7 +1715,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1734,7 +1737,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1753,7 +1756,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1772,7 +1775,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1788,7 +1791,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1892,7 +1895,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -1977,7 +1980,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.3
         version: 4.0.4
@@ -2040,7 +2043,7 @@ importers:
         version: 5.0.0(coveralls@3.1.1)(typescript@5.6.3)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -2122,7 +2125,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
+        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -2207,7 +2210,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jest-mock:
         specifier: ^29.7.0
         version: 29.7.0
@@ -2325,7 +2328,7 @@ importers:
         version: file:packages/loctool/test/ilib-loctool-mock-resource/ilib-loctool-mock-resource-1.0.0.tgz
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
 
   packages/message-accumulator:
     dependencies:
@@ -2377,7 +2380,7 @@ importers:
         version: 5.0.0(coveralls@3.1.1)(typescript@5.6.3)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -2414,7 +2417,7 @@ importers:
         version: link:../ilib-tools-common
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+        version: 29.7.0(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -11060,6 +11063,21 @@ snapshots:
       pify: 4.0.1
       safe-buffer: 5.2.1
 
+  create-jest@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-jest@29.7.0(@types/node@12.20.55):
     dependencies:
       '@jest/types': 29.6.3
@@ -11097,21 +11115,6 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@20.17.4)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@22.10.2):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.10.2)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -12066,6 +12069,15 @@ snapshots:
       chalk: 4.1.2
       hooker: 0.2.3
       jshint: 2.13.6
+
+  grunt-contrib-nodeunit@4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
+    dependencies:
+      nodeunit-x: 0.15.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
+    transitivePeerDependencies:
+      - flow-remove-types
+      - supports-color
+      - ts-node
+      - typescript
 
   grunt-contrib-nodeunit@4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
@@ -13108,16 +13120,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.10.2)(node-notifier@8.0.2):
+  jest-cli@29.7.0(node-notifier@8.0.2):
     dependencies:
       '@jest/core': 29.7.0(node-notifier@8.0.2)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.10.2)
+      create-jest: 29.7.0
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.10.2)
+      jest-config: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -13128,6 +13140,34 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0:
+    dependencies:
+      '@babel/core': 7.26.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@12.20.55):
     dependencies:
@@ -13519,12 +13559,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.10.2)(node-notifier@8.0.2):
+  jest@29.7.0(node-notifier@8.0.2):
     dependencies:
       '@jest/core': 29.7.0(node-notifier@8.0.2)
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+      jest-cli: 29.7.0(node-notifier@8.0.2)
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -14345,6 +14385,16 @@ snapshots:
       nodemailer-smtp-transport: 2.7.2
       socks: 1.1.9
     optional: true
+
+  nodeunit-x@0.15.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
+    dependencies:
+      ejs: 3.1.10
+      tap: 15.2.3(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
+    transitivePeerDependencies:
+      - flow-remove-types
+      - supports-color
+      - ts-node
+      - typescript
 
   nodeunit-x@0.15.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
@@ -15859,6 +15909,36 @@ snapshots:
       typescript: 3.9.10
       write-file-atomic: 2.4.3
       yapool: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  tap@15.2.3(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
+    dependencies:
+      chokidar: 3.6.0
+      coveralls: 3.1.1
+      findit: 2.0.0
+      foreground-child: 2.0.0
+      fs-exists-cached: 1.0.0
+      glob: 7.2.3
+      isexe: 2.0.0
+      istanbul-lib-processinfo: 2.0.3
+      jackspeak: 1.4.2
+      libtap: 1.4.1
+      minipass: 3.3.6
+      mkdirp: 1.0.4
+      nyc: 15.1.0
+      opener: 1.5.2
+      rimraf: 3.0.2
+      signal-exit: 3.0.7
+      source-map-support: 0.5.21
+      tap-mocha-reporter: 5.0.4
+      tap-parser: 11.0.2
+      tap-yaml: 1.0.2
+      tcompare: 5.0.7
+      which: 2.0.2
+    optionalDependencies:
+      ts-node: 8.10.2(typescript@3.9.10)
+      typescript: 3.9.10
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
- add a built-in JsonFormatter to format results in json form for the purposes of graphing the results across your localization batches. This leaves out a lot of the details such as the source string or description, as these are not needed for graphing.