### PR TITLE
ilib-lint, ilib-lint-common: Update json formatter output so we can do better stats

### DIFF
--- a/.changeset/sharp-dragons-tickle.md
+++ b/.changeset/sharp-dragons-tickle.md
@@ -1,0 +1,12 @@
+---
+"ilib-lint": minor
+---
+
+- Added ability to count source words
+  - Added support from FileStats for source words
+  - Added support to most results to output the locale of the result
+    so we can slice and dice by locale if necessary
+  - Added tests for XliffParser to make sure it is producing the right
+    file stats
+  - Added support in the json formatter for source words and for
+    target locales of results

--- a/.changeset/yellow-otters-crash.md
+++ b/.changeset/yellow-otters-crash.md
@@ -1,0 +1,6 @@
+---
+"ilib-lint-common": minor
+---
+
+- Added support for counting the number of source words
+  in the FileStats object

--- a/packages/ilib-lint-common/src/FileStats.js
+++ b/packages/ilib-lint-common/src/FileStats.js
@@ -1,7 +1,7 @@
 /*
  * FileStats.js - statistics about a file or a number of files
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023, 2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ class FileStats {
     /** @private */ lines = 0;
     /** @private */ bytes = 0;
     /** @private */ modules = 0;
+    /** @private */ words = 0;  // number of source words
 
     /**
      * Construct an file statistics instance. Each count in the
@@ -42,11 +43,14 @@ class FileStats {
      * by the programming language and may mean things like functions
      * or classes. It is up to the parser for that programming language
      * to count these.
+     * @param {Number} [options.words] the number of source words in those
+     * source files. This is not the same as the number of words in the
+     * target strings.
      * @constructor
      */
     constructor(options) {
         if (!options) return;
-        ["files", "lines", "bytes", "modules"].forEach(property => {
+        ["files", "lines", "bytes", "modules", "words"].forEach(property => {
             if (typeof(options[property]) === 'number') this[property] = options[property];
         });
     }
@@ -60,7 +64,7 @@ class FileStats {
      */
     addStats(stats) {
         if (!stats || typeof(stats) !== 'object' || !(stats instanceof FileStats)) return this;
-        ["files", "lines", "bytes", "modules"].forEach(property => {
+        ["files", "lines", "bytes", "modules", "words"].forEach(property => {
             this[property] += stats[property] || 0;
         });
         if (typeof(stats.files) !== 'number') {
@@ -81,7 +85,7 @@ class FileStats {
     /**
      * Add the given amount to the number of files.
      * @param {Number} num the amount to add
-     * @returns {FileStats} the current instance
+     * @returns {FileStats} the current instance so you can chain the calls
      */
     addFiles(num) {
         if (typeof(num) !== 'number') return this;
@@ -102,7 +106,7 @@ class FileStats {
      * Add the given amount to the number of lines.
      *
      * @param {Number} num the amount to add
-     * @returns {FileStats} the current instance
+     * @returns {FileStats} the current instance so you can chain the calls
      */
     addLines(num) {
         if (typeof(num) !== 'number') return this;
@@ -123,7 +127,7 @@ class FileStats {
      * Add the given amount to the number of bytes.
      *
      * @param {Number} num the amount to add
-     * @returns {FileStats} the current instance
+     * @returns {FileStats} the current instance so that you can chain calls
      */
     addBytes(num) {
         if (typeof(num) !== 'number') return this;
@@ -149,11 +153,34 @@ class FileStats {
      * Add the given amount to the number of modules.
      *
      * @param {Number} num the amount to add
-     * @returns {FileStats} the current instance
+     * @returns {FileStats} the current instance so that you can chain calls
      */
     addModules(num) {
         if (typeof(num) !== 'number') return this;
         this.modules += num;
+        return this;
+    }
+
+    /**
+     * Get the number of source words being counted. This is not the same
+     * as the number of words in the target strings, which varies by
+     * locale and is not counted here.
+     *
+     * @returns {Number} the number of source words being counted
+     */
+    getWords() {
+        return this.words;
+    }
+
+    /**
+     * Add the given amount to the number of source words.
+     *
+     * @param {Number} num the amount to add
+     * @returns {FileStats} the current instance so that you can chain calls
+     */
+    addWords(num) {
+        if (typeof(num) !== 'number') return this;
+        this.words += num;
         return this;
     }
 }

--- a/packages/ilib-lint-common/test/FileStats.test.js
+++ b/packages/ilib-lint-common/test/FileStats.test.js
@@ -21,74 +21,85 @@ import FileStats from '../src/FileStats.js';
 
 describe("testFileStats", () => {
     test("FileStatsEmpty", () => {
-        expect.assertions(4);
+        expect.assertions(5);
 
         const stats = new FileStats();
         expect(stats.getFiles()).toBe(1);
         expect(stats.getLines()).toBe(0);
         expect(stats.getBytes()).toBe(0);
         expect(stats.getModules()).toBe(0);
+        expect(stats.getWords()).toBe(0);
     });
 
     test("FileStatsWithOptions", () => {
-        expect.assertions(4);
+        expect.assertions(5);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 7853,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(7853);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
     });
 
     test("FileStatsWithNonObjectOptions", () => {
-        expect.assertions(4);
+        expect.assertions(5);
 
+        // @ts-ignore
         const stats = new FileStats(true);
         expect(stats.getFiles()).toBe(1);
         expect(stats.getLines()).toBe(0);
         expect(stats.getBytes()).toBe(0);
         expect(stats.getModules()).toBe(0);
+        expect(stats.getWords()).toBe(0);
     });
 
     test("FileStatsWithOptionsThatAreNotNumbers", () => {
-        expect.assertions(3);
+        expect.assertions(5);
 
         const stats = new FileStats({
             files: true,
             lines: [1],
             bytes: foo => { return "bar"; },
-            modules: "asdf"
+            modules: "asdf",
+            words: null
         });
         expect(stats.getFiles()).toBe(1);
         expect(stats.getLines()).toBe(0);
+        expect(stats.getBytes()).toBe(0);
         expect(stats.getModules()).toBe(0);
+        expect(stats.getWords()).toBe(0);
     });
 
     test("FileStatsAddStats", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats1 = new FileStats({
             files: 4,
             lines: 456,
             bytes: 32452,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
         const stats2 = new FileStats({
             files: 8,
             lines: 44,
             bytes: 94343,
-            modules: 8
+            modules: 8,
+            words: 5678
         });
 
         expect(stats1.getFiles()).toBe(4);
         expect(stats1.getLines()).toBe(456);
         expect(stats1.getBytes()).toBe(32452);
         expect(stats1.getModules()).toBe(2);
+        expect(stats1.getWords()).toBe(1234);
 
         stats1.addStats(stats2);
 
@@ -96,23 +107,26 @@ describe("testFileStats", () => {
         expect(stats1.getLines()).toBe(500);
         expect(stats1.getBytes()).toBe(126795);
         expect(stats1.getModules()).toBe(10);
+        expect(stats1.getWords()).toBe(6912);
     });
 
     test("FileStatsAddStatsToEmptyObj", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats1 = new FileStats();
         const stats2 = new FileStats({
             files: 8,
             lines: 44,
             bytes: 94343,
-            modules: 8
+            modules: 8,
+            words: 5678
         });
 
         expect(stats1.getFiles()).toBe(1);
         expect(stats1.getLines()).toBe(0);
         expect(stats1.getBytes()).toBe(0);
         expect(stats1.getModules()).toBe(0);
+        expect(stats1.getWords()).toBe(0);
 
         stats1.addStats(stats2);
 
@@ -120,68 +134,79 @@ describe("testFileStats", () => {
         expect(stats1.getLines()).toBe(44);
         expect(stats1.getBytes()).toBe(94343);
         expect(stats1.getModules()).toBe(8);
+        expect(stats1.getWords()).toBe(5678);
     });
 
     test("FileStatsAddStatsNotAStatsInstance1", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 3423,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
 
+        // @ts-ignore
         stats.addStats({x:2});
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
     });
 
     test("FileStatsAddStatsNotAStatsInstance2", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 3423,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
 
+        // @ts-ignore
         stats.addStats(true);
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
     });
 
     test("FileStatsAddFiles", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 3423,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
 
         stats.addFiles(23);
 
@@ -189,45 +214,52 @@ describe("testFileStats", () => {
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
     });
 
     test("FileStatsAddFilesNotNumber", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 3423,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
 
+        // @ts-ignore
         stats.addFiles("asdf");
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
     });
 
     test("FileStatsAddLines", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 3423,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
 
         stats.addLines(23);
 
@@ -235,45 +267,52 @@ describe("testFileStats", () => {
         expect(stats.getLines()).toBe(479);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
     });
 
     test("FileStatsAddLinesNotNumber", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 3423,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
 
+        // @ts-ignore
         stats.addLines("asdf");
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
     });
 
     test("FileStatsAddBytes", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 3423,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
 
         stats.addBytes(23);
 
@@ -281,45 +320,52 @@ describe("testFileStats", () => {
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3446);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
     });
 
     test("FileStatsAddBytesNotNumber", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 3423,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
 
+        // @ts-ignore
         stats.addBytes("asdf");
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
     });
 
     test("FileStatsAddModules", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 3423,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
 
         stats.addModules(23);
 
@@ -327,29 +373,88 @@ describe("testFileStats", () => {
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(25);
+        expect(stats.getWords()).toBe(1234);
     });
 
     test("FileStatsAddModulesNotNumber", () => {
-        expect.assertions(8);
+        expect.assertions(10);
 
         const stats = new FileStats({
             files: 4,
             lines: 456,
             bytes: 3423,
-            modules: 2
+            modules: 2,
+            words: 1234
         });
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
 
+        // @ts-ignore
         stats.addModules("asdf");
 
         expect(stats.getFiles()).toBe(4);
         expect(stats.getLines()).toBe(456);
         expect(stats.getBytes()).toBe(3423);
         expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
     });
+
+    test("FileStatsAddWords", () => {
+        expect.assertions(10);
+
+        const stats = new FileStats({
+            files: 4,
+            lines: 456,
+            bytes: 3423,
+            modules: 2,
+            words: 1234
+        });
+
+        expect(stats.getFiles()).toBe(4);
+        expect(stats.getLines()).toBe(456);
+        expect(stats.getBytes()).toBe(3423);
+        expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
+
+        stats.addWords(23);
+
+        expect(stats.getFiles()).toBe(4);
+        expect(stats.getLines()).toBe(456);
+        expect(stats.getBytes()).toBe(3423);
+        expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1257);
+    });
+
+    test("FileStatsAddWordsNotNumber", () => {
+        expect.assertions(10);
+
+        const stats = new FileStats({
+            files: 4,
+            lines: 456,
+            bytes: 3423,
+            modules: 2,
+            words: 1234
+        });
+
+        expect(stats.getFiles()).toBe(4);
+        expect(stats.getLines()).toBe(456);
+        expect(stats.getBytes()).toBe(3423);
+        expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
+
+        // @ts-ignore
+        stats.addWords("asdf");
+
+        expect(stats.getFiles()).toBe(4);
+        expect(stats.getLines()).toBe(456);
+        expect(stats.getBytes()).toBe(3423);
+        expect(stats.getModules()).toBe(2);
+        expect(stats.getWords()).toBe(1234);
+    });
+
 });
 

--- a/packages/ilib-lint/src/formatters/JsonFormatter.js
+++ b/packages/ilib-lint/src/formatters/JsonFormatter.js
@@ -70,7 +70,8 @@ class JsonFormatter extends Formatter {
                 return {
                     pathName: result.pathName,
                     rule: result.rule.getName(),
-                    severity: result.severity
+                    severity: result.severity,
+                    locale: result.locale
                 };
             })
         };
@@ -86,6 +87,7 @@ class JsonFormatter extends Formatter {
             obj[name].stats.lines = fileStats.lines;
             obj[name].stats.bytes = fileStats.bytes;
             obj[name].stats.modules = fileStats.modules;
+            obj[name].stats.words = fileStats.words;
         }
 
         // write as compressed JSON to save space;

--- a/packages/ilib-lint/src/rules/ResourceCompleteness.js
+++ b/packages/ilib-lint/src/rules/ResourceCompleteness.js
@@ -66,7 +66,8 @@ class ResourceCompleteness extends ResourceRule {
             return new Result({
                 ...resultMetaProps,
                 severity: "error",
-                description: "Missing target string in resource"
+                description: "Missing target string in resource",
+                locale: resource.getTargetLocale()
             });
         }
         // if there's an extra translation string for which there is no source, just warn
@@ -75,7 +76,8 @@ class ResourceCompleteness extends ResourceRule {
                 ...resultMetaProps,
                 severity: "warning",
                 description: "Extra target string in resource",
-                highlight: `<e0>${target}</e0>`
+                highlight: `<e0>${target}</e0>`,
+                locale: resource.getTargetLocale()
             });
         }
         else return /* no error */;

--- a/packages/ilib-lint/src/rules/ResourceRule.js
+++ b/packages/ilib-lint/src/rules/ResourceRule.js
@@ -25,7 +25,7 @@ import { Rule } from 'ilib-lint-common';
 class ResourceRule extends Rule {
     /**
      * Construct a new resource checker rule.
-*
+     *
      * If a subclass defines a property "locales" with the
      * value being a Set of locale lang-specs, then this
      * class will ensure that the rule is only applied to

--- a/packages/ilib-lint/src/rules/ResourceSourceICUPluralCategories.js
+++ b/packages/ilib-lint/src/rules/ResourceSourceICUPluralCategories.js
@@ -1,7 +1,7 @@
 /*
  * ResourceSourceICUPluralCategories.js
  *
- * Copyright © 2023-2024 JEDLSoft
+ * Copyright © 2023-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,6 +116,7 @@ export class ResourceSourceICUPluralCategories extends ResourceRule {
                             highlight: `<e0>${this.substringForLocation(source, partialResult.location)}</e0>`,
                             severity: partialResult.severity,
                             description: partialResult.description,
+                            locale: resource.getTargetLocale(),
                         })
                 )
         );

--- a/packages/ilib-lint/src/rules/ResourceSourceICUPluralParams.js
+++ b/packages/ilib-lint/src/rules/ResourceSourceICUPluralParams.js
@@ -1,7 +1,7 @@
 /*
  * ResourceSourceICUPluralParams.js
  *
- * Copyright © 2023-2024 JEDLSoft
+ * Copyright © 2023-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,6 +117,7 @@ export class ResourceSourceICUPluralParams extends ResourceRule {
                         highlight: `<e0>${this.substringForLocation(source, partialResult.location)}</e0>`,
                         severity: partialResult.severity,
                         description: partialResult.description,
+                        locale: resource.getTargetLocale(),
                     });
                 }
                 return undefined;

--- a/packages/ilib-lint/src/rules/ResourceSourceICUPluralSyntax.js
+++ b/packages/ilib-lint/src/rules/ResourceSourceICUPluralSyntax.js
@@ -1,7 +1,7 @@
 /*
  * ResourceSourceICUPluralSyntax.js
  *
- * Copyright © 2023-2024 JEDLSoft
+ * Copyright © 2023-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ export class ResourceSourceICUPluralSyntax extends ResourceRule {
                 id: resource.getKey(),
                 pathName: file,
                 lineNumber,
+                locale: resource.getSourceLocale(),
             });
         }
         return undefined;

--- a/packages/ilib-lint/src/rules/ResourceSourceICUUnexplainedParams.js
+++ b/packages/ilib-lint/src/rules/ResourceSourceICUUnexplainedParams.js
@@ -1,7 +1,7 @@
 /*
  * ResourceSourceICUUnexplainedParams.js
  *
- * Copyright © 2023-2024 JEDLSoft
+ * Copyright © 2023-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,7 +136,8 @@ export class ResourceSourceICUUnexplainedParams extends ResourceRule {
                     source: source,
                     severity: "warning",
                     description: `Replacement parameter "${name}" is not mentioned in the string's comment for translators.`,
-                    highlight: this.highlightLocation(source, location)
+                    highlight: this.highlightLocation(source, location),
+                    locale: resource.getTargetLocale()
                 })
         );
     }

--- a/packages/ilib-lint/src/rules/SourceRegexpChecker.js
+++ b/packages/ilib-lint/src/rules/SourceRegexpChecker.js
@@ -1,7 +1,7 @@
 /*
  * SourceRegexpChecker.js - rule to check if regexps match in the source
  *
- * Copyright © 2023-2024 JEDLSoft
+ * Copyright © 2023-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,8 @@ class SourceRegexpChecker extends Rule {
                 pathName: ir.getSourceFile().getPath(),
                 highlight: snippet,
                 description: this.note.replace(/\{matchString\}/g, match[0]),
-                lineNumber
+                lineNumber,
+                locale: ir.getSourceFile().sourceLocale || this.sourceLocale
             }));
             match = re.exec(src);
         }

--- a/packages/ilib-lint/test/ResourceSourceICUPluralSyntax.test.js
+++ b/packages/ilib-lint/test/ResourceSourceICUPluralSyntax.test.js
@@ -118,7 +118,8 @@ describe("testResourceSourceICUPluralSyntax", () => {
             source: '{count, plural, one {{This is singular} other {This is plural}}',
             highlight: '{count, plural, one {<e0>{This </e0>is singular} other {This is plural}}',
             rule,
-            pathName: "a/b/c.xliff"
+            pathName: "a/b/c.xliff",
+            locale: "en-US"
         });
         expect(result).toStrictEqual(expected);
     });
@@ -147,7 +148,8 @@ describe("testResourceSourceICUPluralSyntax", () => {
             source: '{count, plural, one {This is singular} other {This is plural}',
             highlight: '<e0>{count, plural, one {This is singular} other {This is plural}</e0>',
             rule,
-            pathName: "a/b/c.xliff"
+            pathName: "a/b/c.xliff",
+            locale: "en-US"
         });
         expect(result).toStrictEqual(expected);
     });
@@ -176,7 +178,8 @@ describe("testResourceSourceICUPluralSyntax", () => {
             source: '{count, plural, one {This is singular}}',
             highlight: '{count, plural, one {This is singular}<e0></e0>}',
             rule,
-            pathName: "a/b/c.xliff"
+            pathName: "a/b/c.xliff",
+            locale: "en-US"
         });
         expect(result).toStrictEqual(expected);
     });
@@ -247,7 +250,8 @@ describe("testResourceSourceICUPluralSyntax", () => {
             highlight: 'The file is located in {count, plural, one {# collection} other {# collections} visible <e0></e0>to user {name}.',
             rule,
             pathName: "a/b/c.xliff",
-            source: 'The file is located in {count, plural, one {# collection} other {# collections} visible to user {name}.'
+            source: 'The file is located in {count, plural, one {# collection} other {# collections} visible to user {name}.',
+            locale: "en-US"
         });
         expect(result).toStrictEqual(expected);
     });

--- a/packages/ilib-lint/test/XliffParser.test.js
+++ b/packages/ilib-lint/test/XliffParser.test.js
@@ -1,7 +1,7 @@
 /*
  * XliffParser.test.js - test the built-in XliffParser plugin
  *
- * Copyright © 2024 JEDLSoft
+ * Copyright © 2024-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,5 +114,26 @@ describe("test the XliffParser plugin", () => {
         expect(() => {
             xp.parse(sourceFile);
         }).toThrow();
+    });
+
+    test("Parse a regular xliff file and return the correct file stats", () => {
+        expect.assertions(9);
+
+        const xp = new XliffParser();
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+
+        const ir = xp.parse(sourceFile);
+        expect(ir).toBeTruthy();
+        expect(ir.length).toBe(1);
+        expect(ir[0] instanceof IntermediateRepresentation).toBeTruthy();
+
+        const stats = ir[0].getStats();
+        expect(stats).toBeTruthy();
+        expect(stats?.getFiles()).toBe(1);
+        expect(stats?.getLines()).toBe(12);
+        expect(stats?.getBytes()).toBe(9);
+        expect(stats?.getModules()).toBe(1);
+        expect(stats?.getWords()).toBe(2);
     });
 });

--- a/packages/ilib-lint/test/formatters/JsonFormatter.test.js
+++ b/packages/ilib-lint/test/formatters/JsonFormatter.test.js
@@ -37,11 +37,12 @@ describe('JsonFormatter', () => {
                     pathName: "test.txt",
                     rule: getTestRule(),
                     severity: "error",
-                    source: "test"
+                    source: "test",
+                    locale: "en-US"
                 })
             ],
             resultStats: undefined,
-            expected: `{"ios-app":{"stats":{},"results":[{"pathName":"test.txt","rule":"testRule","severity":"error"}]}}`+"\n"
+            expected: `{"ios-app":{"stats":{},"results":[{"pathName":"test.txt","rule":"testRule","severity":"error","locale":"en-US"}]}}`+"\n"
         },
         {
             testName: "format a single result with stats",
@@ -55,7 +56,8 @@ describe('JsonFormatter', () => {
                     pathName: "test.txt",
                     rule: getTestRule(),
                     severity: "error",
-                    source: "test"
+                    source: "test",
+                    locale: "de-DE"
                 })
             ],
             resultStats: {
@@ -63,7 +65,7 @@ describe('JsonFormatter', () => {
                 warnings: 0,
                 suggestions: 0
             },
-            expected:`{"ios-app":{"stats":{"errors":1,"warnings":0,"suggestions":0},"results":[{"pathName":"test.txt","rule":"testRule","severity":"error"}]}}`+"\n"
+            expected:`{"ios-app":{"stats":{"errors":1,"warnings":0,"suggestions":0},"results":[{"pathName":"test.txt","rule":"testRule","severity":"error","locale":"de-DE"}]}}`+"\n"
         },
         {
             testName: "format a single result with file stats",
@@ -77,16 +79,18 @@ describe('JsonFormatter', () => {
                     pathName: "test.txt",
                     rule: getTestRule(),
                     severity: "error",
-                    source: "test"
+                    source: "test",
+                    locale: "fr-FR"
                 })
             ],
             fileStats: {
                 files: 1,
                 lines: 10,
                 bytes: 100,
-                modules: 1
+                modules: 1,
+                words: 50
             },
-            expected:`{"ios-app":{"stats":{"files":1,"lines":10,"bytes":100,"modules":1},"results":[{"pathName":"test.txt","rule":"testRule","severity":"error"}]}}`+"\n"
+            expected:`{"ios-app":{"stats":{"files":1,"lines":10,"bytes":100,"modules":1,"words":50},"results":[{"pathName":"test.txt","rule":"testRule","severity":"error","locale":"fr-FR"}]}}`+"\n"
         },
         {
             testName: "format a single result with file and result stats",
@@ -100,7 +104,8 @@ describe('JsonFormatter', () => {
                     pathName: "test.txt",
                     rule: getTestRule(),
                     severity: "error",
-                    source: "test"
+                    source: "test",
+                    locale: "es-ES"
                 })
             ],
             resultStats: {
@@ -112,9 +117,10 @@ describe('JsonFormatter', () => {
                 files: 1,
                 lines: 10,
                 bytes: 100,
-                modules: 1
+                modules: 1,
+                words: 50
             },
-            expected:`{"ios-app":{"stats":{"errors":1,"warnings":0,"suggestions":0,"files":1,"lines":10,"bytes":100,"modules":1},"results":[{"pathName":"test.txt","rule":"testRule","severity":"error"}]}}`+"\n"
+            expected:`{"ios-app":{"stats":{"errors":1,"warnings":0,"suggestions":0,"files":1,"lines":10,"bytes":100,"modules":1,"words":50},"results":[{"pathName":"test.txt","rule":"testRule","severity":"error","locale":"es-ES"}]}}`+"\n"
         },
         {
             testName: "format multiple results",
@@ -128,7 +134,8 @@ describe('JsonFormatter', () => {
                     pathName: "test.txt",
                     rule: getTestRule(),
                     severity: "error",
-                    source: "test"
+                    source: "test",
+                    locale: "en-US"
                 }),
                 new Result({
                     description: "Another description for testing purposes",
@@ -138,10 +145,11 @@ describe('JsonFormatter', () => {
                     pathName: "test2.txt",
                     rule: getTestRule(),
                     severity: "warning",
-                    source: "test"
+                    source: "test",
+                    locale: "en-US"
                 })
             ],
-            expected:`{"ios-app":{"stats":{},"results":[{"pathName":"test.txt","rule":"testRule","severity":"error"},{"pathName":"test2.txt","rule":"testRule","severity":"warning"}]}}`+"\n"
+            expected:`{"ios-app":{"stats":{},"results":[{"pathName":"test.txt","rule":"testRule","severity":"error","locale":"en-US"},{"pathName":"test2.txt","rule":"testRule","severity":"warning","locale":"en-US"}]}}`+"\n"
         },
         {
             testName: "format multiple results with stats",


### PR DESCRIPTION
- ilib-lint-common: Added support for counting the number of source words in the FileStats object
    - modules is already used as number of resources in the XliffParser, so we don't need to change anything there
- ilib-lint: Added ability to count source words
    - Added support from FileStats for source words
    - Added support to most results to output the locale of the result so we can slice and dice by locale if necessary
    - Added tests for XliffParser to make sure it is producing the right file stats
    - Added support in the json formatter for source words and for target locales of results