### PR TITLE
loctool: deprecate xliffsDir in favor of translationsDir

### DIFF
--- a/.changeset/calm-kids-compare.md
+++ b/.changeset/calm-kids-compare.md
@@ -1,0 +1,9 @@
+---
+"loctool": patch
+---
+
+- Deprecate the xliffsDir setting to be replaced by the
+  translationsDir setting instead. The reason is that
+  this directory may now contain translations that are
+  not encoded as xliff files but in some other resource
+  file format instead!

--- a/.changeset/calm-kids-compare.md
+++ b/.changeset/calm-kids-compare.md
@@ -7,3 +7,9 @@
   this directory may now contain translations that are
   not encoded as xliff files but in some other resource
   file format instead!
+    - all users should transition to using the
+      --translationsDir command-line option and the
+      "translationsDir" property in the settings in
+      their ilib-lint-config.json file.
+    - xliffDir will be removed in the next major
+      update to loctool

--- a/packages/loctool/README.md
+++ b/packages/loctool/README.md
@@ -139,9 +139,13 @@ All paths are relative to the root of the project.
 * settings - other settings which configure this project. Some important
     settings:
     * locales - an array of target locales
-    * xliffsDir - directory containing input translation xliff files
+    * translationsDir - directory containing input translation files
+    * xliffsDir - (deprecated) old name for the translationsDir setting
+      which is still supported for backwards compatibility
+        * deprecated because the dir may now contain translated files that are not
+          xliff files!)
     * xliffsOut - where to place the output xliff files, such as
-    the "new" strings files
+      the "new" strings files
 * plugins - an array of names of plugins to use that handle various file
   types in your project. Make sure you have put these plugins as dependencies
   in your package.json. See the plugins section below for more information

--- a/packages/loctool/lib/GenerateMode.js
+++ b/packages/loctool/lib/GenerateMode.js
@@ -35,15 +35,16 @@ var logger = log4js.getLogger("loctool.lib.GenerateMode");
  *
  * @constructor
  * @param {String} sourceLocale the source locale for this set
