### PR TITLE
(ilib-po) Fix Parser plural forms fallback to English

### DIFF
--- a/.changeset/little-ghosts-battle.md
+++ b/.changeset/little-ghosts-battle.md
@@ -1,0 +1,5 @@
+---
+"ilib-po": patch
+---
+
+Fixed Parser attempting to use non-existent plural forms definitions - now it properly falls back to English if the form is not defined for a given language.

--- a/packages/ilib-po/src/Parser.ts
+++ b/packages/ilib-po/src/Parser.ts
@@ -262,7 +262,7 @@ class Parser {
                         case TokenType.PLURAL:
                             if (typeof(token.category) !== 'undefined') {
                                 const language = this.targetLocale?.getLanguage() ?? "en";
-                                const forms = pluralForms[language].categories || pluralForms.en.categories;
+                                const forms = (pluralForms[language] ?? pluralForms.en).categories;
                                 if (token.category >= forms.length) {
                                     restart();
                                 } else {


### PR DESCRIPTION
Prevents
```
TypeError: Cannot read properties of undefined (reading 'categories')
18:14:27      at Parser.parse (ilib-po/lib/Parser.js:208:83)
```
for languages which don't have forms defined in `packages/ilib-po/src/pluralforms.ts`.