### PR TITLE
loctool and ilib-xliff: Fix loctool select and add extended attributes

### DIFF
--- a/.changeset/gold-radios-tan.md
+++ b/.changeset/gold-radios-tan.md
@@ -1,0 +1,9 @@
+---
+"ilib-xliff": minor
+---
+
+- Added the ability to parse and generate xliffs
+  with extended attributes on the translation
+  unit elements.
+  - for xliff v1.2, the attributes start with x-
+  - for xliff v2.0, the attributes start with l:

--- a/.changeset/good-donuts-melt.md
+++ b/.changeset/good-donuts-melt.md
@@ -1,0 +1,13 @@
+---
+"loctool": minor
+---
+
+- added the ability to add extended attributes
+  to translation units
+- added the ability to specify the project name
+  and extended attributes for the select command
+  on the command-line
+- the select command automatically adds an extended
+  attribute containing the name of the original
+  file where the selected translation unit comes
+  from

--- a/packages/ilib-xliff/src/TranslationUnit.js
+++ b/packages/ilib-xliff/src/TranslationUnit.js
@@ -1,7 +1,7 @@
 /*
  * TranslationUnit.js - model a translation unit
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,11 @@ class TranslationUnit {
      * <li><i>translate</i> - flag that tells whether to translate this unit (optional)
      * <li><i>location</i> - the line and character location of the start of this
      * translation unit in the xml representation of the file
+     * <li><i>extended</i> - extended properties for this unit. This is an object that
+     * can contain any additional properties that are not explicitly defined in
+     * this class. This is useful for storing additional metadata about the
+     * translation unit that may be specific to a particular application or
+     * use case.
      * </ul>
      *
      * If the required properties are not given, the constructor throws an exception.<p>

--- a/packages/ilib-xliff/src/XmlUtil.js
+++ b/packages/ilib-xliff/src/XmlUtil.js
@@ -1,3 +1,22 @@
+/*
+ * XmlUtils.js - utils to parse xml elements and retrieve attributes and text
+ *
+ * Copyright © 2024-2025 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // type imports
 /** @ignore @typedef {import("ilib-xml-js").Element} Element */
 

--- a/packages/ilib-xliff/test/testXliff20.js
+++ b/packages/ilib-xliff/test/testXliff20.js
@@ -1,7 +1,7 @@
 /*
  * testXliff20.js - test the Xliff 2.0 object.
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -482,6 +482,85 @@ export const testXliff20 = {
                 '  <file original="foo/bar/j.java" l:project="webapp">\n' +
                 '    <group id="group_2" name="plaintext">\n' +
                 '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">come &amp; enjoy it with us</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>baby baby</source>\n' +
+                '          <target>bebe bebe</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        let actual = x.serialize();
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithExtendedAttributes: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        let tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "foobarfoo",
+            targetLocale: "de-DE",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            comment: "foobar is where it's at!",
+            datatype: "plaintext",
+            extended: {
+                foo: "bar"
+            }
+        });
+
+        x.addTranslationUnit(tu);
+
+        tu = new TranslationUnit({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            target: "bebe bebe",
+            targetLocale: "de-DE",
+            key: "huzzah",
+            file: "foo/bar/j.java",
+            project: "webapp",
+            comment: "come & enjoy it with us",
+            datatype: "plaintext",
+            extended: {
+                baz: "quux"
+            }
+        });
+
+        x.addTranslationUnit(tu);
+
+        let expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext" l:foo="bar">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">foobar is where it\'s at!</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>Asdf asdf</source>\n' +
+                '          <target>foobarfoo</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <group id="group_2" name="plaintext">\n' +
+                '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext" l:baz="quux">\n' +
                 '        <notes>\n' +
                 '          <note appliesTo="source">come &amp; enjoy it with us</note>\n' +
                 '        </notes>\n' +
@@ -1137,6 +1216,68 @@ export const testXliff20 = {
         test.equal(tulist[1].target, "bebe bebe");
         test.equal(tulist[1].targetLocale, "de-DE");
         test.deepEqual(tulist[1].location, {line: 11, char: 5});
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithSourceAndTarget: function(test) {
+        test.expect(25);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string" l:foo="bar">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string" l:baz="quux">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        // console.log("x is " + JSON.stringify(x, undefined, 4));
+        let tulist = x.getTranslationUnits();
+        // console.log("x is now " + JSON.stringify(x, undefined, 4));
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+        test.equal(tulist[0].target, "foobarfoo");
+        test.equal(tulist[0].targetLocale, "de-DE");
+        test.deepEqual(tulist[0].location, {line: 3, char: 5});
+        test.deepEqual(tulist[0].extended, {"foo": "bar"});  // custom attributes
+
+        test.equal(tulist[1].source, "baby baby");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+        test.equal(tulist[1].target, "bebe bebe");
+        test.equal(tulist[1].targetLocale, "de-DE");
+        test.deepEqual(tulist[1].location, {line: 11, char: 5});
+        test.deepEqual(tulist[1].extended, {"baz": "quux"});  // custom attributes
 
         test.done();
     },

--- a/packages/loctool/lib/Xliff.js
+++ b/packages/loctool/lib/Xliff.js
@@ -50,6 +50,10 @@ var logger = log4js.getLogger("loctool.lib.Xliff");
  * <li><i>comment</i> - the translator's comment for this unit (optional)
  * <li><i>datatype</i> - the source of the data of this unit (optional)
  * <li><i>flavor</i> - the flavor that this string comes from(optional)
+ * <li><i>extended</i> - an object containing any other properties that
+ * are not part of the standard properties of a translation unit. These are
+ * encoded as attributes on the trans-unit element in the xliff file that
+ * have names that start with "x-".
  * </ul>
  *
  * If the required properties are not given, the constructor throws an exception.<p>
@@ -689,7 +693,7 @@ Xliff.prototype.toString1 = function(units) {
                     "x-flavor": tu.flavor
                 }
             };
-            if (this["tool-id"] || this["tool-name"] || this["tool-version"] || this["tool-company"] ||  this["company"]) {
+            if (this["tool-id"] || this["tool-name"] || this["tool-version"] || this["tool-company"] || this["company"]) {
                 file.header = {
                     "tool": {
                         _attributes: {
@@ -716,6 +720,12 @@ Xliff.prototype.toString1 = function(units) {
                 "_text": tu.source
             }
         };
+
+        if (tu.extended) {
+            Object.keys(tu.extended).forEach(function(key) {
+                tujson._attributes["x-" + key] = tu.extended[key];
+            });
+        }
 
         if (tu.id && tu.id > index) {
             index = tu.id + 1;
@@ -858,6 +868,12 @@ Xliff.prototype.toString2 = function(units) {
                 "l:datatype": tu.datatype
             }
         };
+
+        if (tu.extended) {
+            Object.keys(tu.extended).forEach(function(key) {
+                tujson._attributes["l:" + key] = tu.extended[key];
+            });
+        }
 
         if (tu.comment) {
             tujson.notes = {
@@ -1016,6 +1032,11 @@ Xliff.prototype.toStringCustom = function(units) {
             }
         };
 
+        if (tu.extended) {
+            Object.keys(tu.extended).forEach(function(key) {
+                tujson._attributes["x-" + key] = tu.extended[key];
+            });
+        }
         if (tu.comment) {
             tujson.notes = {
                 "note": [
@@ -1201,6 +1222,18 @@ Xliff.prototype.parse1 = function(xliff) {
                             }
                         }
 
+                        var extended;
+                        if (!tu._attributes) {
+                            Object.keys(tu._attributes).forEach(function(key) {
+                                if (key.startsWith("x-")) {
+                                    if (!extended) {
+                                        extended = {};
+                                    }
+                                    extended[key.substring(2)] = tu[key];
+                                }
+                            });
+                        }
+
                         try {
                             var unit = new TranslationUnit({
                                 file: fileSettings.pathName,
@@ -1217,7 +1250,8 @@ Xliff.prototype.parse1 = function(xliff) {
                                 resType: tu._attributes.restype,
                                 state: tu.target && tu.target._attributes && tu.target._attributes.state,
                                 datatype: tu._attributes.datatype,
-                                flavor: fileSettings.flavor
+                                flavor: fileSettings.flavor,
+                                extended: extended
                             });
                             switch (unit.resType) {
                             case "array":
@@ -1292,6 +1326,18 @@ Xliff.prototype.parse2 = function(xliff) {
                             restype = tu._attributes.type.substring(4);
                         }
 
+                        var extended;
+                        if (!tu._attributes) {
+                            Object.keys(tu._attributes).forEach(function(key) {
+                                if (key.startsWith("x-")) {
+                                    if (!extended) {
+                                        extended = {};
+                                    }
+                                    extended[key.substring(2)] = tu[key];
+                                }
+                            });
+                        }
+
                         if (tu.segment) {
                             var segments = makeArray(tu.segment);
                             for (var j = 0; j < segments.length; j++) {
@@ -1330,7 +1376,8 @@ Xliff.prototype.parse2 = function(xliff) {
                                     resType: restype,
                                     state: state,
                                     datatype: datatype,
-                                    flavor: fileSettings.flavor
+                                    flavor: fileSettings.flavor,
+                                    extended: extended
                                 });
                                 switch (restype) {
                                 case "array":

--- a/packages/loctool/lib/Xliff.js
+++ b/packages/loctool/lib/Xliff.js
@@ -1327,13 +1327,17 @@ Xliff.prototype.parse2 = function(xliff) {
                         }
 
                         var extended;
-                        if (!tu._attributes) {
+                        if (tu._attributes) {
                             Object.keys(tu._attributes).forEach(function(key) {
-                                if (key.startsWith("x-")) {
+                                if (key.startsWith("l:") &&
+                                        key !== "l:datatype" &&
+                                        key !== "l:index" &&
+                                        key !== "l:category" &&
+                                        key !== "l:context") {
                                     if (!extended) {
                                         extended = {};
                                     }
-                                    extended[key.substring(2)] = tu[key];
+                                    extended[key.substring(2)] = tu._attributes[key];
                                 }
                             });
                         }

--- a/packages/loctool/lib/XliffSelect.js
+++ b/packages/loctool/lib/XliffSelect.js
@@ -83,7 +83,9 @@ var XliffSelect = function XliffSelect(settings) {
             });
             xliff.deserialize(data);
             xliff.getTranslationUnits().forEach(function(unit) {
-                unit.project = unit.project || projectName;
+                if (projectName) {
+                    unit.project = projectName;
+                }
                 if (settings.extendedAttr) {
                     unit.extended = unit.extended || {};
                     Object.keys(settings.extendedAttr).forEach(function(key) {

--- a/packages/loctool/lib/XliffSelect.js
+++ b/packages/loctool/lib/XliffSelect.js
@@ -86,12 +86,11 @@ var XliffSelect = function XliffSelect(settings) {
                 if (projectName) {
                     unit.project = projectName;
                 }
-                if (settings.extendedAttr) {
-                    unit.extended = unit.extended || {};
-                    Object.keys(settings.extendedAttr).forEach(function(key) {
-                        unit.extended[key] = settings.extendedAttr[key];
-                    });
+                unit.extended = unit.extended || {};
+                if (typeof(settings.extendedAttr) === "object") {
+                    Object.assign(unit.extended, settings.extendedAttr);
                 }
+                unit.extended["original-file"] = file;
                 var hash = unit.hash();
                 if (transUnitCache.has(hash)) return;
                 units.push(unit);

--- a/packages/loctool/lib/XliffSelect.js
+++ b/packages/loctool/lib/XliffSelect.js
@@ -47,6 +47,8 @@ function wordCount(string) {
  * @param {string} settings.xliffStyle the style of the xliff file
  * @param {Array.<string>} settings.infiles the paths to input xliff files
  * @param {string} settings.criteria selection criteria from the command-line
+ * @param {Map.<string, string>} settings.extendedAttr extended attributes to add to the selected units
+ * @param {string} settings.id the project id to add to the selected units
  * @returns {Xliff} xliff file with data merged into one
  *
  */