- * @param {String} xliffsDir the directory that contains the intermediate files
+ * @param {String} translationsDir the directory that contains the intermediate files
  */
 var GenerateMode = function (options) {
     logger.trace("GenerateMode constructor called");
-    this.xliffsDir = ["."];
+    this.translationsDir = ["."];
 
     if (options) {
-        this.xliffsDir = options.xliffsDir ?
-            (ilib.isArray(options.xliffsDir) ? options.xliffsDir : [options.xliffsDir]) :
+        var transDir = options.translationsDir || options.xliffsDir;
+        this.translationsDir = transDir ?
+            (ilib.isArray(transDir) ? transDir : [transDir]) :
             ["."];
         this.settings = options.settings;
     }
@@ -61,7 +62,7 @@ var poFileFilter = /([.*][\-])?([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A
  * initialization is done
  */
 GenerateMode.prototype.init = function() {
-    var dirs = this.xliffsDir;
+    var dirs = this.translationsDir;
     var list = [];
     var fileFormat = (this.settings && this.settings.intermediateFormat) || "xliff";
     var fileFilter = fileFormat === "xliff" ? xliffFileFilter : poFileFilter;
@@ -102,12 +103,12 @@ GenerateMode.prototype.init = function() {
     }
 };
 
-GenerateMode.prototype.getXliffsDir = function() {
-    return this.xliffsDir;
+GenerateMode.prototype.getTranslationsDir = function() {
+    return this.translationsDir;
 };
 
-GenerateMode.prototype.setXliffsDir = function(dir) {
-    this.xliffsDir = ilib.isArray(dir) ? dir : [dir];
+GenerateMode.prototype.setTranslationsDir = function(dir) {
+    this.translationsDir = ilib.isArray(dir) ? dir : [dir];
 };
 
 GenerateMode.prototype.getResSize = function() {

--- a/packages/loctool/lib/LocalRepository.js
+++ b/packages/loctool/lib/LocalRepository.js
@@ -43,16 +43,17 @@ var getIntermediateFile = iff.getIntermediateFile;
  */
 var LocalRepository = function (options) {
     logger.trace("LocalRepository constructor called");
-    var xliffsDir = ["."];
+    var translationsDir = ["."];
     this.sourceLocale = "en-US";
     if (options) {
         this.sourceLocale = options.sourceLocale || "en-US";
         this.pseudoLocale = options.pseudoLocale;
-        if (options.xliffsDir) {
-            xliffsDir = ilib.isArray(options.xliffsDir) ? options.xliffsDir : [options.xliffsDir];
+        var transDir = options.translationsDir || options.xliffsDir;
+        if (transDir) {
+            translationsDir = ilib.isArray(transDir) ? transDir : [transDir];
         }
         if (options.pathName) {
-            xliffsDir.find(function(dir) {
+            translationsDir.find(function(dir) {
                 var pathName = path.join(dir, options.pathName);
                 if (fs.existsSync(pathName)) {
                     this.pathName = pathName;
@@ -62,7 +63,7 @@ var LocalRepository = function (options) {
             }.bind(this));
         }
         this.project = options.project;
-        this.xliffsDir = !this.pathName && xliffsDir;
+        this.translationsDir = !this.pathName && translationsDir;
         this.intermediateFormat = options.intermediateFormat;
     }
     this.intermediateFormat = this.intermediateFormat || "xliff";
@@ -126,12 +127,12 @@ LocalRepository.prototype.init = function(cb) {
     var fileFormat = this.intermediateFormat;
     var fileFilter = fileFormat === "xliff" ? xliffFileFilter : poFileFilter;
 
-    if (this.xliffsDir && this.xliffsDir.length > 0) {
+    if (this.translationsDir && this.translationsDir.length > 0) {
         var files = [];
         var miniMatchExpressions = getIntermediateFileExtensions().map(function(ext) {
             return "**/*." + ext;
         });
-        this.xliffsDir.forEach(function(dir) {
+        this.translationsDir.forEach(function(dir) {
             if (!fs.existsSync(dir)) {
                logger.warn("Translation dir " + dir + " does not exist.");
                return;

--- a/packages/loctool/lib/Project.js
+++ b/packages/loctool/lib/Project.js
@@ -159,9 +159,10 @@ var Project = function(options, root, settings) {
     }
 
     // where the translation xliff files are read from
-    this.xliffsDir = ilib.isArray(this.settings.xliffsDir) ? this.settings.xliffsDir.map(function(dir) {
+    var translationsDir = this.settings.translationsDir || this.settings.xliffsDir || '.';
+    this.translationsDir = ilib.isArray(translationsDir) ? translationsDir.map(function(dir) {
         return smartJoin(this.root, dir);
-    }.bind(this)) : [smartJoin(this.root, this.settings.xliffsDir || '.')];
+    }.bind(this)) : [smartJoin(this.root, translationsDir)];
 
     // where the xliff files are written to
     this.xliffsOut = smartJoin(this.root, this.settings.xliffsOut || '.');
@@ -188,9 +189,9 @@ var Project = function(options, root, settings) {
         this.db = new LocalRepository({
             sourceLocale: this.sourceLocale,
             pseudoLocale: this.pseudoLocale,
-            pathName: ((this.settings.xliffVersion !== 2) ? (path.join(this.xliffsDir[0], this.options.id + ".xliff")): undefined),
+            pathName: ((this.settings.xliffVersion !== 2) ? (path.join(this.translationsDir[0], this.options.id + ".xliff")): undefined),
             project: this,
-            xliffsDir: this.xliffsDir,
+            translationsDir: this.translationsDir,
             intermediateFormat: this.settings.intermediateFormat
         });
     }
@@ -666,7 +667,7 @@ Project.prototype.generateMode = function(cb) {
 
     var genMode = new GenerateMode({
         targetDir: this.settings.targetDir,
-        xliffsDir: this.settings.xliffsDir,
+        translationsDir: this.settings.translationsDir,
         settings: this.settings
     });
 

--- a/packages/loctool/loctool.js
+++ b/packages/loctool/loctool.js
@@ -270,7 +270,7 @@ var settings = {
     intermediateFormat: "xliff",
     nopseudo: true,
     targetDir: ".",            // target directory for all output files
-    xliffsDir: ["."],
+    translationsDir: ["."],
     xliffVersion: 1.2,
     xliffStyle: "standard",
     allowDups: true,
@@ -418,7 +418,7 @@ for (var i = 0; i < argv.length; i++) {
     } else if (val === "-x" || val === "--xliffs" || val === '-r' || val === '--translations') {
         // support the old "-x" and "--xliffs" options as well as the new "-r" and "--translations" options
         if (i+1 < argv.length && argv[i+1] && argv[i+1][0] !== "-") {
-            settings.xliffsDir = argv[++i].split(/,/g);
+            settings.translationsDir = argv[++i].split(/,/g);
         } else {
             console.error("Error: -r (--translations or -x or --xliffs) option requires a directory name argument to follow it.");
             usage();

--- a/packages/loctool/test/GenerateMode.test.js
+++ b/packages/loctool/test/GenerateMode.test.js
@@ -38,7 +38,7 @@ describe("genmodemode", function() {
     test("GenerateModeProcess", function() {
         expect.assertions(1);
         var settings = {
-            xliffsDir: "./xliffs",
+            translationsDir: "./xliffs",
             rootDir: ".",
             projectType: "sample"
         };
@@ -51,30 +51,30 @@ describe("genmodemode", function() {
 
         var genmode = new GenerateMode();
         expect(genmode).toBeTruthy();
-        expect(genmode.getXliffsDir()).toStrictEqual(["."]);
+        expect(genmode.getTranslationsDir()).toStrictEqual(["."]);
     });
     test("GenerateModeWithParams", function() {
         expect.assertions(2);
 
         var genmode = new GenerateMode({
-           xliffsDir: "./xliffs"
+           translationsDir: "./xliffs"
         });
         expect(genmode).toBeTruthy();
-        expect(genmode.getXliffsDir()).toStrictEqual(["./xliffs"]);
+        expect(genmode.getTranslationsDir()).toStrictEqual(["./xliffs"]);
     });
     test("GenerateModeSetParams", function() {
         expect.assertions(2);
 
         var genmode = new GenerateMode();
         expect(genmode).toBeTruthy();
-        genmode.setXliffsDir("./test/testfiles");
-        expect(genmode.getXliffsDir()).toStrictEqual(["./test/testfiles"]);
+        genmode.setTranslationsDir("./test/testfiles");
+        expect(genmode.getTranslationsDir()).toStrictEqual(["./test/testfiles"]);
     });
     test("GenerateModeInit", function() {
         expect.assertions(2);
 
         var genmode = new GenerateMode({
-            xliffsDir: "./test/testfiles/xliff20/app1",
+            translationsDir: "./test/testfiles/xliff20/app1",
         });
         expect(genmode).toBeTruthy();
         genmode.init();
@@ -82,6 +82,18 @@ describe("genmodemode", function() {
     });
 
     test("GenerateModeInitMultipleXliffDirs", function() {
+        expect.assertions(2);
+
+        var genmode = new GenerateMode({
+            translationsDir: ["./test/testfiles/xliff20/app1", "./test/testfiles/xliff20/app2"],
+        });
+        expect(genmode).toBeTruthy();
+        genmode.init();
+        expect(genmode.getResSize()).toBe(9);
+    });
+
+    // still accepts the old name for translationsDir
+    test("GenerateModeInitMultipleXliffDirs still accepts old xliffsDir option", function() {
         expect.assertions(2);
 
         var genmode = new GenerateMode({

--- a/packages/loctool/test/LocalRepository.test.js
+++ b/packages/loctool/test/LocalRepository.test.js
@@ -92,12 +92,12 @@ describe("localrepository", function() {
         })
     });
 
-    test("LocalRepositoryConstructorWithXliffsDir", function() {
+    test("LocalRepositoryConstructorWithTranslationsDir", function() {
         expect.assertions(31);
 
         var repo = new LocalRepository({
             sourceLocale: "en-US",
-            xliffsDir: "./test/testfiles/xliffs"
+            translationsDir: "./test/testfiles/xliffs"
         });
 
         expect(repo).toBeTruthy();
@@ -154,7 +154,58 @@ describe("localrepository", function() {
         })
     });
 
-    test("LocalRepositoryConstructorWithXliffsDirArray", function() {
+    test("LocalRepositoryConstructorWithTranslationsDirArray", function() {
+        expect.assertions(21);
+
+        // should read all xliffs from both directories
+        var repo = new LocalRepository({
+            sourceLocale: "en-US",
+            translationsDir: ["./test/testfiles/xliff20/app3", "./test/testfiles/xliff20/app4"],
+        });
+
+        expect(repo).toBeTruthy();
+
+        repo.init(function(){
+            repo.getBy({
+                reskey: "String 1a"
+            }, function(err, resources) {
+                expect(resources).toBeTruthy();
+                expect(resources.length).toBe(3);
+
+                resources.sort(function(left, right) {
+                    var leftLocale = left.getTargetLocale();
+                    var rightLocale = right.getTargetLocale();
+                    return leftLocale < rightLocale ? -1 : (leftLocale > rightLocale ? 1 : 0);
+                });
+
+                expect(resources[0].getKey()).toBe("String 1a");
+                expect(resources[0].getProject()).toBe("app3");
+                expect(resources[0].getSourceLocale()).toBe("en-KR");
+                expect(resources[0].getSource()).toBe("app3:String 1a");
+                expect(resources[0].getTargetLocale()).toBe("de-DE");
+                expect(resources[0].getTarget()).toBe("Das app3:String 1a");
+
+                expect(resources[1].getKey()).toBe("String 1a");
+                expect(resources[1].getProject()).toBe("app3");
+                expect(resources[1].getSourceLocale()).toBe("en-KR");
+                expect(resources[1].getSource()).toBe("app3:String 1a");
+                expect(resources[1].getTargetLocale()).toBe("en-US");
+                expect(resources[1].getTarget()).toBe("app3:String 1a");
+
+                expect(resources[2].getKey()).toBe("String 1a");
+                expect(resources[2].getProject()).toBe("app3");
+                expect(resources[2].getSourceLocale()).toBe("en-KR");
+                expect(resources[2].getSource()).toBe("app3:String 1a");
+                expect(resources[2].getTargetLocale()).toBe("fr-FR");
+                expect(resources[2].getTarget()).toBe("Le app3:String 1a");
+
+                repo.close(function() {
+                });
+            });
+        })
+    });
+
+    test("LocalRepositoryConstructorWith legacy xliffsDir Array", function() {
         expect.assertions(21);
 
         // should read all xliffs from both directories
@@ -211,7 +262,7 @@ describe("localrepository", function() {
         // should recursively read all xliffs from the deep directory structure
         var repo = new LocalRepository({
             sourceLocale: "en-US",
-            xliffsDir: "./test/testfiles/xliffsdeep"
+            translationsDir: "./test/testfiles/xliffsdeep"
         });
 
         expect(repo).toBeTruthy();

--- a/packages/loctool/test/Project.test.js
+++ b/packages/loctool/test/Project.test.js
@@ -135,7 +135,7 @@ describe("project", function() {
         expect(!fs.existsSync("./test/testfiles/loctest-new-ja-JP.xliff")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/loctest-new-zh-Hans-CN.xliff")).toBeTruthy();
         var project = ProjectFactory('./test/testfiles', {
-            'xliffsDir': "xliffs",
+            'translationsDir': "xliffs",
             'locales': ['ja-JP']
         });
         project.addPath("md/test1.md");
@@ -162,7 +162,7 @@ describe("project", function() {
         expect(!fs.existsSync("./test/testfiles/loctest-new-ja-JP.po")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/loctest-new-zh-Hans-CN.pot")).toBeTruthy();
         var project = ProjectFactory('./test/testfiles', {
-            'xliffsDir': "xliffs",
+            'translationsDir': "xliffs",
             'locales': ['ja-JP'],
             'intermediateFormat': 'po'
         });
@@ -220,7 +220,7 @@ describe("project", function() {
         expect(!fs.existsSync("./test/testfiles/ja-JP/md/test1.md")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/zh-Hans-CN/md/test1.md")).toBeTruthy();
         var project = ProjectFactory('./test/testfiles', {
-            xliffsDir: "translations",
+            translationsDir: "translations",
             locales: ['es-US', 'ja-JP', 'zh-Hans-CN']
         });
         project.addPath("md/test1.md");
@@ -255,7 +255,7 @@ describe("project", function() {
         expect(!fs.existsSync("./test/testfiles/project3/zh-Hans-CN.mock")).toBeTruthy();
 
         var project = ProjectFactory('./test/testfiles/project3', {
-            xliffsDir: "translations2",
+            translationsDir: "translations2",
             locales: ['es-US', 'ja-JP', 'zh-Hans-CN']
         });
         project.addPath("en-US.mock");
@@ -290,7 +290,7 @@ describe("project", function() {
         expect(!fs.existsSync("./test/testfiles/project3/zh-Hans-CN.mock")).toBeTruthy();
 
         var project = ProjectFactory('./test/testfiles/project3', {
-            xliffsDir: "translations1",
+            translationsDir: "translations1",
             locales: ['es-US', 'ja-JP', 'zh-Hans-CN']
         });
         project.addPath("en-US.mock");
@@ -489,7 +489,7 @@ describe("project", function() {
         expect(!fs.existsSync("./test/testfiles/project3/zh-Hans-CN.mock")).toBeTruthy();
 
         var project = ProjectFactory('./test/testfiles/project3', {
-            xliffsDir: "translations2",
+            translationsDir: "translations2",
             locales: ['es-US', 'ja-JP', 'zh-Hans-CN'],
             intermediateFormat: 'po'
         });
@@ -667,7 +667,7 @@ describe("project", function() {
         expect(!fs.existsSync("./test/testfiles/project3/ja-JP.mock")).toBeTruthy();
         expect(!fs.existsSync("./test/testfiles/project3/zh-Hans-CN.mock")).toBeTruthy();
         var project = ProjectFactory('./test/testfiles/project3', {
-            xliffsDir: "translations2",
+            translationsDir: "translations2",
             locales: ['es-US', 'ja-JP', 'zh-Hans-CN'],
             convertPlurals: true
         });
@@ -694,6 +694,167 @@ describe("project", function() {
     });
 
     test("Project localize a mock file with plurals using plural conversions, right content", function() {
+        expect.assertions(18);
+        // set up first
+        expect(!fs.existsSync("./test/testfiles/project3/loctest-new-es-US.xliff")).toBeTruthy();
+        expect(!fs.existsSync("./test/testfiles/project3/loctest-new-ja-JP.xliff")).toBeTruthy();
+        expect(!fs.existsSync("./test/testfiles/project3/loctest-new-zh-Hans-CN.xliff")).toBeTruthy();
+        expect(!fs.existsSync("./test/testfiles/project3/es-US.mock")).toBeTruthy();
+        expect(!fs.existsSync("./test/testfiles/project3/ja-JP.mock")).toBeTruthy();
+        expect(!fs.existsSync("./test/testfiles/project3/zh-Hans-CN.mock")).toBeTruthy();
+        var project = ProjectFactory('./test/testfiles/project3', {
+            translationsDir: "translations1",
+            locales: ['es-US', 'ja-JP', 'zh-Hans-CN'],
+            convertPlurals: true
+        });
+        project.addPath("en-US.mock");
+
+        project.init(function() {
+            project.extract(function() {
+                project.write(function() {
+                    project.save(function() {
+                        project.close(function() {
+                            var filename = "./test/testfiles/project3/loctest-new-es-US.xliff";
+                            expect(fs.existsSync(filename)).toBeTruthy();
+                            var actual = fs.readFileSync(filename, "utf8");
+                            var expected =
+                                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                                '<xliff version="1.2">\n' +
+                                '  <file original="en-US.mock" source-language="en-US" target-language="es-US" product-name="loctest">\n' +
+                                '    <body>\n' +
+                                '      <trans-unit id="1" resname="plu1" restype="string" datatype="mock">\n' +
+                                '        <source>{count, plural, one {singular} other {plural}}</source>\n' +
+                                '        <target state="new">{count, plural, one {singular} many {plural} other {plural}}</target>\n' +
+                                '      </trans-unit>\n' +
+                                '    </body>\n' +
+                                '  </file>\n' +
+                                '</xliff>';
+                            expect(actual).toBe(expected);
+
+                            filename = "./test/testfiles/project3/loctest-new-ja-JP.xliff";
+                            expect(fs.existsSync(filename)).toBeTruthy();
+                            var actual = fs.readFileSync(filename, "utf8");
+                            var expected =
+                                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                                '<xliff version="1.2">\n' +
+                                '  <file original="en-US.mock" source-language="en-US" target-language="ja-JP" product-name="loctest">\n' +
+                                '    <body>\n' +
+                                '      <trans-unit id="1" resname="plu1" restype="string" datatype="mock">\n' +
+                                '        <source>{count, plural, one {singular} other {plural}}</source>\n' +
+                                '        <target state="new">{count, plural, other {plural}}</target>\n' +
+                                '      </trans-unit>\n' +
+                                '    </body>\n' +
+                                '  </file>\n' +
+                                '</xliff>';
+                            expect(actual).toBe(expected);
+
+                            filename = "./test/testfiles/project3/loctest-new-zh-Hans-CN.xliff";
+                            expect(fs.existsSync(filename)).toBeTruthy();
+                            var actual = fs.readFileSync(filename, "utf8");
+                            var expected =
+                                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                                '<xliff version="1.2">\n' +
+                                '  <file original="en-US.mock" source-language="en-US" target-language="zh-Hans-CN" product-name="loctest">\n' +
+                                '    <body>\n' +
+                                '      <trans-unit id="1" resname="plu1" restype="string" datatype="mock">\n' +
+                                '        <source>{count, plural, one {singular} other {plural}}</source>\n' +
+                                '        <target state="new">{count, plural, other {plural}}</target>\n' +
+                                '      </trans-unit>\n' +
+                                '    </body>\n' +
+                                '  </file>\n' +
+                                '</xliff>';
+                            expect(actual).toBe(expected);
+
+                            filename = "./test/testfiles/project3/es-US.mock";
+                            expect(fs.existsSync(filename)).toBeTruthy();
+                            var actual = fs.readFileSync(filename, "utf8");
+                            var expected =
+                                '{\n' +
+                                '    "arr1": [\n' +
+                                '        "uno",\n' +
+                                '        "dos",\n' +
+                                '        "tres"\n' +
+                                '    ],\n' +
+                                '    "arr2": [\n' +
+                                '        "quatro",\n' +
+                                '        "cinco",\n' +
+                                '        "seis"\n' +
+                                '    ],\n' +
+                                '    "foobar1": "Esta es una cadena de prueba",\n' +
+                                '    "foobar2": "Esta es una segunda cadena de prueba",\n' +
+                                '    "plu1": {\n' +
+                                '        "one": "singular",\n' +
+                                '        "other": "plural"\n' +
+                                '    },\n' +
+                                '    "plu2": {\n' +
+                                '        "one": "Hay {n} artículo.",\n' +
+                                '        "many": "Hay {n} artículos.",\n' +
+                                '        "other": "Hay {n} artículos."\n' +
+                                '    }\n' +
+                                '}';
+                            expect(actual).toBe(expected);
+
+                            filename = "./test/testfiles/project3/ja-JP.mock";
+                            expect(fs.existsSync(filename)).toBeTruthy();
+                            var actual = fs.readFileSync(filename, "utf8");
+                            var expected =
+                                '{\n' +
+                                '    "arr1": [\n' +
+                                '        "1",\n' +
+                                '        "2",\n' +
+                                '        "3"\n' +
+                                '    ],\n' +
+                                '    "arr2": [\n' +
+                                '        "4",\n' +
+                                '        "5",\n' +
+                                '        "6"\n' +
+                                '    ],\n' +
+                                '    "foobar1": "これはテスト文字列です",\n' +
+                                '    "foobar2": "これは 2 番目のテスト文字列です",\n' +
+                                '    "plu1": {\n' +
+                                '        "one": "singular",\n' +
+                                '        "other": "plural"\n' +
+                                '    },\n' +
+                                '    "plu2": {\n' +
+                                '        "other": "項目が {n} つあります。"\n' +
+                                '    }\n' +
+                                '}';
+                            expect(actual).toBe(expected);
+
+                            filename = "./test/testfiles/project3/zh-Hans-CN.mock";
+                            expect(fs.existsSync(filename)).toBeTruthy();
+                            var actual = fs.readFileSync(filename, "utf8");
+                            var expected =
+                                '{\n' +
+                                '    "arr1": [\n' +
+                                '        "一",\n' +
+                                '        "二",\n' +
+                                '        "三"\n' +
+                                '    ],\n' +
+                                '    "arr2": [\n' +
+                                '        "四",\n' +
+                                '        "五",\n' +
+                                '        "六"\n' +
+                                '    ],\n' +
+                                '    "foobar1": "这是一个测试字符串",\n' +
+                                '    "foobar2": "这是第二个测试字符串",\n' +
+                                '    "plu1": {\n' +
+                                '        "one": "singular",\n' +
+                                '        "other": "plural"\n' +
+                                '    },\n' +
+                                '    "plu2": {\n' +
+                                '        "other": "有 {n} 个项目。"\n' +
+                                '    }\n' +
+                                '}';
+                            expect(actual).toBe(expected);
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    test("Project localize a mock file with plurals using plural conversions and still accepts the legacy xliffsDir parameter", function() {
         expect.assertions(18);
         // set up first
         expect(!fs.existsSync("./test/testfiles/project3/loctest-new-es-US.xliff")).toBeTruthy();

--- a/packages/loctool/test/ProjectFactory.test.js
+++ b/packages/loctool/test/ProjectFactory.test.js
@@ -61,12 +61,12 @@ describe("projectfactory", function() {
         expect(project.target).toBe('test/testfiles');
     });
 
-    test("ProjectFactoryCorrectDefaultXliffsDir", function() {
+    test("ProjectFactoryCorrectDefaultTranslationsDir", function() {
         expect.assertions(2);
         var project = ProjectFactory('./test/testfiles', {'locales': ['def']});
         expect(project).toBeTruthy();
         // should be relative to the root of the project
-        expect(project.xliffsDir).toStrictEqual(['test/testfiles']);
+        expect(project.translationsDir).toStrictEqual(['test/testfiles']);
     });
 
     test("ProjectFactoryCorrectDefaultXliffsOut", function() {
@@ -85,12 +85,20 @@ describe("projectfactory", function() {
         expect(project.target).toBe('test/testfiles/foobar');
     });
 
-    test("ProjectFactoryCorrectExplicitXliffsDir", function() {
+    test("ProjectFactoryCorrectExplicitTranslationsDir", function() {
+        expect.assertions(2);
+        var project = ProjectFactory('./test/testfiles', {'locales': ['def'], 'translationsDir': 'asdf'});
+        expect(project).toBeTruthy();
+        // should be relative to the root of the project
+        expect(project.translationsDir).toStrictEqual(['test/testfiles/asdf']);
+    });
+
+    test("ProjectFactoryCorrectExplicitTranslationsDir still accepts old xliffsDir parameter", function() {
         expect.assertions(2);
         var project = ProjectFactory('./test/testfiles', {'locales': ['def'], 'xliffsDir': 'asdf'});
         expect(project).toBeTruthy();
         // should be relative to the root of the project
-        expect(project.xliffsDir).toStrictEqual(['test/testfiles/asdf']);
+        expect(project.translationsDir).toStrictEqual(['test/testfiles/asdf']);
     });
 
     test("ProjectFactoryCorrectExplicitXliffsOut", function() {
@@ -110,13 +118,13 @@ describe("projectfactory", function() {
         expect(project.target).toBe('/foo/asdf');
     });
 
-    test("ProjectFactoryAbsolutePathXliffsDir", function() {
+    test("ProjectFactoryAbsolutePathTranslationsDir", function() {
         expect.assertions(2);
         var xliffAbsolutePath = '/foo/asdf';
-        var project = ProjectFactory('./test/testfiles', {'locales': ['def'], 'xliffsDir': xliffAbsolutePath});
+        var project = ProjectFactory('./test/testfiles', {'locales': ['def'], 'translationsDir': xliffAbsolutePath});
         expect(project).toBeTruthy();
         // should be relative to the root of the project
-        expect(project.xliffsDir).toStrictEqual(['/foo/asdf']);
+        expect(project.translationsDir).toStrictEqual(['/foo/asdf']);
     });
 
     test("ProjectFactoryAbsolutePathxliffsOut", function() {


### PR DESCRIPTION
- the dir may now contain files that are not xliffs, so translationsDir is more descriptive
- xliffsDir is still supported for backwards compatibility