### PR TITLE
loctool: Fix incorrect xliffsDir handling

### DIFF
--- a/.changeset/shy-ads-tell.md
+++ b/.changeset/shy-ads-tell.md
@@ -1,0 +1,6 @@
+---
+"loctool": patch
+---
+
+- Fix incorrect handling of the deprecated xliffsDir
+  setting in a project.json file

--- a/packages/loctool/lib/GenerateMode.js
+++ b/packages/loctool/lib/GenerateMode.js
@@ -30,19 +30,19 @@ var getIntermediateFile = iff.getIntermediateFile;
 var logger = log4js.getLogger("loctool.lib.GenerateMode");
 
 /**
- * @class A class that represents the local story of a set of
+ * @class A class that represents the local store of a set of
  * translations used in a project.
  *
  * @constructor
- * @param {String} sourceLocale the source locale for this set
- * @param {String} translationsDir the directory that contains the intermediate files
+ * @param {Object} options the options for this mode
+ * @param {String} options.translationsDir the directory that contains the intermediate files
  */
 var GenerateMode = function (options) {
     logger.trace("GenerateMode constructor called");
     this.translationsDir = ["."];
 
     if (options) {
-        var transDir = options.translationsDir || options.xliffsDir;
+        var transDir = options.xliffsDir || options.translationsDir;
         this.translationsDir = transDir ?
             (ilib.isArray(transDir) ? transDir : [transDir]) :
             ["."];

--- a/packages/loctool/lib/GenerateMode.js
+++ b/packages/loctool/lib/GenerateMode.js
@@ -42,7 +42,7 @@ var GenerateMode = function (options) {
     this.translationsDir = ["."];
 
     if (options) {
-        var transDir = options.xliffsDir || options.translationsDir;
+        var transDir = options.translationsDir || options.xliffsDir;
         this.translationsDir = transDir ?
             (ilib.isArray(transDir) ? transDir : [transDir]) :
             ["."];

--- a/packages/loctool/lib/LocalRepository.js
+++ b/packages/loctool/lib/LocalRepository.js
@@ -48,7 +48,7 @@ var LocalRepository = function (options) {
     if (options) {
         this.sourceLocale = options.sourceLocale || "en-US";
         this.pseudoLocale = options.pseudoLocale;
-        var transDir = options.xliffsDir || options.translationsDir;
+        var transDir = options.translationsDir || options.xliffsDir || ".";
         if (transDir) {
             translationsDir = ilib.isArray(transDir) ? transDir : [transDir];
         }

--- a/packages/loctool/lib/LocalRepository.js
+++ b/packages/loctool/lib/LocalRepository.js
@@ -48,7 +48,7 @@ var LocalRepository = function (options) {
     if (options) {
         this.sourceLocale = options.sourceLocale || "en-US";
         this.pseudoLocale = options.pseudoLocale;
-        var transDir = options.translationsDir || options.xliffsDir;
+        var transDir = options.xliffsDir || options.translationsDir;
         if (transDir) {
             translationsDir = ilib.isArray(transDir) ? transDir : [transDir];
         }

--- a/packages/loctool/lib/Project.js
+++ b/packages/loctool/lib/Project.js
@@ -159,7 +159,12 @@ var Project = function(options, root, settings) {
     }
 
     // where the translation xliff files are read from
-    var translationsDir = this.settings.translationsDir || this.settings.xliffsDir || '.';
+    var translationsDir =
+        options.xliffsDir ||
+        options.translationsDir ||
+        this.settings.xliffsDir ||
+        this.settings.translationsDir ||
+        '.';
     this.translationsDir = ilib.isArray(translationsDir) ? translationsDir.map(function(dir) {
         return smartJoin(this.root, dir);
     }.bind(this)) : [smartJoin(this.root, translationsDir)];
@@ -667,7 +672,7 @@ Project.prototype.generateMode = function(cb) {
 
     var genMode = new GenerateMode({
         targetDir: this.settings.targetDir,
-        translationsDir: this.settings.translationsDir,
+        translationsDir: this.translationsDir,
         settings: this.settings
     });
 

--- a/packages/loctool/lib/Project.js
+++ b/packages/loctool/lib/Project.js
@@ -160,10 +160,10 @@ var Project = function(options, root, settings) {
 
     // where the translation xliff files are read from
     var translationsDir =
-        options.xliffsDir ||
         options.translationsDir ||
-        this.settings.xliffsDir ||
+        options.xliffsDir ||
         this.settings.translationsDir ||
+        this.settings.xliffsDir ||
         '.';
     this.translationsDir = ilib.isArray(translationsDir) ? translationsDir.map(function(dir) {
         return smartJoin(this.root, dir);

--- a/packages/loctool/loctool.js
+++ b/packages/loctool/loctool.js
@@ -270,7 +270,6 @@ var settings = {
     intermediateFormat: "xliff",
     nopseudo: true,
     targetDir: ".",            // target directory for all output files
-    translationsDir: ["."],
     xliffVersion: 1.2,
     xliffStyle: "standard",
     allowDups: true,

--- a/packages/loctool/test/Project.test.js
+++ b/packages/loctool/test/Project.test.js
@@ -1781,18 +1781,62 @@ describe("project", function() {
         expect(project.getLocaleInherit("ko-KR")).toBeUndefined();
         expect(project.getLocaleInherit()).toBeUndefined();
     });
+
     test("GetProjectType", function() {
         expect.assertions(1);
         var project = ProjectFactory('./test/testfiles', {});
         expect(project.getProjectType()).toBe("web");
     });
+
     test("GetProjectTypeCustom", function() {
         expect.assertions(1);
-        var settings = {
+        var options = {
             rootDir: ".",
             projectType: "custom"
-        }
-        var project = ProjectFactory.newProject(settings);
+        };
+        var project = ProjectFactory.newProject(options);
         expect(project.getProjectType()).toBe("custom");
+    });
+
+    test("Project creation supports translationsDir option", function() {
+        expect.assertions(1);
+        var options = {
+            rootDir: "./test/testfiles/project2",
+            projectType: "custom",
+            translationsDir: "res"
+        };
+        var project = ProjectFactory.newProject(options);
+        expect(project.translationsDir).toStrictEqual(["test/testfiles/project2/res"]);
+    });
+
+    test("Project creation still supports the deprecated xliffsDir option", function() {
+        expect.assertions(1);
+        var options = {
+            rootDir: "./test/testfiles/project2",
+            projectType: "custom",
+            xliffsDir: "res"
+        };
+        var project = ProjectFactory.newProject(options);
+        expect(project.translationsDir).toStrictEqual(["test/testfiles/project2/res"]);
+    });
+
+    test("Project creation supports translationsDir using the settings", function() {
+        expect.assertions(1);
+        var settings = {
+            projectType: "custom",
+            translationsDir: "xliffs"
+        }
+        var project = ProjectFactory('./test/testfiles', settings);
+        expect(project.translationsDir).toStrictEqual(["test/testfiles/xliffs"]);
+    });
+
+    test("Project creation still supports the deprecated xliffsDir using the settings", function() {
+        expect.assertions(1);
+        var settings = {
+            projectType: "custom",
+            xliffsDir: "xliffs"
+        }
+        var project = ProjectFactory('./test/testfiles', settings);
+        expect(project.translationsDir).toStrictEqual(["test/testfiles/xliffs"]);
     });
 });

--- a/packages/loctool/test/ProjectFactory.test.js
+++ b/packages/loctool/test/ProjectFactory.test.js
@@ -1,7 +1,7 @@
 /*
  * ProjectFactory.test.js - test class used to load Projects
  *
- * Copyright © 2017, 2023 2020, 2023 Healthtap, Inc. All Rights Reserved.
+ * Copyright © 2017, 2020, 2023, 2025 Healthtap, Inc. All Rights Reserved.
  */
 
 if (!ProjectFactory) {


### PR DESCRIPTION
- translationsDir setting had a default, which meant that it never looked at the xliffsDir setting.
- Now, if the xliffsDir setting is available, it will use that first, and then fall back to the translationsDir setting or its default.
- added some unit tests to verify that it is working properly
- tested in a real project to make sure it works as expected without modifying the existing project.json