### PR TITLE
(ilib-loctool-json) Fix schema path resolution

### DIFF
--- a/.changeset/two-boats-love.md
+++ b/.changeset/two-boats-love.md
@@ -1,5 +1,7 @@
 ---
-"ilib-loctool-json": patch
+"ilib-loctool-json": major
 ---
 
 Fixed absolute schema path resolution. Updated behaviour of relative schema path resolution to be more in-line with project settings convention i.e. resolve it relative to the loctool project's root rather than current working directory (for those rare cases where someone runs loctool outside of a given project).
+
+Migration guide: [docs/upgrades/ilib-loctool-json/2.0.0.md](docs/upgrades/ilib-loctool-json/2.0.0.md)

--- a/.changeset/two-boats-love.md
+++ b/.changeset/two-boats-love.md
@@ -1,0 +1,5 @@
+---
+"ilib-loctool-json": patch
+---
+
+Fixed absolute schema path resolution. Updated behaviour of relative schema path resolution to be more in-line with project settings convention i.e. resolve it relative to the loctool project's root rather than current working directory (for those rare cases where someone runs loctool outside of a given project).

--- a/docs/upgrades/README.md
+++ b/docs/upgrades/README.md
@@ -1,0 +1,21 @@
+This directory contains the migration guides for breaking changes of packages in this monorepo.
+
+Each migration guide should be placed in a subdirectory named after the package it is related to, and named after the version it is migrating to. For example, a migration guide for a breaking change in `ilib-loctool-json` package from version `1.0.0` to `2.0.0` should be placed in `docs/upgrades/ilib-loctool-json/2.0.0.md`.
+
+The migration guide should contain a markdown document with the following structure:
+
+```markdown
+# `package-name`
+
+## Migration from `from-version` to `to-version`
+
+### Breaking change title
+
+Breaking change description
+Migration guide
+
+### Another breaking change title
+
+Breaking change description
+Migration guide
+```

--- a/docs/upgrades/ilib-loctool-json/2.0.0.md
+++ b/docs/upgrades/ilib-loctool-json/2.0.0.md
@@ -1,0 +1,42 @@
+# ilib-loctool-json
+
+## Migration from 1.x.x to 2.0.0
+
+### Schema path resolution
+
+This breaking change updates the behaviour of schema path resolution in loctool's json plugin - paths are now resolved relative to the loctool project's root rather than the current working directory (from which loctool was invoked). Change is only required if you have been running loctool from a different directory than the root of your project.
+
+For example, if you have a monorepo with the following structure:
+
+```plaintext
+packages/
+    project1/
+        project.json
+        schemas/
+        src/
+    project2/
+        project.json
+        schemas/
+        src/
+    ```
+```
+
+and you have been running loctool from the root of the monorepo per-package like
+
+```bash
+yarn loctool localize packages/project1
+yarn loctool localize packages/project2
+```
+
+Then you need to change the schemas directory path in each of `packages/*/project.json` configs from
+```json
+"schemas": [
+    "packages/project1/schemas"
+],
+```
+to
+```json
+"schemas": [
+    "schemas"
+],
+```

--- a/packages/ilib-loctool-json/JsonFileType.js
+++ b/packages/ilib-loctool-json/JsonFileType.js
@@ -57,7 +57,7 @@ var JsonFileType = function(project) {
     this.resourceFiles = {};
     this.schemas = {};
     this.refs = {};
-    this.loadSchemas(".");
+    this.loadSchemas();
 };
 
 JsonFileType.prototype.loadSchemaFile = function(pathName) {
@@ -185,14 +185,15 @@ JsonFileType.prototype.getSchema = function(uri) {
 /**
  * Load all the schema files into memory.
  */
-JsonFileType.prototype.loadSchemas = function(pathName) {
+JsonFileType.prototype.loadSchemas = function() {
     var jsonSettings = this.project.settings.json;
+    var projectRoot = this.project.root || ".";
 
     if (jsonSettings) {
         var schemas = jsonSettings.schemas;
         if (schemas) {
             schemas.forEach(function(schema) {
-                var full = path.join(pathName, schema);
+                var full = path.resolve(projectRoot, schema);
                 this.loadSchemaDirOrFile(full);
             }.bind(this));
         }

--- a/packages/ilib-loctool-json/README.md
+++ b/packages/ilib-loctool-json/README.md
@@ -96,6 +96,7 @@ used within the json property:
   load. If the json file
   does not fit any of the schema (ie. it does not validate according to
   any one of the schema), then that file will be skipped and not localized.
+  This can be a path relative to the project root or an absolute path.
 - mappings: a mapping between file matchers and an object that gives
   info used to localize the files that match it. This allows different
   json files within the project to be processed with different schema.

--- a/packages/ilib-loctool-json/test/JsonFile.test.js
+++ b/packages/ilib-loctool-json/test/JsonFile.test.js
@@ -52,7 +52,7 @@ var p = new CustomProject({
     nopseudo: true,
     json: {
         schemas: [
-            "./test/testfiles/schemas"
+            "./schemas"
         ],
         mappings: {
             "resources/en/US/strings.json": {
@@ -122,7 +122,7 @@ var p2 = new CustomProject({
     nopseudo: false,
     json: {
         schemas: [
-            "./test/testfiles/schemas"
+            "./schemas"
         ],
         mappings: {
             "**/messages.json": {
@@ -3003,7 +3003,7 @@ function setupTest({schema}) {
         nopseudo: true,
         json: {
             schemas: [
-                "./test/testfiles/schemas"
+                "./schemas"
             ],
             mappings: {
                 "**/localizable.json": {


### PR DESCRIPTION
All relative paths provided in loctool's config are treated as relative to the project's root - schema resolution should behave the same way. Additionally, fixed (added?) support for absolute schema paths.
