### PR TITLE
[ilib-lint] Add tests for resource-no-fullwidth-digits rule

### DIFF
--- a/packages/ilib-lint/docs/resource-anguilar-named-params.md
+++ b/packages/ilib-lint/docs/resource-anguilar-named-params.md
@@ -1,9 +1,0 @@
-# resource-angular-named-params
-
-Ensure that named Angular or Vue parameters that appear in the source string are
-also used in the translated string. Named parameters have the syntax {{name}}.
-That is, they are an expression surrounded by double curly braces. The same
-parameter must also exist in the target string containing the same expression.
-Sometimes translators accidentally translate
-the text inside of the parameter or they forget to include the parameter in
-the target string, and this rule helps to catch those cases.

--- a/packages/ilib-lint/docs/resource-anguilar-named-params.md
+++ b/packages/ilib-lint/docs/resource-anguilar-named-params.md
@@ -1,0 +1,9 @@
+# resource-angular-named-params
+
+Ensure that named Angular or Vue parameters that appear in the source string are
+also used in the translated string. Named parameters have the syntax {{name}}.
+That is, they are an expression surrounded by double curly braces. The same
+parameter must also exist in the target string containing the same expression.
+Sometimes translators accidentally translate
+the text inside of the parameter or they forget to include the parameter in
+the target string, and this rule helps to catch those cases.

