### PR TITLE
[ilib-loctool-po] [ilib-po] Correct Polish plural category handling for PO files

### DIFF
--- a/.changeset/thick-elephant-ears.md
+++ b/.changeset/thick-elephant-ears.md
@@ -1,0 +1,6 @@
+---
+"ilib-po": patch
+---
+
+- Fixed handling of Polish plural categories in PO files. The categories `one`, `few`, and `many` are now correctly recognized and processed.
+- Added logic to backfill the `many` plural category with the `other` category for Polish when `many` is missing in the incoming `Resource` object.

--- a/.changeset/thick-pianos-grab.md
+++ b/.changeset/thick-pianos-grab.md
@@ -1,0 +1,6 @@
+---
+"ilib-loctool-po": patch
+---
+
+- Improved support for Polish plural categories in PO file localization. The `many` category is now correctly handled and backfilled with the `other` category when missing.
+- Enhanced PO file parsing to ensure accurate recognition of Polish plural forms (`one`, `few`, `many`).

--- a/packages/ilib-loctool-po/POFile.js
+++ b/packages/ilib-loctool-po/POFile.js
@@ -835,8 +835,10 @@ POFile.prototype.localize = function(translations, locales) {
  * @returns {Object|undefined} A plural object with appropriate categories for the target locale.
  */
 POFile.prototype.getTargetStrings = function(translationPlurals, targetLocale) {
-    switch (targetLocale) {
-        case "pl-PL":
+    const language = new Locale(targetLocale).getLanguage();
+
+    switch (language) {
+        case "pl":
             /*
              * In Polish (`pl`), the plural forms defined in CLDR are: "one", "few", "many", and "other".
              * However, PO files (due to GNU gettext limitations) only support "one", "few", and "many".

--- a/packages/ilib-loctool-po/pluralforms.json
+++ b/packages/ilib-loctool-po/pluralforms.json
@@ -256,7 +256,7 @@
         "categories": [
             "one",
             "few",
-            "other"
+            "many"
         ]
     },
     "sl": {

--- a/packages/ilib-loctool-po/test/POFile.test.js
+++ b/packages/ilib-loctool-po/test/POFile.test.js
@@ -405,6 +405,91 @@ describe("pofile", function() {
         expect(resources[0].getTargetLocale()).toBe("de-DE");
     });
 
+    test("POFile correctly parses plural strings with Polish translations", function() {
+        var file = new POFile({
+            project: p,
+            locale: "pl-PL",
+            type: t
+        });
+
+        file.parse(`
+            msgid "Your item"
+            msgid_plural "Selected items"
+            msgstr[0] "ONE Twój element"
+            msgstr[1] "FEW Wybrane elementy"
+            msgstr[2] "MANY Wybrane elementy"
+        `);
+
+        const set = file.getTranslationSet();
+        const resources = set.getAll();
+        const resource = resources[0];
+        const type = resource.getType();
+        const key = resource.getKey();
+        const sourceLocale = resource.getSourceLocale();
+        const targetLocale = resource.getTargetLocale();
+
+        expect(set.size()).toBe(1);
+        expect(resources.length).toBe(1);
+        expect(key).toBe("Your item");
+        expect(type).toBe("plural");
+        expect(sourceLocale).toBe("en-US");
+        expect(targetLocale).toBe("pl-PL");
+    });
+
+    test("POFile correctly recognizes the Polish plural categories in PO files as 'one', 'few', and 'many'.", function() {
+        var file = new POFile({
+            project: p,
+            locale: "pl-PL",
+            type: t
+        });
+
+        file.parse(`
+            msgid "Your item"
+            msgid_plural "Selected items"
+            msgstr[0] "ONE Twój element"
+            msgstr[1] "FEW Wybrane elementy"
+            msgstr[2] "MANY Wybrane elementy"
+        `);
+
+        const resource = file.getTranslationSet().getAll()[0];
+        const sourcePlurals = resource.getSourcePlurals();
+        const targetPlurals = resource.getTargetPlurals();
+
+        expect(sourcePlurals).toEqual({
+            one: "Your item",
+            other: "Selected items"
+        });
+        expect(targetPlurals).toEqual(expect.objectContaining({
+            one: "ONE Twój element",
+            few: "FEW Wybrane elementy",
+            many: "MANY Wybrane elementy"
+        }))
+    });
+
+    test("POFile correctly backfills the plural 'other' category with the 'many' category for the Polish language", function() {
+        var file = new POFile({
+            project: p,
+            locale: "pl-PL",
+            type: t
+        });
+
+        file.parse(`
+            msgid "Your item"
+            msgid_plural "Selected items"
+            msgstr[0] "ONE Twój element"
+            msgstr[1] "FEW Wybrane elementy"
+            msgstr[2] "MANY Wybrane elementy"
+        `);
+
+        const resource = file.getTranslationSet().getAll()[0];
+        const targetPlurals = resource.getTargetPlurals();
+
+        expect(targetPlurals.many).toEqual("MANY Wybrane elementy");
+        expect(targetPlurals.other).toEqual(targetPlurals.many);
+    });
+
+
+
     test("POFileParsePluralStringWithEmptyTranslations", function() {
         expect.assertions(11);
 

--- a/packages/ilib-loctool-po/test/POFile.test.js
+++ b/packages/ilib-loctool-po/test/POFile.test.js
@@ -489,42 +489,6 @@ describe("pofile", function() {
         expect(targetPlurals.other).toEqual(targetPlurals.many);
     });
 
-    // test("POFile backfills the plural 'many' category with the 'other' category for Polish language, when 'many' is missing in incoming Resource object", () => {
-    //     const generator = new Generator({
-    //         pathName: "./po/messages.po",
-    //         targetLocale: "pl-PL",
-    //         contextInKey: false,
-    //         datatype: "po",
-    //         projectName: "foo"
-    //     });
-    //
-    //     const translations = new TranslationSet();
-    //     translations.add(new ResourcePlural({
-    //         project: "foo",
-    //         key: "Your item",
-    //         source: {
-    //             one: "Your item",
-    //             other: "Selected items"
-    //         },
-    //         sourceLocale: "en-US",
-    //         target: {
-    //             one: "ONE",
-    //             few: "FEW",
-    //             other: "OTHER - should be used as a backfill for MANY"
-    //         },
-    //         targetLocale: "pl-PL",
-    //         datatype: "po"
-    //     }));
-    //
-    //     const actual = generator.generate(translations);
-    //     const expected =
-    //         'msgstr[0] "ONE"\n' +
-    //         'msgstr[1] "FEW"\n' +
-    //         'msgstr[2] "OTHER - should be used as a backfill for MANY"\n';
-    //
-    //     expect(actual).toContain(expected);
-    // })
-
     test("POFileParsePluralStringWithEmptyTranslations", function() {
         expect.assertions(11);
 
@@ -3584,7 +3548,7 @@ describe("pofile", function() {
         expect(content).toBe(expected);
     });
 
-    test("POFile write uses the plural 'many' category for Polish when it exists in Resource object", function() {
+    test("POFile `write` uses the plural 'many' category for Polish when it exists in Resource object", function() {
         const base = path.dirname(module.id);
         const xdd = path.join(base, "testfiles/po/pl-PL.po");
 
@@ -3623,7 +3587,7 @@ describe("pofile", function() {
         expect(content).toContain(expected);
     });
 
-    test("POFile write backfills the plural 'many' category with the plural 'other' category for Polish when 'many' is missing in Resource object", function() {
+    test("POFile `write` backfills the plural 'many' category with the plural 'other' category for Polish when 'many' is missing in Resource object", function() {
         const base = path.dirname(module.id);
         const testFile = path.join(base, "testfiles/po/pl-PL.po");
 

--- a/packages/ilib-po/src/Generator.ts
+++ b/packages/ilib-po/src/Generator.ts
@@ -17,11 +17,11 @@
  * limitations under the License.
  */
 
-import { TranslationSet } from "ilib-tools-common";
+import {TranslationSet} from "ilib-tools-common";
 import Locale from "ilib-locale";
 
-import { Comments, CommentType, escapeQuotes, makeKey } from "./utils";
-import { pluralForms, PluralForm } from "./pluralforms";
+import {Comments, CommentType, escapeQuotes, makeKey, Plural, PluralCategory} from "./utils";
+import {pluralForms, PluralForm} from "./pluralforms";
 
 /** Options for the generator constructor */
 export interface GeneratorOptions {
@@ -45,7 +45,7 @@ export interface GeneratorOptions {
     /**
      * The default data type of the resources
      */
-     datatype?: string;
+    datatype?: string;
 
     /**
      * The name of the project that the resources belong to
@@ -210,14 +210,33 @@ class Generator {
                 output += `msgid_plural "${escapeQuotes(sourcePlurals.other)}"\n`;
                 if (translatedPlurals) {
                     this.plurals.categories.forEach((category, index) => {
-                        const translation =
-                            translatedPlurals[category] !== sourcePlurals[category] ? translatedPlurals[category] : "";
+                        const translation = this.getTranslation(translatedPlurals, sourcePlurals, category);
                         output += `msgstr[${index}] "${escapeQuotes(translation)}"\n`;
                     });
                 }
             }
         }
         return output;
+    }
+
+    /**
+     * @private
+     *
+     * Get the translation for a specific plural category.
+     *
+     * @param translatedPlurals the translated plurals
+     * @param sourcePlurals the source plurals
+     * @param category the plural category as defined in the pluralForms.ts
+     *
+     * @returns the translation for the specified plural category
+     */
+    private getTranslation(translatedPlurals: Plural, sourcePlurals: Plural, category: PluralCategory): string {
+        switch (category) {
+            case "one":
+                return translatedPlurals[category] === sourcePlurals[category] ? "" : translatedPlurals[category] ?? "";
+            default:
+                return translatedPlurals[category] === sourcePlurals["other"] ? "" : translatedPlurals[category] ?? "";
+        }
     }
 }
 

--- a/packages/ilib-po/src/Generator.ts
+++ b/packages/ilib-po/src/Generator.ts
@@ -209,8 +209,10 @@ class Generator {
 
                 output += `msgid_plural "${escapeQuotes(sourcePlurals.other)}"\n`;
                 if (translatedPlurals) {
+                    const translated = this.backfillTranslations(translatedPlurals, this.targetLocale);
+
                     this.plurals.categories.forEach((category, index) => {
-                        const translation = this.getTranslationOrEmptyString(translatedPlurals, sourcePlurals, category);
+                        const translation = this.getTranslationOrEmptyString(translated, sourcePlurals, category);
                         output += `msgstr[${index}] "${escapeQuotes(translation)}"\n`;
                     });
                 }
@@ -226,17 +228,51 @@ class Generator {
      * If the translation is the same as the source, returns an empty string.
      * Otherwise, returns the translation.
      *
-     * @param translatedPlurals the translated plurals
-     * @param sourcePlurals the source plurals
-     * @param category the plural category as defined in the pluralForms.ts
+     * @param translatedPlurals - The object containing the translated plural forms.
+     * @param sourcePlurals - The object containing the original source plural forms.
+     * @param category - The plural category to retrieve (e.g., "one", "few", "many", "other") as defined in the pluralForms.
      *
      * @returns empty string if the translation is the same as the source, otherwise returns the translation
+     * @returns The translated string for the given category, or an empty string if the translation matches the source value.
      */
     private getTranslationOrEmptyString(translatedPlurals: Plural, sourcePlurals: Plural, category: PluralCategory): string {
         const sourceValue = sourcePlurals[category] ?? sourcePlurals["other"];
         const targetValue = translatedPlurals[category] ?? "";
 
         return sourceValue === targetValue ? "" : targetValue;
+    }
+
+    /**
+     * Ensures that plural translations for Polish include the "many" category.
+     *
+     * Due to inconsistencies in how plural forms are handled in some Resource sources
+     * (such as PO files from other loctool plugins, legacy translations, or results
+     * from format conversion via "loctool convert"), Resource instances may not have
+     * the "many" plural category for Polish.
+     *
+     * This method backfills the "many" plural category using the value from "other"
+     * if "many" is missing and the target locale is Polish.
+     *
+     * This is necessary because the correct plural categories for Polish are:
+     * "one", "few", "many", and "other". Failing to include "many" can result in
+     * malformed or incorrect PO file outputs, particularly when generating msgstr[2].
+     *
+     * @param translatedPlurals - The pluralized translation strings object.
+     * @param targetLocale - The locale of the target language, used to determine if special handling is required.
+     * @returns A new `Plural` object with "many" backfilled from "other" when applicable.
+     */
+    private backfillTranslations(translatedPlurals: Plural, targetLocale: Locale): Plural {
+        const language = targetLocale.getLanguage();
+        const isManyMissing = translatedPlurals?.many === undefined;
+
+        if(language === "pl" && isManyMissing) {
+            return {
+                ...translatedPlurals,
+                many: translatedPlurals.other
+            };
+        }
+
+        return translatedPlurals;
     }
 }
 

--- a/packages/ilib-po/src/Generator.ts
+++ b/packages/ilib-po/src/Generator.ts
@@ -210,7 +210,7 @@ class Generator {
                 output += `msgid_plural "${escapeQuotes(sourcePlurals.other)}"\n`;
                 if (translatedPlurals) {
                     this.plurals.categories.forEach((category, index) => {
-                        const translation = this.getTranslation(translatedPlurals, sourcePlurals, category);
+                        const translation = this.getTranslationOrEmptyString(translatedPlurals, sourcePlurals, category);
                         output += `msgstr[${index}] "${escapeQuotes(translation)}"\n`;
                     });
                 }
@@ -222,21 +222,21 @@ class Generator {
     /**
      * @private
      *
-     * Get the translation for a specific plural category.
+     * Gets the translation for a given plural category.
+     * If the translation is the same as the source, returns an empty string.
+     * Otherwise, returns the translation.
      *
      * @param translatedPlurals the translated plurals
      * @param sourcePlurals the source plurals
      * @param category the plural category as defined in the pluralForms.ts
      *
-     * @returns the translation for the specified plural category
+     * @returns empty string if the translation is the same as the source, otherwise returns the translation
      */
-    private getTranslation(translatedPlurals: Plural, sourcePlurals: Plural, category: PluralCategory): string {
-        switch (category) {
-            case "one":
-                return translatedPlurals[category] === sourcePlurals[category] ? "" : translatedPlurals[category] ?? "";
-            default:
-                return translatedPlurals[category] === sourcePlurals["other"] ? "" : translatedPlurals[category] ?? "";
-        }
+    private getTranslationOrEmptyString(translatedPlurals: Plural, sourcePlurals: Plural, category: PluralCategory): string {
+        const sourceValue = sourcePlurals[category] ?? sourcePlurals["other"];
+        const targetValue = translatedPlurals[category] ?? "";
+
+        return sourceValue === targetValue ? "" : targetValue;
     }
 }
 

--- a/packages/ilib-po/src/Parser.ts
+++ b/packages/ilib-po/src/Parser.ts
@@ -298,7 +298,7 @@ class Parser {
                                         context: context,
                                         index: resourceIndex++,
                                         targetLocale: translationPlurals && this.targetLocale?.getSpec(),
-                                        targetStrings: this.getTargetStrings(translationPlurals)
+                                        targetStrings: this.mapTranslations(translationPlurals)
                                     });
                                 } else if (type === "array") {
                                     // if there is an existing array resource with the same key, use that one
@@ -484,7 +484,7 @@ class Parser {
      *                              This may be `undefined` if no plural translations are provided.
      * @returns A plural object with appropriate categories for the target locale.
      */
-    private getTargetStrings(translationPlurals: Plural | undefined) {
+    private mapTranslations(translationPlurals: Plural | undefined) {
         const language = this.targetLocale?.getLanguage() ?? "en";
 
         switch (language) {

--- a/packages/ilib-po/src/pluralforms.ts
+++ b/packages/ilib-po/src/pluralforms.ts
@@ -286,7 +286,7 @@ export const pluralForms: PluralForms = {
         "categories" : [
             "one",
             "few",
-            "other"
+            "many"
         ]
     },
     "sl" : {

--- a/packages/ilib-po/test/Generator.test.ts
+++ b/packages/ilib-po/test/Generator.test.ts
@@ -927,12 +927,6 @@ describe("generator", () => {
                 other: "Selected items"
             },
             sourceLocale: "en-US",
-            target: {
-                one: "Your item",
-                few: "Selected items",
-                many: "Selected items",
-                other: "Selected items",
-            },
             targetLocale: "pl-PL",
             datatype: "po"
         }));

--- a/packages/ilib-po/test/Generator.test.ts
+++ b/packages/ilib-po/test/Generator.test.ts
@@ -909,6 +909,137 @@ describe("generator", () => {
         expect(actual).toBe(expected);
     });
 
+    test("Generator generates empty plural translations for Polish with correct number of categories", () => {
+        const generator = new Generator({
+            pathName: "./po/messages.po",
+            targetLocale: "pl-PL",
+            contextInKey: false,
+            datatype: "po",
+            projectName: "foo"
+        });
+
+        const translations = new TranslationSet();
+        translations.add(new ResourcePlural({
+            project: "foo",
+            key: "Your item",
+            source: {
+                one: "Your item",
+                other: "Selected items"
+            },
+            sourceLocale: "en-US",
+            target: {
+                one: "Your item",
+                few: "Selected items",
+                many: "Selected items",
+                other: "Selected items",
+            },
+            targetLocale: "pl-PL",
+            datatype: "po"
+        }));
+
+        const actual = generator.generate(translations);
+        const expected =
+            'msgid "Your item"\n' +
+            'msgid_plural "Selected items"\n' +
+            'msgstr[0] ""\n' +
+            'msgstr[1] ""\n' +
+            'msgstr[2] ""\n';
+
+        expect(actual).toContain(expected);
+    });
+
+    test("Generator generates correct plural translations for Polish with all plural forms except 'other' populated", () => {
+        const generator = new Generator({
+            pathName: "./po/messages.po",
+            targetLocale: "pl-PL",
+            contextInKey: false,
+            datatype: "po",
+            projectName: "foo"
+        });
+
+        const translations = new TranslationSet();
+        translations.add(new ResourcePlural({
+            project: "foo",
+            key: "Your item",
+            source: {
+                one: "Your item",
+                other: "Selected items"
+            },
+            sourceLocale: "en-US",
+            target: {
+                one: "ONE Twój element",
+                few: "FEW Wybrane elementy",
+                many: "MANY Wybrane elementy",
+                other: "OTHER Wybrane elementy"
+            },
+            targetLocale: "pl-PL",
+            datatype: "po"
+        }));
+
+        const actual = generator.generate(translations);
+        const expected =
+            'msgid "Your item"\n' +
+            'msgid_plural "Selected items"\n' +
+            'msgstr[0] "ONE Twój element"\n' +
+            'msgstr[1] "FEW Wybrane elementy"\n' +
+            'msgstr[2] "MANY Wybrane elementy"\n';
+
+        expect(actual).toContain(expected);
+        expect(actual).not.toContain("OTHER Wybrane elementy")
+    });
+
+    test("Generates a file with both singular and plural entries for Polish with all plural forms except 'other'", () => {
+        const generator = new Generator({
+            pathName: "./po/messages.po",
+            targetLocale: "pl-PL",
+            contextInKey: false,
+            datatype: "po",
+            projectName: "foo"
+        });
+
+        const set = new TranslationSet();
+        set.add(new ResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "string 1",
+            sourceLocale: "en-US",
+            target: "słowo 1",
+            targetLocale: "pl-PL",
+            datatype: "po"
+        }));
+        set.add(new ResourcePlural({
+            project: "foo",
+            key: "one string",
+            source: {
+                "one": "one string",
+                "other": "{$count} strings"
+            },
+            sourceLocale: "en-US",
+            target: {
+                "one": "{$count} słowo",
+                "few": "{$count} słowa",
+                "many": "{$count} słów",
+                "other": "{$count} OTHER słowa"
+            },
+            targetLocale: "pl-PL",
+            datatype: "po"
+        }));
+
+        const actual = generator.generate(set);
+        const expected =
+            'msgid "string 1"\n' +
+            'msgstr "słowo 1"\n' +
+            '\n' +
+            'msgid "one string"\n' +
+            'msgid_plural "{$count} strings"\n' +
+            'msgstr[0] "{$count} słowo"\n' +
+            'msgstr[1] "{$count} słowa"\n' +
+            'msgstr[2] "{$count} słów"\n';
+
+        expect(actual).toContain(expected);
+        expect(actual).not.toContain("{$count} OTHER słowa");
+    })
+
     test("Generator generate text plurals with translations", () => {
         expect.assertions(2);
 

--- a/packages/ilib-po/test/Parser.test.ts
+++ b/packages/ilib-po/test/Parser.test.ts
@@ -404,6 +404,66 @@ describe("parser", () => {
         expect(resources[0].getTargetLocale()).toBe("ru-RU");
     });
 
+    test("Parser correctly parses all Polish plural categories from PO file and recognizes them as 'one', 'few', and 'many'", () => {
+        const parser = new Parser({
+            pathName: "./testfiles/po/messages.po",
+            sourceLocale: "en-US",
+            targetLocale: "pl-PL",
+            projectName: "boo",
+            datatype: "po"
+        });
+
+        const set = parser.parse(`
+            msgid "Your item"
+            msgid_plural "Selected items"
+            msgstr[0] "ONE Twój element"
+            msgstr[1] "FEW Wybrane elementy"
+            msgstr[2] "MANY Wybrane elementy"
+        `);
+
+        const resource = set.getAll()[0];
+        const type = resource.getType();
+        const locale = resource.getTargetLocale();
+        const source = resource.getSource();
+        const target = resource.getTarget();
+
+        expect(type).toBe("plural");
+        expect(locale).toBe("pl-PL");
+        expect(source).toEqual({
+            one: "Your item",
+            other: "Selected items"
+        })
+        expect(target).toEqual(expect.objectContaining({
+            one: "ONE Twój element",
+            few: "FEW Wybrane elementy",
+            many: "MANY Wybrane elementy"
+        }))
+    });
+
+    test("Parser backfills the plural 'other' category with the 'many' category for the Polish language", () => {
+        const parser = new Parser({
+            pathName: "./testfiles/po/messages.po",
+            sourceLocale: "en-US",
+            targetLocale: "pl-PL",
+            projectName: "boo",
+            datatype: "po"
+        });
+
+        const set = parser.parse(`
+            msgid "Your item"
+            msgid_plural "Selected items"
+            msgstr[0] "ONE Twój element"
+            msgstr[1] "FEW Wybrane elementy"
+            msgstr[2] "MANY Wybrane elementy"
+        `);
+
+        const resource = set.getAll()[0];
+        const target = resource.getTarget();
+
+        expect(target.many).toEqual("MANY Wybrane elementy");
+        expect(target.other).toEqual(target.many);
+    });
+
     test("ParserParsePluralStringWithTranslations With Locale From Header", () => {
         expect.assertions(13);
 

--- a/packages/loctool/test/ResourcePlural.test.js
+++ b/packages/loctool/test/ResourcePlural.test.js
@@ -54,6 +54,7 @@ describe("resourceplural", function() {
                 "many": "This is the many case"
             }
         });
+
         expect(rp).toBeTruthy();
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
         version: file:packages/ilib-assemble/test/ilib-mock/ilib-mock-1.0.0.tgz
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -219,7 +219,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -319,7 +319,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -419,7 +419,7 @@ importers:
         version: link:../ilib-data-utils
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -498,7 +498,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -561,7 +561,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jest-mock:
         specifier: ^29.7.0
         version: 29.7.0
@@ -607,7 +607,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -847,7 +847,7 @@ importers:
         version: 2.0.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -878,7 +878,7 @@ importers:
         version: 2.0.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -936,7 +936,7 @@ importers:
         version: 10.7.6
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -1012,7 +1012,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jest-mock:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1103,7 +1103,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jest-mock:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1252,7 +1252,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1271,7 +1271,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1287,7 +1287,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1345,7 +1345,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1419,7 +1419,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1444,7 +1444,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1457,7 +1457,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1476,7 +1476,7 @@ importers:
         version: link:../ilib-loctool-json
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1492,7 +1492,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1511,7 +1511,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1533,7 +1533,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1546,7 +1546,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1571,7 +1571,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1584,7 +1584,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1600,7 +1600,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1616,7 +1616,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1629,7 +1629,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1654,7 +1654,7 @@ importers:
         version: link:../ilib-loctool-javascript-resource
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1667,7 +1667,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1689,7 +1689,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1702,7 +1702,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1715,7 +1715,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1737,7 +1737,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1756,7 +1756,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1775,7 +1775,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1791,7 +1791,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       loctool:
         specifier: workspace:^
         version: link:../loctool
@@ -1895,7 +1895,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -1980,7 +1980,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.3
         version: 4.0.4
@@ -2043,7 +2043,7 @@ importers:
         version: 5.0.0(coveralls@3.1.1)(typescript@5.6.3)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -2125,7 +2125,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
+        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -2210,7 +2210,7 @@ importers:
         version: 5.2.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jest-mock:
         specifier: ^29.7.0
         version: 29.7.0
@@ -2328,7 +2328,7 @@ importers:
         version: file:packages/loctool/test/ilib-loctool-mock-resource/ilib-loctool-mock-resource-1.0.0.tgz
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
 
   packages/message-accumulator:
     dependencies:
@@ -2380,7 +2380,7 @@ importers:
         version: 5.0.0(coveralls@3.1.1)(typescript@5.6.3)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -2417,7 +2417,7 @@ importers:
         version: link:../ilib-tools-common
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.2
         version: 4.0.4
@@ -11063,21 +11063,6 @@ snapshots:
       pify: 4.0.1
       safe-buffer: 5.2.1
 
-  create-jest@29.7.0:
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-jest@29.7.0(@types/node@12.20.55):
     dependencies:
       '@jest/types': 29.6.3
@@ -11115,6 +11100,21 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@20.17.4)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  create-jest@29.7.0(@types/node@22.10.2):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.10.2)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -12069,15 +12069,6 @@ snapshots:
       chalk: 4.1.2
       hooker: 0.2.3
       jshint: 2.13.6
-
-  grunt-contrib-nodeunit@4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      nodeunit-x: 0.15.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
-    transitivePeerDependencies:
-      - flow-remove-types
-      - supports-color
-      - ts-node
-      - typescript
 
   grunt-contrib-nodeunit@4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
@@ -13120,16 +13111,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(node-notifier@8.0.2):
+  jest-cli@29.7.0(@types/node@22.10.2)(node-notifier@8.0.2):
     dependencies:
       '@jest/core': 29.7.0(node-notifier@8.0.2)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0
+      create-jest: 29.7.0(@types/node@22.10.2)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0
+      jest-config: 29.7.0(@types/node@22.10.2)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -13140,34 +13131,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  jest-config@29.7.0:
-    dependencies:
-      '@babel/core': 7.26.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@12.20.55):
     dependencies:
@@ -13559,12 +13522,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(node-notifier@8.0.2):
+  jest@29.7.0(@types/node@22.10.2)(node-notifier@8.0.2):
     dependencies:
       '@jest/core': 29.7.0(node-notifier@8.0.2)
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(node-notifier@8.0.2)
+      jest-cli: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -14385,16 +14348,6 @@ snapshots:
       nodemailer-smtp-transport: 2.7.2
       socks: 1.1.9
     optional: true
-
-  nodeunit-x@0.15.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      ejs: 3.1.10
-      tap: 15.2.3(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
-    transitivePeerDependencies:
-      - flow-remove-types
-      - supports-color
-      - ts-node
-      - typescript
 
   nodeunit-x@0.15.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
@@ -15909,36 +15862,6 @@ snapshots:
       typescript: 3.9.10
       write-file-atomic: 2.4.3
       yapool: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  tap@15.2.3(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      chokidar: 3.6.0
-      coveralls: 3.1.1
-      findit: 2.0.0
-      foreground-child: 2.0.0
-      fs-exists-cached: 1.0.0
-      glob: 7.2.3
-      isexe: 2.0.0
-      istanbul-lib-processinfo: 2.0.3
-      jackspeak: 1.4.2
-      libtap: 1.4.1
-      minipass: 3.3.6
-      mkdirp: 1.0.4
-      nyc: 15.1.0
-      opener: 1.5.2
-      rimraf: 3.0.2
-      signal-exit: 3.0.7
-      source-map-support: 0.5.21
-      tap-mocha-reporter: 5.0.4
-      tap-parser: 11.0.2
-      tap-yaml: 1.0.2
-      tcompare: 5.0.7
-      which: 2.0.2
-    optionalDependencies:
-      ts-node: 8.10.2(typescript@3.9.10)
-      typescript: 3.9.10
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
This PR fixes the handling of plural categories for Polish in the intermediate PO file and PO file. 

Initially, we had the following **incorrect mapping in the PO file**:
```
msgstr[0] → one

msgstr[1] → few

msgstr[2] → other
```
This mapping was incorrect because, as per the CLDR documentation, `msgstr[2]` corresponds to the `many` category, not `other`. Due to this misinterpretation, we were incorrectly assigning Polish plural categories.

This was hidden by fallback behavior in ICU/react-intl, where a missing `many` would fall back to `other,` giving seemingly correct results even though `many` was never explicitly defined.

The misunderstanding was compounded by the fact that GNU gettext supports only three plural categories (`one`, `few`, `many`) and does not support `other`, while the CLDR defines four categories (`one`, `few`, `many`, and `other`). 
</br>

**With this PR, we’ve corrected the mapping to:**
```
msgstr[0] → one

msgstr[1] → few

msgstr[2] → many (previously mistakenly thought to be other)
```

Additionally, to maintain ICU/react-intl compatibility, we backfill the `other` category using the `many` translation when generating the translated file. This ensures the correct plural forms are utilized without breaking existing workflows.


**Key Changes:**

- Properly maps Polish plural categories to CLDR and GNU gettext standards.

- Corrected mapping where `msgstr[2]` should be `many`, not `other`.
 
- Ensured ResourcePlural objects for Polish include the `other` category (backfilled from `many`).
 
- Updated PO file serialization to omit the `other` category for Polish due to GNU gettext limitations.
👇 
**These changes ensure accurate plural handling for Polish translations across CLDR, GNU gettext and ICU.**

Additionally, some Resource instances may lack the `many` plural category for Polish due to inconsistencies from other `loctool` plugins, legacy translations, or format conversions (e.g., via `loctool convert`). 
👇 
**This PR introduces backward-compatible logic** to populate the missing "many" category from "other" for Polish, ensuring valid plural form handling.