### PR TITLE
ilib-lint: Make sure to output locale when formatting results

### DIFF
--- a/.changeset/violet-fans-think.md
+++ b/.changeset/violet-fans-think.md
@@ -6,4 +6,4 @@
   - update the Ansi Console formatter to include the locale if it is
     available in the result
   - added a test for the ansi console formatter
-  - update the config-based formatt
+  - update the config-based format

--- a/.changeset/violet-fans-think.md
+++ b/.changeset/violet-fans-think.md
@@ -1,0 +1,9 @@
+---
+"ilib-lint": minor
+---
+
+- Make sure to output locale when formatting results
+  - update the Ansi Console formatter to include the locale if it is
+    available in the result
+  - added a test for the ansi console formatter
+  - update the config-based formatt

--- a/packages/ilib-lint/src/formatters/AnsiConsoleFormatter.js
+++ b/packages/ilib-lint/src/formatters/AnsiConsoleFormatter.js
@@ -1,7 +1,7 @@
 /*
  * AnsiConsoleFormatter.js - Formats result output
  *
- * Copyright © 2022-2024 JEDLSoft
+ * Copyright © 2022-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,9 +56,12 @@ class AnsiConsoleFormatter extends Formatter {
             output += `  Source: ${result.source}\n`;
         }
         output += `  ${result.highlight}
-  Auto-fix: ${result.fix === undefined ? "unavailable" : result.fix.applied ? "\u001b[92mapplied" : "\u001B[91mnot applied"}\u001B[0m
+  Auto-fix: ${result.fix === undefined ? "unavailable" : result.fix.applied ? "\u001B[92mapplied\u001B[0m" : "\u001B[91mnot applied\u001B[0m"}
   Rule (${result.rule.getName()}): ${result.rule.getDescription()}
 `;
+        if (result.locale) {
+            output += `  Locale: ${result.locale}\n`;
+        }
 
         // output ascii terminal escape sequences
         output = output.replace(/<e\d><\/e\d>/g, "\u001B[91m␣\u001B[0m");

--- a/packages/ilib-lint/src/formatters/ConfigBasedFormatter.js
+++ b/packages/ilib-lint/src/formatters/ConfigBasedFormatter.js
@@ -1,7 +1,7 @@
 /*
  * ConfigBasedFormatter.js - Formats result output
  *
- * Copyright © 2023-2024 JEDLSoft
+ * Copyright © 2023-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,8 @@ const resultFields = [
     "description",
     "source",
     "highlight",
-    "id"
+    "id",
+    "locale"
 ];
 
 /**

--- a/packages/ilib-lint/test/formatters/AnsiConsoleFormatter.test.js
+++ b/packages/ilib-lint/test/formatters/AnsiConsoleFormatter.test.js
@@ -1,0 +1,70 @@
+/*
+ * AnsiConsoleFormatter.test.js
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Result} from 'ilib-lint-common';
+import dedent from 'dedent';
+
+import AnsiConsoleFormatter from '../../src/formatters/AnsiConsoleFormatter.js';
+import ResourceMatcher from "../../src/rules/ResourceMatcher.js";
+
+describe('Ansi Console Formatter', () => {
+    test('formatting a result with ANSI colors', () => {
+        expect.assertions(1);
+
+        const formatter = new AnsiConsoleFormatter();
+
+        const result = formatter.format(new Result({
+            description: "A description for testing purposes",
+            highlight: "This is just <e0>me</e0> testing.",
+            id: "test.id",
+            lineNumber: 123,
+            pathName: "test.txt",
+            rule: getTestRule(),
+            severity: "error",
+            source: "test",
+            locale: "de-DE"
+        }));
+
+        const esc = "\u001B";
+        const expected =
+              dedent`
+                     test.txt(123):
+                       ${esc}[91mA description for testing purposes${esc}[0m
+                       Key: test.id
+                       Source: test
+                       This is just ${esc}[91mme${esc}[0m testing.
+                       Auto-fix: unavailable
+                       Rule (testRule): Rule for testing purposes
+                       Locale: de-DE
+                       More info: https://example.com/test` + "\n";
+
+        expect(result).toBe(expected);
+    });
+});
+
+function getTestRule() {
+    return new ResourceMatcher({
+        "name": "testRule",
+        "description": "Rule for testing purposes",
+        "regexps": ["test"],
+        "note": "test",
+        "sourceLocale": "en-US",
+        "link": "https://example.com/test",
+    });
+}


### PR DESCRIPTION
- update the Ansi Console formatter to include the locale if it is available in the result
    - added a test for the ansi console formatter
- update the config-based formatter to format the locale into the template format and added tests
- this should have been done in that earlier PR I did, but somehow I updated all rules to include the locale and missed the part where you format it in the results!