--- a/packages/ilib-lint/src/rules/ResourceCompleteness.js
+++ b/packages/ilib-lint/src/rules/ResourceCompleteness.js
@@ -45,7 +45,7 @@ class ResourceCompleteness extends ResourceRule {
      * @param {string} params.file the file where the resource came from
      * @returns {Array.<Result>|undefined} the results
      */
-    matchString({ source, target, resource, file, index, category }) {
+    matchString({ source, target, resource, file }) {
         // note: language specifiers for comparison - "en-US" should match "en-GB" (same language, only different region)
         const sourceLangSpec = new Locale(resource.sourceLocale).getLangSpec();
         const targetLangSpec = new Locale(resource.targetLocale).getLangSpec();

--- a/packages/ilib-lint/src/rules/ResourceDNTTerms.js
+++ b/packages/ilib-lint/src/rules/ResourceDNTTerms.js
@@ -96,7 +96,7 @@ class ResourceDNTTerms extends ResourceRule {
      * @param {string} props.file the file where the resource came from
      * @returns {Array.<Result>|undefined} the results
      */
-    matchString({ source, target, resource, file, index, category }) {
+    matchString({ source, target, resource, file }) {
         const resultProps = {
             id: resource.getKey(),
             rule: this,

--- a/packages/ilib-lint/src/rules/ResourceICUPluralTranslation.js
+++ b/packages/ilib-lint/src/rules/ResourceICUPluralTranslation.js
@@ -213,7 +213,7 @@ class ResourceICUPluralTranslation extends ResourceRule {
      * Check a string in a resource for missing translations of plurals or selects.
      * @override
      */
-    matchString({source, target, file, resource, index, category}) {
+    matchString({source, target, file, resource}) {
         const sLoc = new Locale(resource.getSourceLocale());
         const tLoc = new Locale(resource.getTargetLocale());
 

--- a/packages/ilib-lint/src/rules/ResourceICUPlurals.js
+++ b/packages/ilib-lint/src/rules/ResourceICUPlurals.js
@@ -243,7 +243,7 @@ class ResourceICUPlurals extends ResourceRule {
         return problems;
     }
 
-    matchString({source, target, file, resource, index, category}) {
+    matchString({source, target, file, resource}) {
         if (!target) return; // can't check "nothing" !
 
         const sLoc = new Locale(resource.getSourceLocale());

--- a/packages/ilib-lint/src/rules/ResourceNoTranslation.js
+++ b/packages/ilib-lint/src/rules/ResourceNoTranslation.js
@@ -45,7 +45,7 @@ class ResourceNoTranslation extends ResourceRule {
     /**
      * @override
      */
-    matchString({source, target, file, resource, index, category}) {
+    matchString({source, target, file, resource}) {
         const sourceLocale = new Locale(resource.getSourceLocale());
         const targetLocale = new Locale(resource.getTargetLocale());
         const sourceWords = source.split(/\s+/g).length; // does not work for Asian languages

--- a/packages/ilib-lint/src/rules/ResourceSourceChecker.js
+++ b/packages/ilib-lint/src/rules/ResourceSourceChecker.js
@@ -49,7 +49,7 @@ class ResourceSourceChecker extends DeclarativeResourceRule {
     /**
      * @override
      */
-    checkString({re, source, file, resource, index, category}) {
+    checkString({re, source, file, resource}) {
         re.lastIndex = 0;
         let matches = [];
         const strippedSrc = this.useStripped ? stripPlurals(source) : source;

--- a/packages/ilib-lint/src/rules/ResourceSourceICUPluralCategories.js
+++ b/packages/ilib-lint/src/rules/ResourceSourceICUPluralCategories.js
@@ -87,7 +87,7 @@ export class ResourceSourceICUPluralCategories extends ResourceRule {
      * @param {string} params.file
      * @returns {Result[]}
      */
-    matchString({ source: maybeSource, resource, file, index, category }) {
+    matchString({ source: maybeSource, resource, file }) {
         const source = maybeSource ?? "";
         const sourceLocale = new Locale(resource.getSourceLocale() ?? this.sourceLocale).getSpec();
 

--- a/packages/ilib-lint/src/rules/ResourceSourceICUPluralParams.js
+++ b/packages/ilib-lint/src/rules/ResourceSourceICUPluralParams.js
@@ -93,7 +93,7 @@ export class ResourceSourceICUPluralParams extends ResourceRule {
      * @param {string} params.file
      * @returns {Result | undefined}
      */
-    matchString({ source, resource, file, index, category }) {
+    matchString({ source, resource, file }) {
         if (!source) return; // no source, no checks needed
         const sourceLocale = new Locale(resource.getSourceLocale() ?? this.sourceLocale).getSpec();
 

--- a/packages/ilib-lint/src/rules/ResourceSourceICUPluralSyntax.js
+++ b/packages/ilib-lint/src/rules/ResourceSourceICUPluralSyntax.js
@@ -48,7 +48,7 @@ export class ResourceSourceICUPluralSyntax extends ResourceRule {
      * @param {string} params.file
      * @returns {Result | undefined}
      */
-    matchString({ source: maybeSource, resource, file, index, category }) {
+    matchString({ source: maybeSource, resource, file }) {
         const source = maybeSource ?? "";
         const sourceLocale = new Locale(resource.getSourceLocale() ?? this.sourceLocale).getSpec();
 

--- a/packages/ilib-lint/src/rules/ResourceSourceICUUnexplainedParams.js
+++ b/packages/ilib-lint/src/rules/ResourceSourceICUUnexplainedParams.js
@@ -62,7 +62,7 @@ export class ResourceSourceICUUnexplainedParams extends ResourceRule {
      * @returns {Result[] | undefined}
      * @override
      */
-    matchString({ source, resource, file, index, category }) {
+    matchString({ source, resource, file }) {
         if (!source) return; // no source, no checks needed
 
         const sourceLocale = new Locale(

--- a/packages/ilib-lint/src/rules/ResourceXML.js
+++ b/packages/ilib-lint/src/rules/ResourceXML.js
@@ -154,7 +154,7 @@ class ResourceXML extends ResourceRule {
     /**
      * @override
      */
-    matchString({source, target, resource, index, category}) {
+    matchString({source, target, resource}) {
         if (!target) return; // can't check "nothing" !
         let srcObj, tgtObj;
         let problems = [];

--- a/packages/ilib-lint/test/ResourceNoFullwidthDigits.test.js
+++ b/packages/ilib-lint/test/ResourceNoFullwidthDigits.test.js
@@ -73,7 +73,8 @@ describe("resource-no-fullwidth-digits rule", () => {
             source: resource.getSource()[0],
             target: resource.getTarget()[0],
             resource,
-            file: "a/b/c.xliff"
+            file: "a/b/c.xliff",
+            index: 0
         });
         const result = results[0];
 
@@ -105,7 +106,8 @@ describe("resource-no-fullwidth-digits rule", () => {
             source: resource.getSource().other,
             target: resource.getTarget().other,
             resource,
-            file: "a/b/c.xliff"
+            file: "a/b/c.xliff",
+            category: "other"
         });
         const result = results[0];
 

--- a/packages/ilib-lint/test/ResourceNoFullwidthDigits.test.js
+++ b/packages/ilib-lint/test/ResourceNoFullwidthDigits.test.js
@@ -82,7 +82,7 @@ describe("resource-no-fullwidth-digits rule", () => {
         expect(result.severity).toBe("error");
         expect(result.id).toBe("matcher.test");
         expect(result.description).toBe("The full-width characters '１２３４５' are not allowed in the target string. Use ASCII digits instead.");
-        expect(result.highlight).toBe("Target: Box<e0>１２３４５</e0>");
+        expect(result.highlight).toBe("Target[0]: Box<e0>１２３４５</e0>");
         expect(result.source).toBe('Box12345');
         expect(result.pathName).toBe("a/b/c.xliff");
     });
@@ -115,7 +115,7 @@ describe("resource-no-fullwidth-digits rule", () => {
         expect(result.severity).toBe("error");
         expect(result.id).toBe("matcher.test");
         expect(result.description).toBe("The full-width characters '１２３４５' are not allowed in the target string. Use ASCII digits instead.");
-        expect(result.highlight).toBe("Target: Box<e0>１２３４５</e0>");
+        expect(result.highlight).toBe("Target(other): Box<e0>１２３４５</e0>");
         expect(result.source).toBe('Box12345');
         expect(result.pathName).toBe("a/b/c.xliff");
     });

--- a/packages/ilib-lint/test/ResourceNoFullwidthDigits.test.js
+++ b/packages/ilib-lint/test/ResourceNoFullwidthDigits.test.js
@@ -1,0 +1,185 @@
+/*
+ * ResourceNoFullwidthDigits.test.js - test the resource-no-fullwidth-digits rule
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ResourceString, ResourceArray, ResourcePlural} from 'ilib-tools-common';
+
+import ResourceTargetChecker from '../src/rules/ResourceTargetChecker.js';
+import {regexRules} from '../src/plugins/BuiltinPlugin.js';
+
+import {IntermediateRepresentation} from 'ilib-lint-common';
+
+import ResourceFixer from '../src/plugins/resource/ResourceFixer.js';
+
+const rule = regexRules.find(rule => rule.name === "resource-no-fullwidth-digits");
+
+describe("resource-no-fullwidth-digits rule", () => {
+    it("detects full-width digits in the target string", () => {
+        const checker = new ResourceTargetChecker(rule);
+        const resource = new ResourceString({
+            key: "matcher.test",
+            source: 'Box12345',
+            target: "Box１２３４５",
+            pathName: "a/b/c.xliff"
+        });
+
+        const results = checker.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        const result = results[0];
+
+        expect(results.length).toBe(1);
+        expect(result.severity).toBe("error");
+        expect(result.id).toBe("matcher.test");
+        expect(result.description).toBe("The full-width characters '１２３４５' are not allowed in the target string. Use ASCII digits instead.");
+        expect(result.highlight).toBe("Target: Box<e0>１２３４５</e0>");
+        expect(result.source).toBe('Box12345');
+        expect(result.pathName).toBe("a/b/c.xliff");
+    });
+
+    it("detects full-width digits in the target array - NEEDS FIX !!!", () => {
+        const checker = new ResourceTargetChecker(rule);
+        const resource = new ResourceArray({
+            key: "matcher.test",
+            source: [
+                'Box12345'
+            ],
+            target: [
+                "Box１２３４５"
+            ],
+            pathName: "a/b/c.xliff"
+        });
+
+        // TODO: fix error in DeclarativeResourceRule.checkString:  Cannot create a ResourceStringLocator for an array resource without an index
+        const results = checker.matchString({
+            source: resource.getSource()[0],
+            target: resource.getTarget()[0],
+            resource,
+            file: "a/b/c.xliff"
+        });
+        const result = results[0];
+
+        expect(results.length).toBe(1);
+        expect(result.severity).toBe("error");
+        expect(result.id).toBe("matcher.test");
+        expect(result.description).toBe("The full-width characters '１２３４５' are not allowed in the target string. Use ASCII digits instead.");
+        expect(result.highlight).toBe("Target: Box<e0>１２３４５</e0>");
+        expect(result.source).toBe('Box12345');
+        expect(result.pathName).toBe("a/b/c.xliff");
+    });
+
+    it("detects full-width digits in the target plural - NEEDS FIX !!!", () => {
+        const checker = new ResourceTargetChecker(rule);
+        const resource = new ResourcePlural({
+            key: "matcher.test",
+            source: {
+                one: 'Box1',
+                other: 'Box12345'
+            },
+            target: {
+                other: "Box１２３４５"
+            },
+            pathName: "a/b/c.xliff"
+        });
+
+        //TODO: fix error in DeclarativeResourceRule.checkString: Cannot create a ResourceStringLocator for a plural resource without a plural category
+        const results = checker.matchString({
+            source: resource.getSource().other,
+            target: resource.getTarget().other,
+            resource,
+            file: "a/b/c.xliff"
+        });
+        const result = results[0];
+
+        expect(results.length).toBe(1);
+        expect(result.severity).toBe("error");
+        expect(result.id).toBe("matcher.test");
+        expect(result.description).toBe("The full-width characters '１２３４５' are not allowed in the target string. Use ASCII digits instead.");
+        expect(result.highlight).toBe("Target: Box<e0>１２３４５</e0>");
+        expect(result.source).toBe('Box12345');
+        expect(result.pathName).toBe("a/b/c.xliff");
+    });
+
+    it("returns undefined if the target string is not a full-width digit", () => {
+        const checker = new ResourceTargetChecker(rule);
+        const resource = new ResourceString({
+            key: "matcher.test",
+            source: 'Box12345',
+            target: "Box12345",
+        });
+
+        const results = checker.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+
+        expect(results).toBeUndefined();
+    });
+
+    it("returns undefined if the target array does not contain a full-width digit", () => {
+        const checker = new ResourceTargetChecker(rule);
+        const resource = new ResourceArray({
+            key: "matcher.test",
+            source: [
+                'Box12345'
+            ],
+            target: [
+                "Box12345"
+            ],
+            pathName: "a/b/c.xliff"
+        });
+
+        const results = checker.matchString({
+            source: resource.getSource()[0],
+            target: resource.getTarget()[0],
+            resource,
+            file: "a/b/c.xliff"
+        });
+
+        expect(results).toBeUndefined();
+    });
+
+    it("returns undefined if the target plural does not contain a full-width digit", () => {
+        const checker = new ResourceTargetChecker(rule);
+        const resource = new ResourcePlural({
+            key: "matcher.test",
+            source: {
+                one: 'Box1',
+                other: 'Box12345'
+            },
+            target: {
+                other: "Box12345"
+            },
+            pathName: "a/b/c.xliff"
+        });
+
+        const results = checker.matchString({
+            source: resource.getSource().other,
+            target: resource.getTarget().other,
+            resource,
+            file: "a/b/c.xliff"
+        });
+
+        expect(results).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Two tests for the `resource-no-fullwidth-digits` rule are failing because `DeclarativeResourceRule.checkString` is throwing errors due to missing arguments after calling `ResourceTargetChecker.matchString()` for plural and array resources.

For the plural resource, the error is:

```
Cannot create a ResourceStringLocator for a plural resource without a plural category.
```

For the array resource, the error is:

```
Cannot create a ResourceStringLocator for an array resource without an index.
```