@@ -60,6 +62,7 @@ var XliffSelect = function XliffSelect(settings) {
     // Remember which trans-units were added already, so we don't have
     // to add them again
     var transUnitCache = new ISet();
+    var projectName = settings.id;
 
     var target = new Xliff({
         path: settings.outfile,
@@ -80,6 +83,13 @@ var XliffSelect = function XliffSelect(settings) {
             });
             xliff.deserialize(data);
             xliff.getTranslationUnits().forEach(function(unit) {
+                unit.project = unit.project || projectName;
+                if (settings.extendedAttr) {
+                    unit.extended = unit.extended || {};
+                    Object.keys(settings.extendedAttr).forEach(function(key) {
+                        unit.extended[key] = settings.extendedAttr[key];
+                    });
+                }
                 var hash = unit.hash();
                 if (transUnitCache.has(hash)) return;
                 units.push(unit);

--- a/packages/loctool/lib/XliffSelect.js
+++ b/packages/loctool/lib/XliffSelect.js
@@ -92,7 +92,6 @@ var XliffSelect = function XliffSelect(settings) {
                 }
                 unit.extended["original-file"] = file;
                 var hash = unit.hash();
-                if (transUnitCache.has(hash)) return;
                 units.push(unit);
                 transUnitCache.add(hash);
             });

--- a/packages/loctool/loctool.js
+++ b/packages/loctool/loctool.js
@@ -177,7 +177,14 @@ var commandOptionHelp = {
         "outfile\n" +
         "  the path to the file where the selected translation units are written to\n" +
         "filename\n" +
-        "  You may list as many input files to select from as you like",
+        "  You may list as many input files to select from as you like" +
+        "--projectId <projectName>\n" +
+        "  Specify the project name to use when selecting translation units. This is used in the output file\n" +
+        "  if the project name is not already set in the input files.\n" +
+        "--extendedAttr <name>=<value>\n" +
+        "  Add an extended attribute to the output file. This can be used to add arbitrary metadata to\n" +
+        "  each translation unit in the output file. You may specify this option multiple times to add\n" +
+        "  multiple extended attributes.",
 };
 
 function usage() {
@@ -452,6 +459,17 @@ for (var i = 0; i < argv.length; i++) {
         }
     } else if (val === "--convertPlurals") {
         settings.convertPlurals = true;
+    } else if (val === "--extendedAttr") {
+        if (i + 1 < argv.length && argv[i + 1]) {
+            var attr = argv[++i].split("=");
+            if (attr.length === 2) {
+                settings.extendedAttr = settings.extendedAttr || {};
+                settings.extendedAttr[attr[0]] = attr[1];
+            } else {
+                console.error("Error: --extendedAttr option requires a name=value argument to follow it.");
+                usage();
+            }
+        }
     } else {
         options.push(val);
     }

--- a/packages/loctool/test/XliffSelect.test.js
+++ b/packages/loctool/test/XliffSelect.test.js
@@ -235,15 +235,15 @@ describe("xliff select translation units in xliff v1", function() {
         '<xliff version="1.0">\n' +
         '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1a</source>\n' +
         '        <target>app1:String 1a</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1b</source>\n' +
         '        <target>app1:String 1b</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1c</source>\n' +
         '        <target>app1:String 1c</target>\n' +
         '      </trans-unit>\n' +
@@ -251,11 +251,11 @@ describe("xliff select translation units in xliff v1", function() {
         '  </file>\n' +
         '  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app2">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript">\n' +
+        '      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript" x-original-file="test/testfiles/xliff20/app2/en-US.xliff">\n' +
         '        <source>app2: String 2a</source>\n' +
         '        <target>app2: String 2a</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript">\n' +
+        '      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript" x-original-file="test/testfiles/xliff20/app2/en-US.xliff">\n' +
         '        <source>app2: String 2b</source>\n' +
         '        <target>app2: String 2b</target>\n' +
         '      </trans-unit>\n' +
@@ -286,11 +286,11 @@ describe("xliff select translation units in xliff v1", function() {
         '<xliff version="1.0">\n' +
         '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1a</source>\n' +
         '        <target>app1:String 1a</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1b</source>\n' +
         '        <target>app1:String 1b</target>\n' +
         '      </trans-unit>\n' +
@@ -323,15 +323,15 @@ describe("xliff select translation units in xliff v1", function() {
         '<xliff version="1.0">\n' +
         '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1a</source>\n' +
         '        <target>app1:String 1a</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1b</source>\n' +
         '        <target>app1:String 1b</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1c</source>\n' +
         '        <target>app1:String 1c</target>\n' +
         '      </trans-unit>\n' +
@@ -363,15 +363,15 @@ describe("xliff select translation units in xliff v1", function() {
         '<xliff version="1.0">\n' +
         '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1a</source>\n' +
         '        <target>app1:String 1a</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1b</source>\n' +
         '        <target>app1:String 1b</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1c</source>\n' +
         '        <target>app1:String 1c</target>\n' +
         '      </trans-unit>\n' +
@@ -436,7 +436,7 @@ describe("xliff select translation units in xliff v1", function() {
         '<xliff version="1.0">\n' +
         '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1a</source>\n' +
         '        <target>app1:String 1a</target>\n' +
         '      </trans-unit>\n' +
@@ -467,7 +467,7 @@ describe("xliff select translation units in xliff v1", function() {
         '<xliff version="1.0">\n' +
         '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1a</source>\n' +
         '        <target>app1:String 1a</target>\n' +
         '      </trans-unit>\n' +
@@ -498,11 +498,11 @@ describe("xliff select translation units in xliff v1", function() {
         '<xliff version="1.0">\n' +
         '  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app2">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript">\n' +
+        '      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript" x-original-file="test/testfiles/xliff20/app2/en-US.xliff">\n' +
         '        <source>app2: String 2a</source>\n' +
         '        <target>app2: String 2a</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript">\n' +
+        '      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript" x-original-file="test/testfiles/xliff20/app2/en-US.xliff">\n' +
         '        <source>app2: String 2b</source>\n' +
         '        <target>app2: String 2b</target>\n' +
         '      </trans-unit>\n' +
@@ -534,7 +534,7 @@ describe("xliff select translation units in xliff v1", function() {
         '<xliff version="1.0">\n' +
         '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1c</source>\n' +
         '        <target>app1:String 1c</target>\n' +
         '      </trans-unit>\n' +
@@ -567,15 +567,15 @@ describe("xliff select translation units in xliff v1", function() {
         '<xliff version="1.0">\n' +
         '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1a</source>\n' +
         '        <target>app1:String 1a</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1b</source>\n' +
         '        <target>app1:String 1b</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1c</source>\n' +
         '        <target>app1:String 1c</target>\n' +
         '      </trans-unit>\n' +
@@ -606,15 +606,15 @@ describe("xliff select translation units in xliff v1", function() {
         '<xliff version="1.0">\n' +
         '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1a</source>\n' +
         '        <target>app1:String 1a</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1b</source>\n' +
         '        <target>app1:String 1b</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <source>app1:String 1c</source>\n' +
         '        <target>app1:String 1c</target>\n' +
         '      </trans-unit>\n' +
@@ -648,13 +648,13 @@ describe("xliff select translation units in xliff v2", function() {
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app1" l:project="app1">\n' +
         '    <group id="group_1" name="cpp">\n' +
-        '      <unit id="app1_1" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1a</source>\n' +
         '          <target>app1:String 1a</target>\n' +
         '        </segment>\n' +
         '      </unit>\n' +
-        '      <unit id="app1_2" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_2" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1b</source>\n' +
         '          <target>app1:String 1b</target>\n' +
@@ -662,7 +662,7 @@ describe("xliff select translation units in xliff v2", function() {
         '      </unit>\n' +
         '    </group>\n' +
         '    <group id="group_2" name="x-json">\n' +
-        '      <unit id="app1_3" type="res:string" l:datatype="x-json">\n' +
+        '      <unit id="app1_3" type="res:string" l:datatype="x-json" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1c</source>\n' +
         '          <target>app1:String 1c</target>\n' +
@@ -672,13 +672,13 @@ describe("xliff select translation units in xliff v2", function() {
         '  </file>\n' +
         '  <file original="app2" l:project="app2">\n' +
         '    <group id="group_3" name="javascript">\n' +
-        '      <unit id="app2_1" type="res:string" l:datatype="javascript">\n' +
+        '      <unit id="app2_1" type="res:string" l:datatype="javascript" l:original-file="test/testfiles/xliff20/app2/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app2: String 2a</source>\n' +
         '          <target>app2: String 2a</target>\n' +
         '        </segment>\n' +
         '      </unit>\n' +
-        '      <unit id="app2_2" type="res:string" l:datatype="javascript">\n' +
+        '      <unit id="app2_2" type="res:string" l:datatype="javascript" l:original-file="test/testfiles/xliff20/app2/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app2: String 2b</source>\n' +
         '          <target>app2: String 2b</target>\n' +
@@ -711,13 +711,13 @@ describe("xliff select translation units in xliff v2", function() {
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app1" l:project="app1">\n' +
         '    <group id="group_1" name="cpp">\n' +
-        '      <unit id="app1_1" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1a</source>\n' +
         '          <target>app1:String 1a</target>\n' +
         '        </segment>\n' +
         '      </unit>\n' +
-        '      <unit id="app1_2" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_2" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1b</source>\n' +
         '          <target>app1:String 1b</target>\n' +
@@ -752,13 +752,13 @@ describe("xliff select translation units in xliff v2", function() {
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app1" l:project="app1">\n' +
         '    <group id="group_1" name="cpp">\n' +
-        '      <unit id="app1_1" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1a</source>\n' +
         '          <target>app1:String 1a</target>\n' +
         '        </segment>\n' +
         '      </unit>\n' +
-        '      <unit id="app1_2" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_2" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1b</source>\n' +
         '          <target>app1:String 1b</target>\n' +
@@ -766,7 +766,7 @@ describe("xliff select translation units in xliff v2", function() {
         '      </unit>\n' +
         '    </group>\n' +
         '    <group id="group_2" name="x-json">\n' +
-        '      <unit id="app1_3" type="res:string" l:datatype="x-json">\n' +
+        '      <unit id="app1_3" type="res:string" l:datatype="x-json" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1c</source>\n' +
         '          <target>app1:String 1c</target>\n' +
@@ -800,13 +800,13 @@ describe("xliff select translation units in xliff v2", function() {
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app1" l:project="app1">\n' +
         '    <group id="group_1" name="cpp">\n' +
-        '      <unit id="app1_1" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1a</source>\n' +
         '          <target>app1:String 1a</target>\n' +
         '        </segment>\n' +
         '      </unit>\n' +
-        '      <unit id="app1_2" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_2" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1b</source>\n' +
         '          <target>app1:String 1b</target>\n' +
@@ -814,7 +814,7 @@ describe("xliff select translation units in xliff v2", function() {
         '      </unit>\n' +
         '    </group>\n' +
         '    <group id="group_2" name="x-json">\n' +
-        '      <unit id="app1_3" type="res:string" l:datatype="x-json">\n' +
+        '      <unit id="app1_3" type="res:string" l:datatype="x-json" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1c</source>\n' +
         '          <target>app1:String 1c</target>\n' +
@@ -881,7 +881,7 @@ describe("xliff select translation units in xliff v2", function() {
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app1" l:project="app1">\n' +
         '    <group id="group_1" name="cpp">\n' +
-        '      <unit id="app1_1" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1a</source>\n' +
         '          <target>app1:String 1a</target>\n' +
@@ -914,7 +914,7 @@ describe("xliff select translation units in xliff v2", function() {
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app1" l:project="app1">\n' +
         '    <group id="group_1" name="cpp">\n' +
-        '      <unit id="app1_1" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1a</source>\n' +
         '          <target>app1:String 1a</target>\n' +
@@ -947,13 +947,13 @@ describe("xliff select translation units in xliff v2", function() {
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app2" l:project="app2">\n' +
         '    <group id="group_1" name="javascript">\n' +
-        '      <unit id="app2_1" type="res:string" l:datatype="javascript">\n' +
+        '      <unit id="app2_1" type="res:string" l:datatype="javascript" l:original-file="test/testfiles/xliff20/app2/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app2: String 2a</source>\n' +
         '          <target>app2: String 2a</target>\n' +
         '        </segment>\n' +
         '      </unit>\n' +
-        '      <unit id="app2_2" type="res:string" l:datatype="javascript">\n' +
+        '      <unit id="app2_2" type="res:string" l:datatype="javascript" l:original-file="test/testfiles/xliff20/app2/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app2: String 2b</source>\n' +
         '          <target>app2: String 2b</target>\n' +
@@ -987,7 +987,7 @@ describe("xliff select translation units in xliff v2", function() {
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app1" l:project="app1">\n' +
         '    <group id="group_1" name="x-json">\n' +
-        '      <unit id="app1_3" type="res:string" l:datatype="x-json">\n' +
+        '      <unit id="app1_3" type="res:string" l:datatype="x-json" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1c</source>\n' +
         '          <target>app1:String 1c</target>\n' +
@@ -1022,13 +1022,13 @@ describe("xliff select translation units in xliff v2", function() {
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app1" l:project="app1">\n' +
         '    <group id="group_1" name="cpp">\n' +
-        '      <unit id="app1_1" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1a</source>\n' +
         '          <target>app1:String 1a</target>\n' +
         '        </segment>\n' +
         '      </unit>\n' +
-        '      <unit id="app1_2" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_2" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1b</source>\n' +
         '          <target>app1:String 1b</target>\n' +
@@ -1036,7 +1036,7 @@ describe("xliff select translation units in xliff v2", function() {
         '      </unit>\n' +
         '    </group>\n' +
         '    <group id="group_2" name="x-json">\n' +
-        '      <unit id="app1_3" type="res:string" l:datatype="x-json">\n' +
+        '      <unit id="app1_3" type="res:string" l:datatype="x-json" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1c</source>\n' +
         '          <target>app1:String 1c</target>\n' +
@@ -1069,13 +1069,13 @@ describe("xliff select translation units in xliff v2", function() {
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app1" l:project="app1">\n' +
         '    <group id="group_1" name="cpp">\n' +
-        '      <unit id="app1_1" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1a</source>\n' +
         '          <target>app1:String 1a</target>\n' +
         '        </segment>\n' +
         '      </unit>\n' +
-        '      <unit id="app1_2" type="res:string" l:datatype="cpp">\n' +
+        '      <unit id="app1_2" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1b</source>\n' +
         '          <target>app1:String 1b</target>\n' +
@@ -1083,7 +1083,7 @@ describe("xliff select translation units in xliff v2", function() {
         '      </unit>\n' +
         '    </group>\n' +
         '    <group id="group_2" name="x-json">\n' +
-        '      <unit id="app1_3" type="res:string" l:datatype="x-json">\n' +
+        '      <unit id="app1_3" type="res:string" l:datatype="x-json" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1c</source>\n' +
         '          <target>app1:String 1c</target>\n' +

--- a/packages/loctool/test/XliffSelect.test.js
+++ b/packages/loctool/test/XliffSelect.test.js
@@ -601,20 +601,24 @@ describe("xliff select translation units in xliff v1", function() {
         expect(target).toBeTruthy();
 
         var actual = target.serialize();
+
+        // the trans-units for the second file should override the ones
+        // from the first file, but since they are identical, it should
+        // only appear once in the output.
         var expected =
         '<?xml version="1.0" encoding="utf-8"?>\n' +
         '<xliff version="1.0">\n' +
         '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
         '    <body>\n' +
-        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/en-US-2.xliff">\n' +
         '        <source>app1:String 1a</source>\n' +
         '        <target>app1:String 1a</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/en-US-2.xliff">\n' +
         '        <source>app1:String 1b</source>\n' +
         '        <target>app1:String 1b</target>\n' +
         '      </trans-unit>\n' +
-        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-original-file="test/testfiles/xliff20/en-US-2.xliff">\n' +
         '        <source>app1:String 1c</source>\n' +
         '        <target>app1:String 1c</target>\n' +
         '      </trans-unit>\n' +
@@ -1064,18 +1068,22 @@ describe("xliff select translation units in xliff v2", function() {
         expect(target).toBeTruthy();
 
         var actual = target.serialize();
+
+        // the units from the second file should override the ones
+        // from the first file, but since they are identical, it should
+        // only appear once in the output.
         var expected =
         '<?xml version="1.0" encoding="utf-8"?>\n' +
         '<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
         '  <file original="app1" l:project="app1">\n' +
         '    <group id="group_1" name="cpp">\n' +
-        '      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
+        '      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/en-US-2.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1a</source>\n' +
         '          <target>app1:String 1a</target>\n' +
         '        </segment>\n' +
         '      </unit>\n' +
-        '      <unit id="app1_2" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
+        '      <unit id="app1_2" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/en-US-2.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1b</source>\n' +
         '          <target>app1:String 1b</target>\n' +
@@ -1083,7 +1091,7 @@ describe("xliff select translation units in xliff v2", function() {
         '      </unit>\n' +
         '    </group>\n' +
         '    <group id="group_2" name="x-json">\n' +
-        '      <unit id="app1_3" type="res:string" l:datatype="x-json" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">\n' +
+        '      <unit id="app1_3" type="res:string" l:datatype="x-json" l:original-file="test/testfiles/xliff20/en-US-2.xliff">\n' +
         '        <segment>\n' +
         '          <source>app1:String 1c</source>\n' +
         '          <target>app1:String 1c</target>\n' +

--- a/packages/loctool/test/XliffSelect.test.js
+++ b/packages/loctool/test/XliffSelect.test.js
@@ -21,12 +21,6 @@ var fs = require("fs");
 var Xliff = require("../lib/Xliff.js");
 var XliffSelect = require("../lib/XliffSelect.js");
 
-function rmrf(path) {
-    if (fs.existsSync(path)) {
-        fs.unlinkSync(path);
-    }
-}
-
 describe("xliff select criteria parser", function() {
     test("simple criteria", function() {
         expect.assertions(1);
@@ -203,21 +197,436 @@ describe("xliff select criteria parser", function() {
     });
 });
 
-describe("xliff select translation units", function() {
+describe("xliff select test edge cases", function() {
     test("Select no parameters", function() {
         expect.assertions(1);
 
         var target = XliffSelect();
         expect(target).toBeFalsy();
     });
-    
+
     test("Select Write no parameters", function() {
         expect.assertions(1);
 
         var target = XliffSelect.write();
         expect(target).toBeFalsy();
     });
-    
+});
+
+describe("xliff select translation units in xliff v1", function() {
+    test("Select everything", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ]
+        };
+
+        // no selection criteria, so selects everything
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="1.0">\n' +
+        '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1a</source>\n' +
+        '        <target>app1:String 1a</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1b</source>\n' +
+        '        <target>app1:String 1b</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '        <source>app1:String 1c</source>\n' +
+        '        <target>app1:String 1c</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app2">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript">\n' +
+        '        <source>app2: String 2a</source>\n' +
+        '        <target>app2: String 2a</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript">\n' +
+        '        <source>app2: String 2b</source>\n' +
+        '        <target>app2: String 2b</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '</xliff>';
+        expect(actual).toBe(expected);
+    });
+
+    test("Select with max units", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            criteria: "maxunits:2"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="1.0">\n' +
+        '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1a</source>\n' +
+        '        <target>app1:String 1a</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1b</source>\n' +
+        '        <target>app1:String 1b</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '</xliff>';
+
+        expect(actual).toBe(expected);
+    });
+
+    test("Select with max source words", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            criteria: "maxsource:8"
+        };
+
+        // no selection criteria, so selects everything
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="1.0">\n' +
+        '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1a</source>\n' +
+        '        <target>app1:String 1a</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1b</source>\n' +
+        '        <target>app1:String 1b</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '        <source>app1:String 1c</source>\n' +
+        '        <target>app1:String 1c</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '</xliff>';
+        expect(actual).toBe(expected);
+    });
+
+    test("Select with max target words", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            criteria: "maxtarget:8"
+        };
+
+        // no selection criteria, so selects everything
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="1.0">\n' +
+        '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1a</source>\n' +
+        '        <target>app1:String 1a</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1b</source>\n' +
+        '        <target>app1:String 1b</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '        <source>app1:String 1c</source>\n' +
+        '        <target>app1:String 1c</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '</xliff>';
+        expect(actual).toBe(expected);
+    });
+
+    // there is a 1 in 120 chance that this one will fail if the random numbers
+    // cause the array to sort the same way that it originally was, making this
+    // an unstable test. So, making this test.skip for now. Reenable this test
+    // locally if you want to test the randomization functionality.
+    test.skip("Select randomly", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            criteria: "random"
+        };
+
+        // no selection criteria, so selects everything
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.getTranslationUnits().map(function(unit) {
+            return unit.id;
+        });
+        var expected = [
+            "app1_1",
+            "app1_2",
+            "app1_3",
+            "app2_1",
+            "app2_2"
+        ];
+
+        expect(actual).not.toStrictEqual(expected);
+    });
+
+    test("Select with simple field criteria", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            criteria: "source=1a"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="1.0">\n' +
+        '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1a</source>\n' +
+        '        <target>app1:String 1a</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '</xliff>';
+        expect(actual).toBe(expected);
+    });
+
+    test("Select with regex field criteria", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            criteria: "source=^app1:.*a$"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="1.0">\n' +
+        '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1a</source>\n' +
+        '        <target>app1:String 1a</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '</xliff>';
+        expect(actual).toBe(expected);
+    });
+
+    test("Select with regex field criteria multiple results", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            criteria: "source=^app2"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="1.0">\n' +
+        '  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app2">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript">\n' +
+        '        <source>app2: String 2a</source>\n' +
+        '        <target>app2: String 2a</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript">\n' +
+        '        <source>app2: String 2b</source>\n' +
+        '        <target>app2: String 2b</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '</xliff>';
+
+        expect(actual).toBe(expected);
+    });
+
+    test("Select with multiple criteria", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            criteria: "source=1,targetLocale=en-US,datatype=x-json"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="1.0">\n' +
+        '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '        <source>app1:String 1c</source>\n' +
+        '        <target>app1:String 1c</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '</xliff>';
+        expect(actual).toBe(expected);
+    });
+
+    test("Select while avoiding duplicated file names", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff", // should only read this file once
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app1/en-US.xliff"
+            ]
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="1.0">\n' +
+        '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1a</source>\n' +
+        '        <target>app1:String 1a</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1b</source>\n' +
+        '        <target>app1:String 1b</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '        <source>app1:String 1c</source>\n' +
+        '        <target>app1:String 1c</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '</xliff>';
+
+        expect(actual).toBe(expected);
+    });
+
+    test("Select while avoiding duplicated trans units", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/en-US-2.xliff" // has different file name but same contents as the first file
+            ]
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        var expected =
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff version="1.0">\n' +
+        '  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">\n' +
+        '    <body>\n' +
+        '      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1a</source>\n' +
+        '        <target>app1:String 1a</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">\n' +
+        '        <source>app1:String 1b</source>\n' +
+        '        <target>app1:String 1b</target>\n' +
+        '      </trans-unit>\n' +
+        '      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">\n' +
+        '        <source>app1:String 1c</source>\n' +
+        '        <target>app1:String 1c</target>\n' +
+        '      </trans-unit>\n' +
+        '    </body>\n' +
+        '  </file>\n' +
+        '</xliff>';
+
+        expect(actual).toBe(expected);
+    });
+});
+
+describe("xliff select translation units in xliff v2", function() {
     test("Select everything", function() {
         expect.assertions(2);
 
@@ -232,7 +641,7 @@ describe("xliff select translation units", function() {
         // no selection criteria, so selects everything
         var target = XliffSelect(settings);
         expect(target).toBeTruthy();
-        
+
         var actual = target.serialize();
         var expected =
         '<?xml version="1.0" encoding="utf-8"?>\n' +
@@ -280,7 +689,7 @@ describe("xliff select translation units", function() {
         '</xliff>';
         expect(actual).toBe(expected);
     });
-    
+
     test("Select with max units", function() {
         expect.assertions(2);
 
@@ -336,7 +745,7 @@ describe("xliff select translation units", function() {
         // no selection criteria, so selects everything
         var target = XliffSelect(settings);
         expect(target).toBeTruthy();
-        
+
         var actual = target.serialize();
         var expected =
         '<?xml version="1.0" encoding="utf-8"?>\n' +
@@ -368,7 +777,7 @@ describe("xliff select translation units", function() {
         '</xliff>';
         expect(actual).toBe(expected);
     });
-    
+
     test("Select with max target words", function() {
         expect.assertions(2);
 
@@ -384,7 +793,7 @@ describe("xliff select translation units", function() {
         // no selection criteria, so selects everything
         var target = XliffSelect(settings);
         expect(target).toBeTruthy();
-        
+
         var actual = target.serialize();
         var expected =
         '<?xml version="1.0" encoding="utf-8"?>\n' +
@@ -436,7 +845,7 @@ describe("xliff select translation units", function() {
         // no selection criteria, so selects everything
         var target = XliffSelect(settings);
         expect(target).toBeTruthy();
-        
+
         var actual = target.getTranslationUnits().map(function(unit) {
             return unit.id;
         });
@@ -450,7 +859,7 @@ describe("xliff select translation units", function() {
 
         expect(actual).not.toStrictEqual(expected);
     });
-    
+
     test("Select with simple field criteria", function() {
         expect.assertions(2);
 
@@ -685,5 +1094,131 @@ describe("xliff select translation units", function() {
         '</xliff>';
 
         expect(actual).toBe(expected);
+    });
+});
+
+describe("xliff select extra unit information", function() {
+    test("Make sure that after select, each file has the project id set correctly with xliff v1", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            id: "app1"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        expect(actual).toMatchSnapshot();
+    });
+
+    test("Make sure that after select, each file has the project id set correctly with xliff v2", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 2,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            id: "app1"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        expect(actual).toMatchSnapshot();
+    });
+
+    test("Make sure that after select, each unit has the extended attributes set correctly with xliff v1", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            extendedAttr: {
+                foo: "bar"
+            }
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        expect(actual).toMatchSnapshot();
+    });
+
+    test("Make sure that after select, each unit has the extended attributes set correctly with xliff v2", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 2,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            extendedAttr: {
+                foo: "bar"
+            }
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        expect(actual).toMatchSnapshot();
+    });
+
+    test("Make sure that after select, each unit has the extended attributes and each file has the project id set correctly with xliff v1", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            extendedAttr: {
+                foo: "bar"
+            },
+            id: "app1"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        expect(actual).toMatchSnapshot();
+    });
+
+    test("Make sure that after select, each unit has the extended attributes and each file has the project id set correctly with xliff v2", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 2,
+            infiles: [
+                "test/testfiles/xliff20/app1/en-US.xliff",
+                "test/testfiles/xliff20/app2/en-US.xliff"
+            ],
+            extendedAttr: {
+                foo: "bar"
+            },
+            id: "app1"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var actual = target.serialize();
+        expect(actual).toMatchSnapshot();
     });
 });

--- a/packages/loctool/test/__snapshots__/XliffSelect.test.js.snap
+++ b/packages/loctool/test/__snapshots__/XliffSelect.test.js.snap
@@ -5,27 +5,27 @@ exports[`xliff select extra unit information Make sure that after select, each f
 <xliff version="1.0">
   <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">
     <body>
-      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">
+      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <source>app1:String 1a</source>
         <target>app1:String 1a</target>
       </trans-unit>
-      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">
+      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <source>app1:String 1b</source>
         <target>app1:String 1b</target>
       </trans-unit>
-      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">
+      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <source>app1:String 1c</source>
         <target>app1:String 1c</target>
       </trans-unit>
     </body>
   </file>
-  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app2">
+  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app1">
     <body>
-      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript">
+      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript" x-original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <source>app2: String 2a</source>
         <target>app2: String 2a</target>
       </trans-unit>
-      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript">
+      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript" x-original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <source>app2: String 2b</source>
         <target>app2: String 2b</target>
       </trans-unit>
@@ -39,13 +39,13 @@ exports[`xliff select extra unit information Make sure that after select, each f
 <xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
   <file original="app1" l:project="app1">
     <group id="group_1" name="cpp">
-      <unit id="app1_1" type="res:string" l:datatype="cpp">
+      <unit id="app1_1" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <segment>
           <source>app1:String 1a</source>
           <target>app1:String 1a</target>
         </segment>
       </unit>
-      <unit id="app1_2" type="res:string" l:datatype="cpp">
+      <unit id="app1_2" type="res:string" l:datatype="cpp" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <segment>
           <source>app1:String 1b</source>
           <target>app1:String 1b</target>
@@ -53,7 +53,7 @@ exports[`xliff select extra unit information Make sure that after select, each f
       </unit>
     </group>
     <group id="group_2" name="x-json">
-      <unit id="app1_3" type="res:string" l:datatype="x-json">
+      <unit id="app1_3" type="res:string" l:datatype="x-json" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <segment>
           <source>app1:String 1c</source>
           <target>app1:String 1c</target>
@@ -61,15 +61,15 @@ exports[`xliff select extra unit information Make sure that after select, each f
       </unit>
     </group>
   </file>
-  <file original="app2" l:project="app2">
+  <file original="app2" l:project="app1">
     <group id="group_3" name="javascript">
-      <unit id="app2_1" type="res:string" l:datatype="javascript">
+      <unit id="app2_1" type="res:string" l:datatype="javascript" l:original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <segment>
           <source>app2: String 2a</source>
           <target>app2: String 2a</target>
         </segment>
       </unit>
-      <unit id="app2_2" type="res:string" l:datatype="javascript">
+      <unit id="app2_2" type="res:string" l:datatype="javascript" l:original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <segment>
           <source>app2: String 2b</source>
           <target>app2: String 2b</target>
@@ -85,27 +85,27 @@ exports[`xliff select extra unit information Make sure that after select, each u
 <xliff version="1.0">
   <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">
     <body>
-      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-foo="bar">
+      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-foo="bar" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <source>app1:String 1a</source>
         <target>app1:String 1a</target>
       </trans-unit>
-      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-foo="bar">
+      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-foo="bar" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <source>app1:String 1b</source>
         <target>app1:String 1b</target>
       </trans-unit>
-      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-foo="bar">
+      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-foo="bar" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <source>app1:String 1c</source>
         <target>app1:String 1c</target>
       </trans-unit>
     </body>
   </file>
-  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app2">
+  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app1">
     <body>
-      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript" x-foo="bar">
+      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript" x-foo="bar" x-original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <source>app2: String 2a</source>
         <target>app2: String 2a</target>
       </trans-unit>
-      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript" x-foo="bar">
+      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript" x-foo="bar" x-original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <source>app2: String 2b</source>
         <target>app2: String 2b</target>
       </trans-unit>
@@ -119,13 +119,13 @@ exports[`xliff select extra unit information Make sure that after select, each u
 <xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
   <file original="app1" l:project="app1">
     <group id="group_1" name="cpp">
-      <unit id="app1_1" type="res:string" l:datatype="cpp" l:foo="bar">
+      <unit id="app1_1" type="res:string" l:datatype="cpp" l:foo="bar" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <segment>
           <source>app1:String 1a</source>
           <target>app1:String 1a</target>
         </segment>
       </unit>
-      <unit id="app1_2" type="res:string" l:datatype="cpp" l:foo="bar">
+      <unit id="app1_2" type="res:string" l:datatype="cpp" l:foo="bar" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <segment>
           <source>app1:String 1b</source>
           <target>app1:String 1b</target>
@@ -133,7 +133,7 @@ exports[`xliff select extra unit information Make sure that after select, each u
       </unit>
     </group>
     <group id="group_2" name="x-json">
-      <unit id="app1_3" type="res:string" l:datatype="x-json" l:foo="bar">
+      <unit id="app1_3" type="res:string" l:datatype="x-json" l:foo="bar" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <segment>
           <source>app1:String 1c</source>
           <target>app1:String 1c</target>
@@ -141,15 +141,15 @@ exports[`xliff select extra unit information Make sure that after select, each u
       </unit>
     </group>
   </file>
-  <file original="app2" l:project="app2">
+  <file original="app2" l:project="app1">
     <group id="group_3" name="javascript">
-      <unit id="app2_1" type="res:string" l:datatype="javascript" l:foo="bar">
+      <unit id="app2_1" type="res:string" l:datatype="javascript" l:foo="bar" l:original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <segment>
           <source>app2: String 2a</source>
           <target>app2: String 2a</target>
         </segment>
       </unit>
-      <unit id="app2_2" type="res:string" l:datatype="javascript" l:foo="bar">
+      <unit id="app2_2" type="res:string" l:datatype="javascript" l:foo="bar" l:original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <segment>
           <source>app2: String 2b</source>
           <target>app2: String 2b</target>
@@ -165,15 +165,15 @@ exports[`xliff select extra unit information Make sure that after select, each u
 <xliff version="1.0">
   <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">
     <body>
-      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-foo="bar">
+      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-foo="bar" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <source>app1:String 1a</source>
         <target>app1:String 1a</target>
       </trans-unit>
-      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-foo="bar">
+      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-foo="bar" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <source>app1:String 1b</source>
         <target>app1:String 1b</target>
       </trans-unit>
-      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-foo="bar">
+      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-foo="bar" x-original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <source>app1:String 1c</source>
         <target>app1:String 1c</target>
       </trans-unit>
@@ -181,11 +181,11 @@ exports[`xliff select extra unit information Make sure that after select, each u
   </file>
   <file original="app2" source-language="en-KR" target-language="en-US" product-name="app2">
     <body>
-      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript" x-foo="bar">
+      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript" x-foo="bar" x-original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <source>app2: String 2a</source>
         <target>app2: String 2a</target>
       </trans-unit>
-      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript" x-foo="bar">
+      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript" x-foo="bar" x-original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <source>app2: String 2b</source>
         <target>app2: String 2b</target>
       </trans-unit>
@@ -199,13 +199,13 @@ exports[`xliff select extra unit information Make sure that after select, each u
 <xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
   <file original="app1" l:project="app1">
     <group id="group_1" name="cpp">
-      <unit id="app1_1" type="res:string" l:datatype="cpp" l:foo="bar">
+      <unit id="app1_1" type="res:string" l:datatype="cpp" l:foo="bar" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <segment>
           <source>app1:String 1a</source>
           <target>app1:String 1a</target>
         </segment>
       </unit>
-      <unit id="app1_2" type="res:string" l:datatype="cpp" l:foo="bar">
+      <unit id="app1_2" type="res:string" l:datatype="cpp" l:foo="bar" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <segment>
           <source>app1:String 1b</source>
           <target>app1:String 1b</target>
@@ -213,7 +213,7 @@ exports[`xliff select extra unit information Make sure that after select, each u
       </unit>
     </group>
     <group id="group_2" name="x-json">
-      <unit id="app1_3" type="res:string" l:datatype="x-json" l:foo="bar">
+      <unit id="app1_3" type="res:string" l:datatype="x-json" l:foo="bar" l:original-file="test/testfiles/xliff20/app1/en-US.xliff">
         <segment>
           <source>app1:String 1c</source>
           <target>app1:String 1c</target>
@@ -223,13 +223,13 @@ exports[`xliff select extra unit information Make sure that after select, each u
   </file>
   <file original="app2" l:project="app2">
     <group id="group_3" name="javascript">
-      <unit id="app2_1" type="res:string" l:datatype="javascript" l:foo="bar">
+      <unit id="app2_1" type="res:string" l:datatype="javascript" l:foo="bar" l:original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <segment>
           <source>app2: String 2a</source>
           <target>app2: String 2a</target>
         </segment>
       </unit>
-      <unit id="app2_2" type="res:string" l:datatype="javascript" l:foo="bar">
+      <unit id="app2_2" type="res:string" l:datatype="javascript" l:foo="bar" l:original-file="test/testfiles/xliff20/app2/en-US.xliff">
         <segment>
           <source>app2: String 2b</source>
           <target>app2: String 2b</target>

--- a/packages/loctool/test/__snapshots__/XliffSelect.test.js.snap
+++ b/packages/loctool/test/__snapshots__/XliffSelect.test.js.snap
@@ -1,0 +1,241 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`xliff select extra unit information Make sure that after select, each file has the project id set correctly with xliff v1 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.0">
+  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">
+    <body>
+      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp">
+        <source>app1:String 1a</source>
+        <target>app1:String 1a</target>
+      </trans-unit>
+      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp">
+        <source>app1:String 1b</source>
+        <target>app1:String 1b</target>
+      </trans-unit>
+      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json">
+        <source>app1:String 1c</source>
+        <target>app1:String 1c</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app2">
+    <body>
+      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript">
+        <source>app2: String 2a</source>
+        <target>app2: String 2a</target>
+      </trans-unit>
+      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript">
+        <source>app2: String 2b</source>
+        <target>app2: String 2b</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`xliff select extra unit information Make sure that after select, each file has the project id set correctly with xliff v2 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file original="app1" l:project="app1">
+    <group id="group_1" name="cpp">
+      <unit id="app1_1" type="res:string" l:datatype="cpp">
+        <segment>
+          <source>app1:String 1a</source>
+          <target>app1:String 1a</target>
+        </segment>
+      </unit>
+      <unit id="app1_2" type="res:string" l:datatype="cpp">
+        <segment>
+          <source>app1:String 1b</source>
+          <target>app1:String 1b</target>
+        </segment>
+      </unit>
+    </group>
+    <group id="group_2" name="x-json">
+      <unit id="app1_3" type="res:string" l:datatype="x-json">
+        <segment>
+          <source>app1:String 1c</source>
+          <target>app1:String 1c</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+  <file original="app2" l:project="app2">
+    <group id="group_3" name="javascript">
+      <unit id="app2_1" type="res:string" l:datatype="javascript">
+        <segment>
+          <source>app2: String 2a</source>
+          <target>app2: String 2a</target>
+        </segment>
+      </unit>
+      <unit id="app2_2" type="res:string" l:datatype="javascript">
+        <segment>
+          <source>app2: String 2b</source>
+          <target>app2: String 2b</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>"
+`;
+
+exports[`xliff select extra unit information Make sure that after select, each unit has the extended attributes and each file has the project id set correctly with xliff v1 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.0">
+  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">
+    <body>
+      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-foo="bar">
+        <source>app1:String 1a</source>
+        <target>app1:String 1a</target>
+      </trans-unit>
+      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-foo="bar">
+        <source>app1:String 1b</source>
+        <target>app1:String 1b</target>
+      </trans-unit>
+      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-foo="bar">
+        <source>app1:String 1c</source>
+        <target>app1:String 1c</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app2">
+    <body>
+      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript" x-foo="bar">
+        <source>app2: String 2a</source>
+        <target>app2: String 2a</target>
+      </trans-unit>
+      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript" x-foo="bar">
+        <source>app2: String 2b</source>
+        <target>app2: String 2b</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`xliff select extra unit information Make sure that after select, each unit has the extended attributes and each file has the project id set correctly with xliff v2 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file original="app1" l:project="app1">
+    <group id="group_1" name="cpp">
+      <unit id="app1_1" type="res:string" l:datatype="cpp" l:foo="bar">
+        <segment>
+          <source>app1:String 1a</source>
+          <target>app1:String 1a</target>
+        </segment>
+      </unit>
+      <unit id="app1_2" type="res:string" l:datatype="cpp" l:foo="bar">
+        <segment>
+          <source>app1:String 1b</source>
+          <target>app1:String 1b</target>
+        </segment>
+      </unit>
+    </group>
+    <group id="group_2" name="x-json">
+      <unit id="app1_3" type="res:string" l:datatype="x-json" l:foo="bar">
+        <segment>
+          <source>app1:String 1c</source>
+          <target>app1:String 1c</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+  <file original="app2" l:project="app2">
+    <group id="group_3" name="javascript">
+      <unit id="app2_1" type="res:string" l:datatype="javascript" l:foo="bar">
+        <segment>
+          <source>app2: String 2a</source>
+          <target>app2: String 2a</target>
+        </segment>
+      </unit>
+      <unit id="app2_2" type="res:string" l:datatype="javascript" l:foo="bar">
+        <segment>
+          <source>app2: String 2b</source>
+          <target>app2: String 2b</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>"
+`;
+
+exports[`xliff select extra unit information Make sure that after select, each unit has the extended attributes set correctly with xliff v1 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.0">
+  <file original="app1" source-language="en-KR" target-language="en-US" product-name="app1">
+    <body>
+      <trans-unit id="app1_1" resname="app1:String 1a" restype="string" datatype="cpp" x-foo="bar">
+        <source>app1:String 1a</source>
+        <target>app1:String 1a</target>
+      </trans-unit>
+      <trans-unit id="app1_2" resname="app1:String 1b" restype="string" datatype="cpp" x-foo="bar">
+        <source>app1:String 1b</source>
+        <target>app1:String 1b</target>
+      </trans-unit>
+      <trans-unit id="app1_3" resname="app1:String 1c" restype="string" datatype="x-json" x-foo="bar">
+        <source>app1:String 1c</source>
+        <target>app1:String 1c</target>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="app2" source-language="en-KR" target-language="en-US" product-name="app2">
+    <body>
+      <trans-unit id="app2_1" resname="app2: String 2a" restype="string" datatype="javascript" x-foo="bar">
+        <source>app2: String 2a</source>
+        <target>app2: String 2a</target>
+      </trans-unit>
+      <trans-unit id="app2_2" resname="app2: String 2b" restype="string" datatype="javascript" x-foo="bar">
+        <source>app2: String 2b</source>
+        <target>app2: String 2b</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"
+`;
+
+exports[`xliff select extra unit information Make sure that after select, each unit has the extended attributes set correctly with xliff v2 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file original="app1" l:project="app1">
+    <group id="group_1" name="cpp">
+      <unit id="app1_1" type="res:string" l:datatype="cpp" l:foo="bar">
+        <segment>
+          <source>app1:String 1a</source>
+          <target>app1:String 1a</target>
+        </segment>
+      </unit>
+      <unit id="app1_2" type="res:string" l:datatype="cpp" l:foo="bar">
+        <segment>
+          <source>app1:String 1b</source>
+          <target>app1:String 1b</target>
+        </segment>
+      </unit>
+    </group>
+    <group id="group_2" name="x-json">
+      <unit id="app1_3" type="res:string" l:datatype="x-json" l:foo="bar">
+        <segment>
+          <source>app1:String 1c</source>
+          <target>app1:String 1c</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+  <file original="app2" l:project="app2">
+    <group id="group_3" name="javascript">
+      <unit id="app2_1" type="res:string" l:datatype="javascript" l:foo="bar">
+        <segment>
+          <source>app2: String 2a</source>
+          <target>app2: String 2a</target>
+        </segment>
+      </unit>
+      <unit id="app2_2" type="res:string" l:datatype="javascript" l:foo="bar">
+        <segment>
+          <source>app2: String 2b</source>
+          <target>app2: String 2b</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>"
+`;

--- a/packages/loctool/test/log4js.json
+++ b/packages/loctool/test/log4js.json
@@ -1,6 +1,6 @@
 {
     "appenders": {
-        "default": { 
+        "default": {
             "type": "console",
             "layout": {
                 "type": "pattern",

--- a/packages/loctool/test/testfiles/java/t1.java
+++ b/packages/loctool/test/testfiles/java/t1.java
@@ -2,10 +2,10 @@ package java;
 
 class t1 {
 	public t1() {}
-	
+
 	public void tester() {
 		RB.getString("This is a test");
-		
+
 		RB.getString("This is a test with a unique id", "id1");
 	}
 }


### PR DESCRIPTION
- added support for extended attributes (ie. custom attributes) on the translation unit element in the xliff
    - support for both xliff v1 and v2
    - for reading AND writing xliff files
- added support for specifying the project name and extended attributes on the command line
    - project name gets added to translation units during the select
- modified the select code to add in the extended attributes and project name to the units that are selected
- the select code also adds and extra extended attribute that gives the original file name where the translation unit was selected from
- added support for extended attributes to the ilib-xliff library as well