### PR TITLE
ilib-lint: Added auto-fix for two rules: quote style and no space between single-byte chars and double-byte punctuation

### DIFF
--- a/.changeset/lazy-pears-prove.md
+++ b/.changeset/lazy-pears-prove.md
@@ -1,0 +1,13 @@
+---
+"ilib-lint": minor
+---
+
+- Implement fix for quote style rule
+  - only fixes quotes which exist in the target but are wrong. It cannot
+    fix missing quotes because it doesn't know where to put them.
+  - quote chars can be separated from the text by a non-breaking space
+    (French)
+  - can deal with Japanese properly too. ie. Only primary quotes, no
+    secondary, but also [square brackets] are accepted as quotes.
+- Added fix for a declarative rule resource-no-space-between-double-and-single-byte-character
+  - the extra spaces are removed

--- a/.changeset/lazy-pears-prove.md
+++ b/.changeset/lazy-pears-prove.md
@@ -3,8 +3,9 @@
 ---
 
 - Implement fix for quote style rule
-  - only fixes quotes which exist in the target but are wrong. It cannot
-    fix missing quotes because it doesn't know where to put them.
+  - only fixes quotes which exist in the target but are not the right
+    ones for the target locale. It cannot fix missing quotes because
+    it doesn't know where to put them.
   - quote chars can be separated from the text by a non-breaking space
     (French)
   - can deal with Japanese properly too. ie. Only primary quotes, no

--- a/packages/ilib-lint/src/plugins/BuiltinPlugin.js
+++ b/packages/ilib-lint/src/plugins/BuiltinPlugin.js
@@ -115,7 +115,11 @@ export const regexRules = [
         regexps: [ "[\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]\\s+[\\x00-\\x20\\x30-\\x39\\x41-\\x5A\\x61-\\x7A\\x8A\\x8C\\x8E\\x9A\\x9C\\x9E\\x9F\\xC0-\\xD6\\xD8-\\xF6\\xF8-\\xFF]|[\\x00-\\x20\\x30-\\x39\\x41-\\x5A\\x61-\\x7A\\x8A\\x8C\\x8E\\x9A\\x9C\\x9E\\x9F\\xC0-\\xD6\\xD8-\\xF6\\xF8-\\xFF]\\s+[\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]" ],
         link: "https://github.com/iLib-js/ilib-mono/blob/main/packages/ilib-lint/docs/resource-no-space-between-double-and-single-byte-character.md",
         severity: "warning",
-        locales: "ja"
+        locales: "ja",
+        fixes: [
+            { search: "([\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF])\\s+", replace: "$1" },
+            { search: "\\s+([\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF])", replace: "$1" }
+        ]
     },
     {
         type: "resource-target",

--- a/packages/ilib-lint/src/rules/ResourceQuoteStyle.js
+++ b/packages/ilib-lint/src/rules/ResourceQuoteStyle.js
@@ -147,23 +147,38 @@ class ResourceQuoteStyle extends ResourceRule {
         // verify that corresponding quote style is present in target
         // otherwise, construct regexps to pinpoint violation positions
         // (for highlighting purposes)
+        let nonQuoteStartChars = regExps.target.nonQuoteChars;
+        let nonQuoteEndChars = regExps.target.nonQuoteChars;
+        let nonQuoteStartCharsAlt = regExps.target.nonQuoteCharsAlt;
+        let nonQuoteEndCharsAlt = regExps.target.nonQuoteCharsAlt;
+        if (locale === "ja-JP") {
+            // Japanese has a special case where the quotes are different
+            nonQuoteStartChars = nonQuoteStartChars.replace(/』/g, "");
+            nonQuoteEndChars = nonQuoteEndChars.replace(/『/g, "");
+            nonQuoteStartCharsAlt = nonQuoteStartCharsAlt.replace(/』/g, "");
+            nonQuoteEndCharsAlt = nonQuoteEndCharsAlt.replace(/『/g, "");
+        }
+
+        // in the regular expressions below, [\u00A0\u202F\u2060\u3000] is used to
+        // match the all types of Unicode non-breaking spaces which are used in some
+        // locales to separate the quote from the text.
         let startQuote, endQuote;
         if (sourceStyle.ascii) {
             if (regExps.target.quotesAll.test(tar)) return;
-            startQuote = new RegExp(`(^|\\W)([${regExps.target.nonQuoteChars}'])([\\p{Letter}\\{])`, "gu");
-            endQuote = new RegExp(`([\\p{Letter}\\}])([${regExps.target.nonQuoteChars}'])(\\W|$)`, "gu");
+            startQuote = new RegExp(`(^|\\W)(([${nonQuoteStartChars}'])[\u00A0\u202F\u2060\u3000]?)([\\p{Letter}{])`, "gu");
+            endQuote = new RegExp(`([\\p{Letter}}])([\u00A0\u202F\u2060\u3000]?([${nonQuoteEndChars}']))(\\W|$)`, "gu");
         } else if (sourceStyle.asciiAlt) {
             if (regExps.target.quotesAllAlt.test(tar)) return;
-            startQuote = new RegExp(`(^|\\W)([${regExps.target.nonQuoteCharsAlt}"])([\\p{Letter}\\{])`, "gu");
-            endQuote = new RegExp(`([\\p{Letter}\\}])([${regExps.target.nonQuoteCharsAlt}"])(\\W|$)`, "gu");
+            startQuote = new RegExp(`(^|\\W)(([${nonQuoteStartCharsAlt}"])[\u00A0\u202F\u2060\u3000]?)([\\p{Letter}{])`, "gu");
+            endQuote = new RegExp(`([\\p{Letter}}])([\u00A0\u202F\u2060\u3000]?([${nonQuoteEndCharsAlt}"]))(\\W|$)`, "gu");
         } else if (sourceStyle.native) {
             if (regExps.target.quotesNative.test(tar)) return;
-            startQuote = new RegExp(`(^|\\W)([${regExps.target.nonQuoteChars}'"])([\\p{Letter}\\{])`, "gu");
-            endQuote = new RegExp(`([\\p{Letter}\\}])([${regExps.target.nonQuoteChars}'"])(\\W|$)`, "gu");
+            startQuote = new RegExp(`(^|\\W)(([${nonQuoteStartChars}'"])[\u00A0\u202F\u2060\u3000]?)([\\p{Letter}{])`, "gu");
+            endQuote = new RegExp(`([\\p{Letter}}])([\u00A0\u202F\u2060\u3000]?([${nonQuoteEndChars}'"]))(\\W|$)`, "gu");
         } else if (sourceStyle.nativeAlt) {
             if (regExps.target.quotesNativeAlt.test(tar)) return;
-            startQuote = new RegExp(`(^|\\W)([${regExps.target.nonQuoteCharsAlt}'"])([\\p{Letter}\\{])`, "gu");
-            endQuote = new RegExp(`([\\p{Letter}\\}])([${regExps.target.nonQuoteCharsAlt}'"])(\\W|$)`, "gu");
+            startQuote = new RegExp(`(^|\\W)(([${nonQuoteStartCharsAlt}'"])[\u00A0\u202F\u2060\u3000]?)([\\p{Letter}{])`, "gu");
+            endQuote = new RegExp(`([\\p{Letter}}])([\u00A0\u202F\u2060\u3000]?([${nonQuoteEndCharsAlt}'"]))(\\W|$)`, "gu");
         } else {
             // no quotes detected in source string
             return;
@@ -172,8 +187,8 @@ class ResourceQuoteStyle extends ResourceRule {
         let highlight, description, lineNumber, fix;
         if (startQuote.test(tar) || endQuote.test(tar)) {
             highlight = tar;
-            if (startQuote) { highlight = highlight.replace(startQuote, "$1<e0>$2</e0>$3"); }
-            if (endQuote) { highlight = highlight.replace(endQuote, "$1<e1>$2</e1>$3"); }
+            if (startQuote) { highlight = highlight.replace(startQuote, "$1<e0>$2</e0>$4"); }
+            if (endQuote) { highlight = highlight.replace(endQuote, "$1<e1>$2</e1>$4"); }
             highlight = `Target: ${highlight}`;
             description = `Quote style for the locale ${locale} should be ${targetQuoteStyleExample}`;
             // create a fix to replace the quotes in the target string with the correct ones
@@ -191,7 +206,7 @@ class ResourceQuoteStyle extends ResourceRule {
             while ((match = startQuote.exec(tar)) !== null) {
                 // now that we have found a start quote, find it in the matched string so
                 // that we can get the index into that string
-                const offset = match[0].indexOf(match[2]);
+                const offset = match[0].indexOf(match[3]);
 
                 commands.push(ResourceFixer.createStringCommand(
                     match.index + offset,
@@ -203,7 +218,7 @@ class ResourceQuoteStyle extends ResourceRule {
             while ((match = endQuote.exec(tar)) !== null) {
                 // now that we have found an end quote, find it in the matched string so
                 // that we can get the index into that string
-                const offset = match[0].indexOf(match[2]);
+                const offset = match[0].indexOf(match[3]);
 
                 commands.push(ResourceFixer.createStringCommand(
                     match.index + offset,
@@ -298,32 +313,32 @@ class ResourceQuoteStyle extends ResourceRule {
 
         // now calculate regular expressions for the source string that use those quotes
         // if the source uses ASCII quotes, then the target could have ASCII or native quotes
-        const sourceQuotesNative = new RegExp(`((^|\\W)${sourceQuoteStart}\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?${sourceQuoteEnd}(\\W|$))`, "gu");
-        const sourceQuotesNativeAlt = new RegExp(`((^|\\W)${sourceQuoteStartAlt}\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?${sourceQuoteEndAlt}(\\W|$))`, "gu");
+        const sourceQuotesNative = new RegExp(`((^|\\W)${sourceQuoteStart}\\s?[\\p{Letter}{]|[\\p{Letter}}]\\s?${sourceQuoteEnd}(\\W|$))`, "gu");
+        const sourceQuotesNativeAlt = new RegExp(`((^|\\W)${sourceQuoteStartAlt}\\s?[\\p{Letter}{]|[\\p{Letter}}]\\s?${sourceQuoteEndAlt}(\\W|$))`, "gu");
 
         // now calculate the regular expressions for the target string that use quotes
         // if the source contains native quotes, then the target should also have native quotes
-        const targetQuotesNative = new RegExp(`((^|\\W)[${targetQuoteStart}]\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?[${targetQuoteEnd}](\\W|$))`, "gu");
-        const targetQuotesNativeAlt = new RegExp(`((^|\\W)[${targetQuoteStartAlt}]\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?[${targetQuoteEndAlt}](\\W|$))`, "gu");
+        const targetQuotesNative = new RegExp(`((^|\\W)[${targetQuoteStart}]\\s?[\\p{Letter}{]|[\\p{Letter}}]\\s?[${targetQuoteEnd}](\\W|$))`, "gu");
+        const targetQuotesNativeAlt = new RegExp(`((^|\\W)[${targetQuoteStartAlt}]\\s?[\\p{Letter}{]|[\\p{Letter}}]\\s?[${targetQuoteEndAlt}](\\W|$))`, "gu");
         const targetQuotesAll = this.localeOnly ?
             targetQuotesNative :
-            new RegExp(`((^|\\W)[${targetQuoteStart}${targetQuoteStartAlt}"]\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?[${targetQuoteEnd}${targetQuoteEndAlt}"](\\W|$))`, "gu");
+            new RegExp(`((^|\\W)[${targetQuoteStart}${targetQuoteStartAlt}"]\\s?[\\p{Letter}{]|[\\p{Letter}}]\\s?[${targetQuoteEnd}${targetQuoteEndAlt}"](\\W|$))`, "gu");
         const targetQuotesAllAlt = this.localeOnly ?
             targetQuotesNativeAlt :
-            new RegExp(`((^|\\W)[${targetQuoteStartAlt}']\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?[${targetQuoteEndAlt}'](\\W|$))`, "gu");
+            new RegExp(`((^|\\W)[${targetQuoteStartAlt}']\\s?[\\p{Letter}{]|[\\p{Letter}}]\\s?[${targetQuoteEndAlt}'](\\W|$))`, "gu");
 
         // the non quote chars are used to highlight errors in the target string where they are using quotes, but
         // they are the wrong type. Start with the superset of all quotes and then remove the valid ones so that
         // you are left with the wrong ones for this locale.
         const targetNonQuoteChars = quoteChars.
-                replace(sourceQuoteStart, "").
+                //replace(sourceQuoteStart, "").
                 replace(new RegExp(`[${targetQuoteStart}]`, "gu"), "").
-                replace(sourceQuoteEnd, "").
+                //replace(sourceQuoteEnd, "").
                 replace(new RegExp(`[${targetQuoteEnd}]`, "gu"), "");
         const targetNonQuoteCharsAlt = quoteChars.
-                replace(new RegExp(`[${sourceQuoteStartAlt}]`, "gu"), "").
+                //replace(new RegExp(`[${sourceQuoteStartAlt}]`, "gu"), "").
                 replace(new RegExp(`[${targetQuoteStartAlt}]`, "gu"), "").
-                replace(new RegExp(`[${sourceQuoteEndAlt}]`, "gu"), "").
+                //replace(new RegExp(`[${sourceQuoteEndAlt}]`, "gu"), "").
                 replace(new RegExp(`[${targetQuoteEndAlt}]`, "gu"), "");
 
         return {

--- a/packages/ilib-lint/src/rules/ResourceQuoteStyle.js
+++ b/packages/ilib-lint/src/rules/ResourceQuoteStyle.js
@@ -331,14 +331,10 @@ class ResourceQuoteStyle extends ResourceRule {
         // they are the wrong type. Start with the superset of all quotes and then remove the valid ones so that
         // you are left with the wrong ones for this locale.
         const targetNonQuoteChars = quoteChars.
-                //replace(sourceQuoteStart, "").
                 replace(new RegExp(`[${targetQuoteStart}]`, "gu"), "").
-                //replace(sourceQuoteEnd, "").
                 replace(new RegExp(`[${targetQuoteEnd}]`, "gu"), "");
         const targetNonQuoteCharsAlt = quoteChars.
-                //replace(new RegExp(`[${sourceQuoteStartAlt}]`, "gu"), "").
                 replace(new RegExp(`[${targetQuoteStartAlt}]`, "gu"), "").
-                //replace(new RegExp(`[${sourceQuoteEndAlt}]`, "gu"), "").
                 replace(new RegExp(`[${targetQuoteEndAlt}]`, "gu"), "");
 
         return {

--- a/packages/ilib-lint/test/ResourceQuoteStyle.test.js
+++ b/packages/ilib-lint/test/ResourceQuoteStyle.test.js
@@ -2,7 +2,7 @@
  * ResourceQuoteStyle.test.js - test the rule that checks the quote style
  * of the translations
  *
- * Copyright © 2023-2024 JEDLSoft
+ * Copyright © 2023-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
  * limitations under the License.
  */
 import { ResourceString } from 'ilib-tools-common';
+import { IntermediateRepresentation, Result, SourceFile } from 'ilib-lint-common';
 
 import ResourceQuoteStyle from "../src/rules/ResourceQuoteStyle.js";
-
-import { IntermediateRepresentation, Result, SourceFile } from 'ilib-lint-common';
+import ResourceFixer from "../src/plugins/resource/ResourceFixer.js";
 
 const sourceFile = new SourceFile("a/b/c.xliff", {});
 
@@ -94,7 +94,7 @@ describe("testResourceQuoteStyle", () => {
             file: "x"
         });
         // if the source contains native quotes, the target must too
-        const expected = new Result({
+        const expected = expect.objectContaining({
             severity: "warning",
             description: "Quote style for the locale de-DE should be „text“",
             id: "quote.test",
@@ -105,6 +105,52 @@ describe("testResourceQuoteStyle", () => {
             pathName: "x"
         });
         expect(actual).toStrictEqual(expected);
+    });
+
+    test("ResourceQuoteStyleMatchSimpleNative -- apply fix", () => {
+        expect.assertions(4);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains “quotes” in it.',
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält 'Anführungszeichen'.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "x"
+        });
+        // if the source contains native quotes, the target must too
+        const expected = expect.objectContaining({
+            severity: "warning",
+            description: "Quote style for the locale de-DE should be „text“",
+            id: "quote.test",
+            source: 'This string contains “quotes” in it.',
+            highlight: 'Target: Diese Zeichenfolge enthält <e0>\'</e0>Anführungszeichen<e1>\'</e1>.',
+            rule,
+            locale: "de-DE",
+            pathName: "x"
+        });
+        expect(actual).toStrictEqual(expected);
+        expect(actual.fix).toBeTruthy();
+
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [resource],
+            sourceFile
+        });
+        
+        const fixer = new ResourceFixer();
+        fixer.applyFixes(ir, [actual.fix]);
+
+        expect(resource.getTarget()).toBe("Diese Zeichenfolge enthält „Anführungszeichen“.");
     });
 
     test("ResourceQuoteStyleMatchSimpleNativeLocaleOnlyOptions", () => {
@@ -130,7 +176,7 @@ describe("testResourceQuoteStyle", () => {
             file: "x"
         });
         // if the source contains native quotes, the target must too
-        const expected = new Result({
+        const expected = expect.objectContaining({
             severity: "error",
             description: "Quote style for the locale de-DE should be „text“",
             id: "quote.test",
@@ -316,7 +362,7 @@ describe("testResourceQuoteStyle", () => {
 
         const rule = new ResourceQuoteStyle();
         expect(rule).toBeTruthy();
-
+debugger;
         const resource = new ResourceString({
             key: "quote.test",
             sourceLocale: "en-US",
@@ -332,7 +378,7 @@ describe("testResourceQuoteStyle", () => {
             file: "a/b/c.xliff"
         });
         // if the source contains alternate quotes, the target should still have main quotes only
-        const expected = new Result({
+        const expected = expect.objectContaining({
             severity: "warning",
             description: "Quote style for the locale ja-JP should be 「text」",
             id: "quote.test",
@@ -366,7 +412,7 @@ describe("testResourceQuoteStyle", () => {
             file: "a/b/c.xliff"
         });
         // if the source contains alternate quotes, the target should still have main quotes only
-        const expected = new Result({
+        const expected = expect.objectContaining({
             severity: "warning",
             description: "Quote style for the locale ja-JP should be 「text」",
             id: "quote.test",
@@ -423,7 +469,7 @@ describe("testResourceQuoteStyle", () => {
             file: "a/b/c.xliff"
         });
         // if the source contains ascii quotes, the target should match
-        const expected = new Result({
+        const expected = expect.objectContaining({
             severity: "warning",
             description: "Quote style for the locale de-DE should be „text“",
             id: "quote.test",
@@ -479,7 +525,7 @@ describe("testResourceQuoteStyle", () => {
             resource,
             file: "a/b"
         });
-        const expected = new Result({
+        const expected = expect.objectContaining({
             severity: "warning",
             description: "Quote style for the locale de-DE should be ‚text‘",
             id: "quote.test",
@@ -513,7 +559,7 @@ describe("testResourceQuoteStyle", () => {
             resource,
             file: "a/b"
         });
-        const expected = new Result({
+        const expected = expect.objectContaining({
             severity: "warning",
             description: "Quote style for the locale af-ZA should be ‘text’",
             id: "quote.test",
@@ -638,7 +684,7 @@ describe("testResourceQuoteStyle", () => {
 
         expect(result).toBeTruthy();
 
-        const expected = new Result({
+        const expected = expect.objectContaining({
             severity: "warning",
             description: "Quotes are missing in the target. Quote style for the locale fr-FR should be «text»",
             id: "quote.test",
@@ -673,7 +719,7 @@ describe("testResourceQuoteStyle", () => {
 
         expect(result).toBeTruthy();
 
-        const expected = new Result({
+        const expected = expect.objectContaining({
             severity: "warning",
             description: "Quotes are missing in the target. Quote style for the locale fr-FR should be «text»",
             id: "quote.test",


### PR DESCRIPTION
- Implement fix for quote style rule
  - only fixes quotes which exist in the target but are wrong. It cannot fix missing quotes because it doesn't know where to put them.
  - quote chars can be separated from the text by a non-breaking space (French)
  - can deal with Japanese properly too. ie. Only primary quotes, no secondary, but also [square brackets] are accepted as quotes.
- Added fix for a declarative rule resource-no-space-between-double-and-single-byte-character
  - the extra spaces are removed
- Fix for rule resource-dnt-terms, which was supposed to be part of this batch, is not possible because we don't know which part of the target string was translated but shouldn't be