### PR TITLE
[ilib-mono] Improve PR code coverage comment generation in GitHub Actions

### DIFF
--- a/.github/workflows/test-affected.yml
+++ b/.github/workflows/test-affected.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           echo "Listing affected packages"
           LIST=$(pnpm turbo ls --affected --output=json)
+          echo "LIST: $LIST"
           echo list=$(echo "$LIST" | jq -c .) >> "$GITHUB_OUTPUT"
           echo "Running tests and generating coverage reports for affected packages"
           pnpm coverage:ci:affected

--- a/.github/workflows/test-affected.yml
+++ b/.github/workflows/test-affected.yml
@@ -1,4 +1,8 @@
-name: Test Affected
+name: Test affected
+# Test Affected workflow
+# This workflow runs tests and generates coverage reports for packages affected by changes in a pull request.
+# It uses Turborepo to determine affected packages and runs their tests in parallel.
+# Coverage reports are merged and processed for coverage reporting in PR comments.
 
 on: pull_request
 
@@ -28,13 +32,26 @@ jobs:
         uses: browser-actions/setup-chrome@v1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Affected packages test and coverage
-        run: pnpm coverage:ci:affected
+      - name: List and test affected packages
+        id: affected-packages
+        run: |
+          echo "Listing affected packages"
+          LIST=$(pnpm turbo ls --affected --output=json)
+          echo list=$(echo "$LIST" | jq -c .) >> "$GITHUB_OUTPUT"
+          echo "Running tests and generating coverage reports for affected packages"
+          pnpm coverage:ci:affected
         env:
           # temporary workaround for `Failed to resolve base ref 'main' from GitHub Actions event`:
           # manually set PR base commit ref
           # per https://github.com/vercel/turborepo/issues/9320#issuecomment-2499219314
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+      - name: Generate coverage paths
+        id: coverage-paths
+        env: 
+          AFFECTED_PACKAGES: ${{steps.affected-packages.outputs.list}}
+        run: |
+          echo "Generating coverage paths"
+          node scripts/generate-coverage-paths.js
       - name: Merge coverage reports
         run: |
           echo "Merging coverage reports"
@@ -42,24 +59,13 @@ jobs:
       - name: Jest Code Coverage Comment
         uses: MishaKav/jest-coverage-comment@main
         with:
-          multiple-files: |
-            ilib-lint-python, ./packages/ilib-lint-python/coverage/coverage-summary.json
-            ilib-lint-python-gnu, ./packages/ilib-lint-python-gnu/coverage/coverage-summary.json
-            ilib-lint-react, ./packages/ilib-lint-react/coverage/coverage-summary.json
-            ilib-lint, ./packages/ilib-lint/coverage/coverage-summary.json
-            loctool, ./packages/loctool/coverage/coverage-summary.json
+          multiple-files: ${{ steps.coverage-paths.outputs.coverage-files }}
           title: Jest Code Coverage
           coverage-path: ./coverage.txt
           coverage-title: Code Coverage for changed files
           create-new-comment: false
           report-only-changed-files: true
-          multiple-junitxml-files: |
-            ilib-lint-python, ./packages/ilib-lint-python/junit.xml
-            ilib-lint-python-gnu, ./packages/ilib-lint-python-gnu/junit.xml
-            ilib-lint-react, ./packages/ilib-lint-react/junit.xml
-            ilib-lint, ./packages/ilib-lint/junit.xml
-            loctool, ./packages/loctool/junit.xml
-
+          multiple-junitxml-files: ${{ steps.coverage-paths.outputs.junit-files }}
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing
 
-We welcome contributions to the ilib-mono project!
-Please follow guidelines defined in this file to contribute and follow the existing code style and conventions.
+We welcome contributions to the `ilib-mono` project!
+Please follow the guidelines defined in this file to contribute and adhere to the existing code style and conventions.
 Ensure your code is documented and passes all linting and tests before submitting a pull request.
 
 This repository is a monorepo for the [iLib-js project](https://github.com/iLib-js).
-Project status and project structure are described in the [README.md](./README.md) file.
+The project status and structure are described in the [README.md](./README.md) file.
 
 ## Table of Contents
 
@@ -13,8 +13,8 @@ Project status and project structure are described in the [README.md](./README.m
 - [Environment](#environment)
 - [Coding Guidelines](#coding-guidelines)
 - [Adding a New Package](#adding-a-new-package)
-- [Running scripts](#running-scripts)
-- [Debugging pluggable CLI applications](#debugging-pluggable-cli-applications)
+- [Running Scripts](#running-scripts)
+- [Debugging Pluggable CLI Applications](#debugging-pluggable-cli-applications)
 - [Code Coverage](#code-coverage)
 - [Documentation](#documentation)
 - [Versioning](#versioning)
@@ -24,38 +24,37 @@ Project status and project structure are described in the [README.md](./README.m
 
 ## Getting Started
 
-If you're internal contributor, follow your internal guidelines.
+If you're an internal contributor, follow your internal guidelines.
 
 External contributors can contribute to the project by following these steps:
 
 1. Fork the repository.
-2. Clone the forked repository to the local machine.
-3. Create a new branch for the feature or bugfix.
+2. Clone the forked repository to your local machine.
+3. Create a new branch for the feature or bug fix.
 4. Make your changes.
-5. Commit changes with a descriptive commit message.
-6. Push changes to the forked repository.
+5. Commit the changes with a descriptive commit message.
+6. Push the changes to your forked repository.
 7. Create a pull request to the main repository.
 
-Before contributing, please set up the project on the local machine by following the instructions in
-the [SETUP.md](./SETUP.md) file.
+Before contributing, please set up the project on your local machine by following the instructions in the [SETUP.md](./SETUP.md) file.
 
 ### Pull Requests
 
-Every pull request should contain the following:
+Every pull request should include the following:
 
-- documentation in the code (following the JSDoc/TSDoc standard)
-- tests
-- changelog entry.
+- Documentation in the code (following the JSDoc/TSDoc standard).
+- Tests.
+- A changelog entry.
 
 ## Environment
 
-This project is developed using the following tools:
+This project uses the following tools:
 
 - Node.js for running JavaScript code.
-- pnpm package manager for package management and package workspaces support.
-- Turborepo for monorepo task running (caching, parallelization).
+- `pnpm` as the package manager for managing dependencies and supporting workspaces.
+- Turborepo for monorepo task management (caching, parallelization).
 
-Common commands are aliased in [root `package.json`](./package.json) scripts.
+Common commands are aliased in the root [`package.json`](./package.json) scripts.
 
 ## Coding Guidelines
 
@@ -65,8 +64,7 @@ TBD
 
 ### Package Template
 
-Currently, there is no package template as we are moving existing `iLib-js` packages into the monorepo without
-unification.
+Currently, there is no package template as we are migrating existing `iLib-js` packages into the monorepo without unification.
 This will be addressed in the future.
 
 ### Manual Package Creation
@@ -75,39 +73,39 @@ To manually create a new package, follow these steps:
 
 1. Create a new directory under `packages/`.
 2. In the new directory, create a `package.json` file.
-3. Add the following scripts to the new package's `package.json` file to plug into monorepo tasks (defined in
-   `turbo.json` in the monorepo root directory):
-    - `build`
-    - `test`
-    - `doc`
+3. Add the following scripts to the new package's `package.json` file to integrate with monorepo tasks (defined in `turbo.json` in the monorepo root directory):
+
+   - `build`
+   - `test`
+   - `doc`
 
    These scripts are optional.
-4. If the new package depends on another package in the monorepo, define this dependency using the workspace protocol in
-   the `dependencies` section of your `packages/<packageName>/package.json`, like this:
-    ```json
-    {
-        "dependencies": {
-            "ilib-common": "workspace:^"
-        }
-    }
-    ```
-   When you run `pnpm publish`, pnpm will automatically substitute this protocol with a proper semver version.
-   You can learn more about pnpm workspaces [here](https://pnpm.io/workspaces).
+
+4. If the new package depends on another package in the monorepo, define this dependency using the workspace protocol in the `dependencies` section of your `packages/<packageName>/package.json`, like this:
+   ```json
+   {
+     "dependencies": {
+       "ilib-common": "workspace:^"
+     }
+   }
+   ```
+   When you run `pnpm publish`, `pnpm` will automatically replace this protocol with the appropriate semver version.
+   You can learn more about `pnpm` workspaces [here](https://pnpm.io/workspaces).
 
 ## Running Scripts
 
-To run scripts for a single package run commands from the package root directory.
+To run scripts for a single package, execute commands from the package's root directory.
 
 ```bash
-# cd packages/loctool
-pnpm [script-name] 
+# cd packages/package-name
+pnpm [script-name]
 ```
 
 ### Build
 
 TBD
 
-To run the build, use:
+To build, use:
 
 ```bash
 pnpm build
@@ -117,7 +115,7 @@ pnpm build
 
 TBD
 
-To run the doc, use:
+To generate documentation, use:
 
 ```bash
 pnpm doc
@@ -129,10 +127,10 @@ TBD
 
 ### Test
 
-There are few ways to run tests:
+There are several ways to run tests:
 
-* for an affected package(s) solely or
-* for all packages in the monorepo.
+- For affected package(s) only.
+- For all packages in the monorepo.
 
 #### 1. Run tests for affected package(s)
 
@@ -145,7 +143,7 @@ pnpm test
 
 #### 2. Run tests for all packages
 
-To run all the tests for all packages in the monorepo, use:
+To run tests for all packages in the monorepo, use:
 
 ```bash
 pnpm test:all
@@ -153,70 +151,69 @@ pnpm test:all
 
 #### 3. Other options
 
-These may be useful for development and/or debugging purposes.
-These commands should be run from the root directory of the package you're interested in.
+These may be useful for development or debugging purposes.
+Run these commands from the root directory of the package you're interested in.
 
-1. Run all the tests for a single package in the monorepo:
+1. Run all tests for a single package in the monorepo:
 
 ```bash
-pnpm --filter loctool test
+pnpm --filter package-name test
 ```
 
-or `cd` into the package directory and run:
+Or `cd` into the package directory and run:
 
 ```bash
-# cd packages/loctool
+# cd packages/package-name
 pnpm test
 ```
 
-2. Run all tests for a single file, by passing the path to the file as an argument to the `pnpm test` command, like
-   this:
+2. Run tests for a single file by passing the file path as an argument to the `pnpm test` command, like this:
 
 ```bash
 pnpm --filter loctool test -- "ResourceConvert.test.js"
 ```
 
-or `cd` into the package directory and run:
+Or `cd` into the package directory and run:
 
 ```bash
-# cd packages/loctool
+# cd packages/package-name
 pnpm test -- "ResourceConvert.test.js"
 ```
 
-## Debugging pluggable CLI applications
+## Debugging Pluggable CLI Applications
 
-This monorepo publishes some CLI applications that support plugins; alongside, it also publishes those plugins. For example:
+This monorepo publishes some CLI applications that support plugins; it also publishes those plugins. For example:
+
 - [`loctool`](./packages/loctool)
   - [`ilib-loctool-json`](./packages/ilib-loctool-json)
 - [`ilib-lint`](./packages/ilib-lint)
   - [`ilib-lint-react`](./packages/ilib-lint-react)
 
-To easily debug those CLI applications with plugins directly within monorepo, you can use the environment variable [`NODE_PATH`](https://nodejs.org/api/modules.html#loading-from-the-global-folders).
+To debug these CLI applications with plugins directly within the monorepo, you can use the environment variable [`NODE_PATH`](https://nodejs.org/api/modules.html#loading-from-the-global-folders).
 
-For example, to debug `loctool` with `ilib-loctool-json` plugin, you can run:
+For example, to debug `loctool` with the `ilib-loctool-json` plugin, you can run:
 
 ```bash
-# first make sure you have built all packages within the monorepo
+# First, ensure all packages in the monorepo are built
 pnpm build
-# set NODE_PATH to monorepo context to allow loading plugins directly from the monorepo
+# Set NODE_PATH to the monorepo context to allow loading plugins directly from the monorepo
 export NODE_PATH=$(pwd)/packages
-# run the app from the monorepo on a project that uses the plugin ilib-loctool-json
+# Run the app from the monorepo on a project that uses the plugin ilib-loctool-json
 node loctool/lib/loctool.js localize ~/ilib-loctool-samples/js-json
 ```
 
-This way, you can easily test your changes to both the CLI application and the plugin at the same time without the need to publish them or otherwise link them manually (e.g. with `yarn link`).
+This allows you to test changes to both the CLI application and the plugin simultaneously without needing to publish or manually link them (e.g., with `yarn link`).
 
-To make this even easier, monorepo provides `run:*` scripts which set `NODE_PATH` for you. The above example can be simplified to:
+To simplify this process, the monorepo provides `run:*` scripts that set `NODE_PATH` for you. The above example can be simplified to:
 
 ```bash
-# build is still required
+# Build is still required
 pnpm build
-# run the app from monorepo using script
+# Run the app from the monorepo using the script
 pnpm run:loctool localize ~/ilib-loctool-samples/js-json
 ```
 
-Those scripts also embed the `--inspect` flag to allow debugging with e.g. VSCode's _Auto Attach: With Flag_ feature.
-
+These scripts also embed the `--inspect` flag to enable debugging with tools like VSCode's _Auto Attach: With Flag_ feature.
 
 ## Code Coverage
 
@@ -308,5 +305,4 @@ To report a bug or submit a feature request, please create an issue on the GitHu
 
 ## License
 
-By contributing to `ilib-mono`, it is understood and acknowledged that contributions will be licensed under the Apache
-License.
+By contributing to `ilib-mono`, it is understood and acknowledged that contributions will be licensed under the Apache License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,66 +220,73 @@ Those scripts also embed the `--inspect` flag to allow debugging with e.g. VSCod
 
 ## Code Coverage
 
-Currently, only some of the packages use has code coverage reporting enabled. For the other packages, code coverage will be
-added in the future.
+Code coverage is configured at the monorepo level in the root `jest.config.js`. Each package that wants to participate in code coverage reporting needs to follow the steps in the [Adding Code Coverage](#adding-code-coverage) section.
 
 ### Running Code Coverage
 
-For the packages that already use code coverage, it has been integrated into the `ilib-mono` GitHub Actions workflow for
-pull requests. Code coverage is calculated with Jest for selected packages, and the coverage report is automatically
-added as a comment to each pull request.
+For packages that already use code coverage, it is integrated into the `ilib-mono` GitHub Actions workflow for pull requests. Code coverage is calculated with Jest for selected packages, and the coverage report is automatically added as a comment to each pull request.
 
-The comment contains detailed information about the code coverage for the files changed in a PR, along with information
-about uncovered lines and direct links to them. Additionally, overall information for each package is also added as a
-comment to each pull request. This includes details about the percentage of covered lines (statements, branches, and
-functions) and information about the number of tests (total, skipped, failures, errors) along with their execution time.
+The comment contains detailed information about the code coverage for the files changed in a PR, along with information about uncovered lines and direct links to them. Additionally, overall information for each package is also added as a comment to each pull request. This includes details about the percentage of covered lines (statements, branches, and functions) and information about the number of tests (total, skipped, failures, errors) along with their execution time.
 
-A full code coverage report is saved as an artifact and is available for download from the GitHub Actions CI workflow
-for pull requests.
+A full code coverage report is saved as an artifact and is available for download from the GitHub Actions CI workflow for pull requests.
 
 To run code coverage locally for all packages in the monorepo, run the following command from the root directory:
 
 ```bash
-pnpm coverage
+pnpm run coverage
 ```
+
 To run it only for affected package(s), use:
 
 ```bash
-pnpm coverage:affected
+pnpm run coverage:affected
 ```
 
-Additionally, code coverage can be run for a single package in the monorepo by navigating to the package directory:
+Additionally, code coverage can be run for a single package in the monorepo from the root directory:
+
+```bash
+pnpm --filter package-name test
+```
+
+Or by navigating to the package directory:
 
 ```bash
 # cd packages/package-name
-pnpm coverage
+pnpm run coverage
 ```
-The `coverage` script in all of these cases produces, in the root of the package,  a `coverage/` directory, as well as `coverage.txt` and `junit.xml` files containing the code coverage details.
+
+The `coverage` script in all of these cases produces a `coverage/` directory in the root of the package, as well as `coverage.txt` and `junit.xml` files containing the code coverage details.
 
 ### Adding Code Coverage
-To include a new package in the code coverage comment in a pull request, follow these steps:  
 
-1. Define the `coverage` script in `package.json`. This script should generate the coverage report.
-     ```bash
-    "scripts": {
-        # ...
-        "coverage": "pnpm test -- --coverage --coverageReporters json-summary --coverageReporters html --coverageReporters text > ./coverage.txt --reporters=default --reporters=jest-junit",
-    }
-    ```
-    
-2. .Update GitHub Actions Workflow for pull request. Add the package coverage source to the `test-affected` workflow in the `.github/workflows/test-affected.yml` file.
-Specifically, update the Jest Code Coverage Comment step to include the new package in both `multiple-files` and `multiple-junitxml-files`.
-    ```yml
-    - name: Jest Code Coverage Comment
-      # ...
-      with:
-        multiple-files: |
-          # ...
-          package-name, ./packages/package-name/coverage/coverage-summary.json
-        multiple-junitxml-files: |
-          #...
-          package-name, ./packages/package-name/junit.xml
-    ```
+Each package that wants to participate in code coverage reporting needs to:
+
+1. Have a `jest.config.cjs` file that extends the root configuration:
+
+```javascript
+const baseConfig = require("../../jest.config.js");
+
+const config = {
+  ...baseConfig,
+  displayName: {
+    name: "package-name",
+    color: "blue", // Choose your color from chalk's palette
+  },
+  // Package-specific Jest configuration (if needed)
+};
+
+module.exports = config;
+```
+
+The `color` property uses [chalk's color palette](https://github.com/chalk/chalk#colors).
+
+2. Have a `coverage` script in its `package.json`:
+```json
+"scripts": {
+  // ...
+  "coverage": "pnpm test -- --coverage"
+}
+```
 
 By following these steps, the package will be included in the code coverage report, and the results will be automatically commented on each pull request to `ilib-mono`.
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -24,6 +24,30 @@ Below is a list of aspect that need to be accounted for when migrating existing 
     -   **CI**: Leftover CI configuration (like CircleCI) should be removed from the package directory after migration; CI is handled by the monorepo through GitHub Actions workflows common for the whole monorepo
     -   **Build**: If the package requires a build step, it should be added as `build` in its `package.json`; it should produce artifacts in `lib` directory which are ready for publishing; note that monorepo packages depend on each other so the build script (called automatically before tests) should produce complete ouptut as if the package was published to npm (so that it can be depended upon)
     -   **Test**: The package should define a `test` script that runs all tests; if using jest, make sure to invoke it with `node node_modules/jest/bin/jest.js` instead of the binary wrapper (to mitigate risk of incorrectly hoisted dependencies - see [pnpm issue #8863](https://github.com/pnpm/pnpm/issues/8863)); build script is called automatically before running tests, so remove it from the test script if it's already there; for now, all tests run in Node 20 with Chrome, we're planning to set up additional workflows for environment matrix testing soon
+    -   **Coverage**: The package should be configured to report code coverage in PR comments. To enable this:
+        1. Create a `jest.config.cjs` file that extends the root configuration:
+           ```javascript
+           const baseConfig = require("../../jest.config.js");
+           
+           const config = {
+             ...baseConfig,
+             displayName: {
+               name: "package-name",
+               color: "blue", // Choose your color from chalk's palette
+             },
+             // Package-specific Jest configuration (if needed)
+           };
+           
+           module.exports = config;
+           ```
+        2. Add a `coverage` script to `package.json`:
+           ```json
+           {
+             "scripts": {
+               "coverage": "pnpm test -- --coverage"
+             }
+           }
+           ```
     -   **Doc**: The package can define a `doc` script to generate HTML documentation; it should produce artifacts in `docs` directory; this is not called automatically at any point - remember to run it manually in a PR and commit the generated files
     -   **Publish**: Package should NOT define any custom `version` or `publish` scripts as it will be handled by the monorepo (using changesets and pnpm release, see [release CI workflow](../.github/workflows/release.yml)); while pnpm should call `prepublish` script implicitly, it's recommended that all things needed for publishing should be handled in the `build` script
 -   **Package**
@@ -115,6 +139,9 @@ Package migration checklist:
 - [ ] Create patchbump changeset for migrated packages
 - [ ] Regenerate lockfile
 - [ ] Regenerate docs
+- [ ] Configure code coverage reporting
+  - [ ] Add `jest.config.cjs` extending root config
+  - [ ] Add `coverage` script to package.json
 
 After merge:
 

--- a/packages/ilib-assemble/jest.config.cjs
+++ b/packages/ilib-assemble/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-assemble",
+        color: "cyan",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-assemble/package.json
+++ b/packages/ilib-assemble/package.json
@@ -49,6 +49,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "pnpm test:cli",
         "test:cli": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:watch": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node --watch",

--- a/packages/ilib-casemapper/jest.config.cjs
+++ b/packages/ilib-casemapper/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-casemapper",
+        color: "white",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-casemapper/package.json
+++ b/packages/ilib-casemapper/package.json
@@ -58,6 +58,7 @@
         "build:prod": "grunt babel --mode=prod && pnpm build:pkg",
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
+        "coverage": "pnpm test:cli --coverage",
         "test": "pnpm test:all",
         "test:cli": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:web": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/karma/bin/karma start --reporters dots --single-run",

--- a/packages/ilib-common/jest.config.cjs
+++ b/packages/ilib-common/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-common",
+        color: "blackBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-common/package.json
+++ b/packages/ilib-common/package.json
@@ -58,6 +58,7 @@
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:test": "webpack-cli --config webpack-test.config.js",
         "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
+        "coverage": "pnpm test:cli --coverage",
         "test": "pnpm test:all",
         "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:karma": "LANG=en_US.UTF8 NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" karma start --reporters dots",

--- a/packages/ilib-ctype/jest.config.cjs
+++ b/packages/ilib-ctype/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-ctype",
+        color: "redBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-ctype/package.json
+++ b/packages/ilib-ctype/package.json
@@ -58,6 +58,7 @@
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
         "build:data": "node scripts/generate.js",
+        "coverage": "pnpm test:cli --coverage",
         "test": "pnpm test:all",
         "test:all": "npm-run-all --npm-path pnpm test:cli test:web",
         "test:cli": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",

--- a/packages/ilib-data-utils/jest.config.cjs
+++ b/packages/ilib-data-utils/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-data-utils",
+        color: "greenBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-data-utils/package.json
+++ b/packages/ilib-data-utils/package.json
@@ -56,6 +56,7 @@
         "build": "pnpm build:prod",
         "build:prod": "grunt babel --mode=prod",
         "build:dev": "grunt babel --mode=dev",
+        "coverage": "pnpm test -- --coverage",
         "test": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:watch": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node --watch",
         "debug": "node --experimental-vm-modules --inspect-brk node_modules/jest/bin/jest.js --testEnvironment node -i",

--- a/packages/ilib-env/jest.config.cjs
+++ b/packages/ilib-env/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-env",
+        color: "yellowBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-env/package.json
+++ b/packages/ilib-env/package.json
@@ -58,6 +58,7 @@
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:test": "webpack-cli --config webpack-test.config.js",
         "build:pkg": "mkdir -p lib && echo '{\"type\": \"commonjs\"}' > lib/package.json",
+        "coverage": "pnpm test:jest --coverage",
         "test": "pnpm run test:all",
         "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:karma": "LANG=en_US.UTF8 NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" karma start --reporters dots",

--- a/packages/ilib-es6/jest.config.cjs
+++ b/packages/ilib-es6/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-es6",
+        color: "blueBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-es6/package.json
+++ b/packages/ilib-es6/package.json
@@ -51,6 +51,7 @@
         "node": ">= 14.0.0"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "pnpm test:cli",
         "test:cli": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:watch": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node --watch",

--- a/packages/ilib-lint-common/jest.config.cjs
+++ b/packages/ilib-lint-common/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-lint-common",
+        color: "magentaBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-lint-common/package.json
+++ b/packages/ilib-lint-common/package.json
@@ -52,6 +52,7 @@
         "node": ">=14.0.0"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js",
         "test:watch": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
         "debug": "LANG=en_US.UTF8 node --experimental-vm-modules --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loader/package.json
+++ b/packages/ilib-loader/package.json
@@ -55,7 +55,6 @@
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:test": "webpack-cli --config webpack-test.config.js",
         "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
-        "coverage": "pnpm test:jest --coverage",
         "test": "echo Success: TODO fix this to pnpm test:all",
         "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:karma": "LANG=en_US.UTF8 NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" karma start --reporters dots",

--- a/packages/ilib-loader/package.json
+++ b/packages/ilib-loader/package.json
@@ -55,6 +55,7 @@
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:test": "webpack-cli --config webpack-test.config.js",
         "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
+        "coverage": "pnpm test:jest --coverage",
         "test": "echo Success: TODO fix this to pnpm test:all",
         "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:karma": "LANG=en_US.UTF8 NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" karma start --reporters dots",

--- a/packages/ilib-locale/jest.config.cjs
+++ b/packages/ilib-locale/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-locale",
+        color: "cyanBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-locale/package.json
+++ b/packages/ilib-locale/package.json
@@ -60,6 +60,7 @@
         "build:prod": "grunt babel --mode=prod && pnpm build:pkg",
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
+        "coverage": "pnpm test:cli --coverage",
         "test": "pnpm test:all",
         "test:cli": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:web": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/karma/bin/karma start --reporters dots --single-run",

--- a/packages/ilib-loctool-android-layout/jest.config.cjs
+++ b/packages/ilib-loctool-android-layout/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-android-layout",
+        color: "whiteBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-android-layout/package.json
+++ b/packages/ilib-loctool-android-layout/package.json
@@ -43,6 +43,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-android-resource/jest.config.cjs
+++ b/packages/ilib-loctool-android-resource/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-android-resource",
+        color: "black",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-android-resource/package.json
+++ b/packages/ilib-loctool-android-resource/package.json
@@ -43,6 +43,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-csv/jest.config.cjs
+++ b/packages/ilib-loctool-csv/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-csv",
+        color: "red",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-csv/package.json
+++ b/packages/ilib-loctool-csv/package.json
@@ -42,6 +42,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-ghfm/jest.config.cjs
+++ b/packages/ilib-loctool-ghfm/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-ghfm",
+        color: "green",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-ghfm/package.json
+++ b/packages/ilib-loctool-ghfm/package.json
@@ -44,6 +44,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-haml/jest.config.cjs
+++ b/packages/ilib-loctool-haml/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-haml",
+        color: "yellow",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-haml/package.json
+++ b/packages/ilib-loctool-haml/package.json
@@ -42,6 +42,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-html/jest.config.cjs
+++ b/packages/ilib-loctool-html/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-html",
+        color: "blue",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-html/package.json
+++ b/packages/ilib-loctool-html/package.json
@@ -41,6 +41,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-java/jest.config.cjs
+++ b/packages/ilib-loctool-java/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-java",
+        color: "magenta",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-java/package.json
+++ b/packages/ilib-loctool-java/package.json
@@ -42,6 +42,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-javascript-resource/jest.config.cjs
+++ b/packages/ilib-loctool-javascript-resource/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-javascript-resource",
+        color: "white",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-javascript-resource/package.json
+++ b/packages/ilib-loctool-javascript-resource/package.json
@@ -42,6 +42,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-javascript/jest.config.cjs
+++ b/packages/ilib-loctool-javascript/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-javascript",
+        color: "cyan",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-javascript/package.json
+++ b/packages/ilib-loctool-javascript/package.json
@@ -42,6 +42,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-json/jest.config.cjs
+++ b/packages/ilib-loctool-json/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-json",
+        color: "blackBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-json/package.json
+++ b/packages/ilib-loctool-json/package.json
@@ -43,6 +43,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-jst/jest.config.cjs
+++ b/packages/ilib-loctool-jst/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-jst",
+        color: "redBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-jst/package.json
+++ b/packages/ilib-loctool-jst/package.json
@@ -42,6 +42,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-jsx/jest.config.cjs
+++ b/packages/ilib-loctool-jsx/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-jsx",
+        color: "greenBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-jsx/package.json
+++ b/packages/ilib-loctool-jsx/package.json
@@ -43,6 +43,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-mrkdwn/jest.config.cjs
+++ b/packages/ilib-loctool-mrkdwn/jest.config.cjs
@@ -1,0 +1,11 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-mrkdwn",
+        color: "black",
+    },
+}
+
+module.exports = config;

--- a/packages/ilib-loctool-mrkdwn/package.json
+++ b/packages/ilib-loctool-mrkdwn/package.json
@@ -46,6 +46,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-objectivec/jest.config.cjs
+++ b/packages/ilib-loctool-objectivec/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-objectivec",
+        color: "greenBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-objectivec/package.json
+++ b/packages/ilib-loctool-objectivec/package.json
@@ -40,6 +40,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-php-resource/jest.config.cjs
+++ b/packages/ilib-loctool-php-resource/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-php-resource",
+        color: "yellowBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-php-resource/package.json
+++ b/packages/ilib-loctool-php-resource/package.json
@@ -44,6 +44,7 @@
     },
     "scripts": {
         "build": "pnpm pack",
+        "coverage": "pnpm test -- --coverage",
         "test": "jest",
         "test:watch": "jest --watch",
         "debug": "NODE_OPTIONS=\"$NODE_OPTIONS --inspect-brk\" jest -i",

--- a/packages/ilib-loctool-po/jest.config.cjs
+++ b/packages/ilib-loctool-po/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-po",
+        color: "blueBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-po/package.json
+++ b/packages/ilib-loctool-po/package.json
@@ -45,6 +45,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-properties/jest.config.cjs
+++ b/packages/ilib-loctool-properties/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-properties",
+        color: "magentaBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-properties/package.json
+++ b/packages/ilib-loctool-properties/package.json
@@ -42,6 +42,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js",

--- a/packages/ilib-loctool-regex/jest.config.cjs
+++ b/packages/ilib-loctool-regex/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-regex",
+        color: "cyanBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-regex/package.json
+++ b/packages/ilib-loctool-regex/package.json
@@ -48,6 +48,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-ruby-ilib/jest.config.cjs
+++ b/packages/ilib-loctool-ruby-ilib/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-ruby-ilib",
+        color: "whiteBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-ruby-ilib/package.json
+++ b/packages/ilib-loctool-ruby-ilib/package.json
@@ -41,6 +41,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-salesforce-metaxml/jest.config.cjs
+++ b/packages/ilib-loctool-salesforce-metaxml/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-salesforce-metaxml",
+        color: "black",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-salesforce-metaxml/package.json
+++ b/packages/ilib-loctool-salesforce-metaxml/package.json
@@ -46,6 +46,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-strings/jest.config.cjs
+++ b/packages/ilib-loctool-strings/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-strings",
+        color: "red",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-strings/package.json
+++ b/packages/ilib-loctool-strings/package.json
@@ -41,6 +41,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-swift/jest.config.cjs
+++ b/packages/ilib-loctool-swift/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-swift",
+        color: "green",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-swift/package.json
+++ b/packages/ilib-loctool-swift/package.json
@@ -41,6 +41,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",

--- a/packages/ilib-loctool-tap-i18n/jest.config.cjs
+++ b/packages/ilib-loctool-tap-i18n/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-tap-i18n",
+        color: "yellow",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-tap-i18n/package.json
+++ b/packages/ilib-loctool-tap-i18n/package.json
@@ -40,6 +40,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:jestfix": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",

--- a/packages/ilib-loctool-xml/jest.config.cjs
+++ b/packages/ilib-loctool-xml/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-xml",
+        color: "blue",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-xml/package.json
+++ b/packages/ilib-loctool-xml/package.json
@@ -44,6 +44,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",

--- a/packages/ilib-loctool-yaml-resource/jest.config.cjs
+++ b/packages/ilib-loctool-yaml-resource/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-yaml-resource",
+        color: "cyan",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-yaml-resource/package.json
+++ b/packages/ilib-loctool-yaml-resource/package.json
@@ -41,6 +41,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-loctool-yaml/jest.config.cjs
+++ b/packages/ilib-loctool-yaml/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-loctool-yaml",
+        color: "magenta",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-loctool-yaml/package.json
+++ b/packages/ilib-loctool-yaml/package.json
@@ -40,6 +40,7 @@
         "url": "https://github.com/iLib-js/ilib-mono.git"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "node node_modules/jest/bin/jest.js --watch",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",

--- a/packages/ilib-po/jest.config.js
+++ b/packages/ilib-po/jest.config.js
@@ -1,5 +1,12 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
+const baseConfig = require("../../jest.config.js");
+
 module.exports = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-po",
+        color: "white",
+    },
     testEnvironment: "node",
     transform: {
         "^.+\\.tsx?$": ["ts-jest", {}],

--- a/packages/ilib-po/package.json
+++ b/packages/ilib-po/package.json
@@ -47,6 +47,7 @@
     },
     "scripts": {
         "build": "tsc --project tsconfig.build.json",
+        "coverage": "pnpm test -- --coverage",
         "types": "tsc",
         "test": "node node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test --watch",

--- a/packages/ilib-tmx/jest.config.cjs
+++ b/packages/ilib-tmx/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-tmx",
+        color: "backBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-tmx/package.json
+++ b/packages/ilib-tmx/package.json
@@ -53,6 +53,7 @@
         "build:prod": "grunt babel --mode=prod && pnpm build:pkg",
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
+        "coverage": "pnpm test -- --coverage",
         "test": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js  --testEnvironment node",
         "test:watch": "pnpm test:jest --watch",
         "debug": "LANG=en_US.UTF8 node --experimental-vm-modules --inspect-brk node_modules/jest/bin/jest.js -i  --testEnvironment node",

--- a/packages/ilib-tools-common/jest.config.cjs
+++ b/packages/ilib-tools-common/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-tools-common",
+        color: "redBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-tools-common/package.json
+++ b/packages/ilib-tools-common/package.json
@@ -58,6 +58,7 @@
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
         "build:data": "node --experimental-vm-modules ./scripts/genPluralCategories.mjs",
+        "coverage": "pnpm test -- --coverage",
         "test": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:watch": "pnpm test:jest --watch",
         "debug": "LANG=en_US.UTF8 node --experimental-vm-modules --inspect-brk node_modules/jest/bin/jest.js -i --testEnvironment node",

--- a/packages/ilib-tree-node/jest.config.cjs
+++ b/packages/ilib-tree-node/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-tree-node",
+        color: "greenBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-tree-node/package.json
+++ b/packages/ilib-tree-node/package.json
@@ -41,6 +41,7 @@
     },
     "scripts": {
         "build": "grunt babel",
+        "coverage": "pnpm test:cli --coverage",
         "test": "npm-run-all --npm-path pnpm build test:cli",
         "test:cli": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js  --testEnvironment node",
         "test:watch": "pnpm test:jest --watch",

--- a/packages/ilib-yaml/jest.config.cjs
+++ b/packages/ilib-yaml/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-yaml",
+        color: "yellowBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/ilib-yaml/package.json
+++ b/packages/ilib-yaml/package.json
@@ -53,6 +53,7 @@
         "build:prod": "grunt babel --mode=prod && pnpm build:pkg",
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
+        "coverage": "pnpm test:cli --coverage",
         "test": "pnpm test:all",
         "test:all": "npm-run-all --npm-path pnpm test:cli",
         "test:cli": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",

--- a/packages/message-accumulator/jest.config.js
+++ b/packages/message-accumulator/jest.config.js
@@ -17,21 +17,25 @@
  * limitations under the License.
  */
 var semver = require('semver');
+var baseConfig = require("../../jest.config.js");
+
+var config = Object.assign({}, baseConfig, {
+    displayName: {
+        name: "message-accumulator",
+        color: "blueBright",
+    },
+});
 
 var settings = semver.major(process.versions.node) < 14 ?
-    {
+    Object.assign(config, {
         transformIgnorePatterns: ['/node_modules/'],
-
         moduleDirectories: ['node_modules', 'src']
-    } :
-    {
+    }) :
+    Object.assign(config, {
         moduleFileExtensions: ['js', 'jsx', 'json'],
-
         transform: {},
-
         transformIgnorePatterns: ['/node_modules/'],
-
         moduleDirectories: ['node_modules', 'src']
-    };
+    });
 
 module.exports = settings;

--- a/packages/message-accumulator/package.json
+++ b/packages/message-accumulator/package.json
@@ -51,6 +51,7 @@
     },
     "scripts": {
         "build": "grunt babel",
+        "coverage": "pnpm test:cli --coverage",
         "test": "npm-run-all --npm-path pnpm build test:cli",
         "test:cli": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:watch": "pnpm test:jest --watch",

--- a/packages/tmxtool/jest.config.cjs
+++ b/packages/tmxtool/jest.config.cjs
@@ -1,0 +1,13 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "tmxtool",
+        color: "magentaBright",
+    }
+}
+
+
+module.exports = config;
+

--- a/packages/tmxtool/package.json
+++ b/packages/tmxtool/package.json
@@ -53,6 +53,7 @@
         "node": ">= 14.0.0"
     },
     "scripts": {
+        "coverage": "pnpm test -- --coverage",
         "test": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:watch": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node --watch",
         "debug": "node --experimental-vm-modules --inspect-brk node_modules/jest/bin/jest.js --testEnvironment node -i",

--- a/scripts/generate-coverage-paths.js
+++ b/scripts/generate-coverage-paths.js
@@ -71,8 +71,6 @@ const junitFiles = affected.packages.items
 
 // Write to GitHub Actions output
 try {
-  console.log({ coverageFiles, junitFiles });
-
   fs.appendFileSync(GITHUB_OUTPUT,`coverage-files<<EOF\n${coverageFiles}\nEOF\n`);
   fs.appendFileSync(GITHUB_OUTPUT, `junit-files<<EOF\n${junitFiles}\nEOF\n`);
   

--- a/scripts/generate-coverage-paths.js
+++ b/scripts/generate-coverage-paths.js
@@ -1,0 +1,83 @@
+const fs = require("fs");
+
+/**
+ * @typedef {Object} PackageItem
+ * @property {string} name - The name of the package
+ * @property {string} path - The path to the package directory
+ */
+
+/**
+ * @typedef {Object} PackagesInfo
+ * @property {number} count - The number of packages
+ * @property {PackageItem[]} items - Array of package items
+ */
+
+/**
+ * @typedef {Object} AffectedPackages
+ * @property {string} packageManager - The package manager being used (e.g. "pnpm9")
+ * @property {PackagesInfo} packages - Information about the affected packages
+ */
+
+// Read the affected packages list from the environment variable
+const { AFFECTED_PACKAGES, GITHUB_OUTPUT } = process.env;
+
+if (!AFFECTED_PACKAGES) {
+  console.error("No AFFECTED_PACKAGES environment variable found");
+  process.exit(1);
+}
+
+if (!GITHUB_OUTPUT) {
+  console.error("No GITHUB_OUTPUT environment variable found");
+  process.exit(1);
+}
+
+/**
+ * @type {AffectedPackages}
+ *
+ * @example
+ * ```json
+ * {
+ *   "packageManager": "pnpm9",
+ *   "packages": {
+ *     "count": 2,
+ *     "items": [
+ *       {
+ *         "name": "ilib-address",
+ *         "path": "packages/ilib-address"
+ *       },
+ *       {
+ *         "name": "ilib-lint",
+ *         "path": "packages/ilib-lint"
+ *       }
+ *     ]
+ *   }
+ * }
+ * ```
+ */
+const affected = JSON.parse(AFFECTED_PACKAGES);
+
+// Generate coverage files paths
+const coverageFiles = affected.packages.items
+  .map(
+    (package) =>
+      `${package.name}, ${package.path}/coverage/coverage-summary.json`
+  )
+  .join("\n");
+
+// Generate junit files paths
+const junitFiles = affected.packages.items
+  .map((package) => `${package.name}, ${package.path}/junit.xml`)
+  .join("\n");
+
+// Write to GitHub Actions output
+try {
+  console.log({ coverageFiles, junitFiles });
+
+  fs.appendFileSync(GITHUB_OUTPUT,`coverage-files<<EOF\n${coverageFiles}\nEOF\n`);
+  fs.appendFileSync(GITHUB_OUTPUT, `junit-files<<EOF\n${junitFiles}\nEOF\n`);
+  
+  console.log("Successfully generated coverage and junit files paths");
+} catch (error) {
+  console.error("Error writing to GITHUB_OUTPUT:", error);
+  process.exit(1);
+}


### PR DESCRIPTION
- Add dynamic file paths for coverage and JUnit files instead of hardcoded ones
- Add file path generation to the `generate-coverage-paths.js` file

This change improves the code coverage comment by dynamically defining which packages should be included in coverage reports based on the dynamically detected affected packages, rather than relying on hardcoded values. It decreases readability but allows us to include all affected packages in the code coverage PR comment instead of just a few explicitly listed ones.

`ilib-mono` packages **without** coverage:

- `ilib-address`: no coverage :point_right: custom testSuite.sh script, no Jest
- `ilib-istring`: no coverage :point_right:  custom testSuite.sh script, no Jest
- `ilib-loader`: no coverage  👉 broken tests
- `ilib-localedata`: no coverage :point_right:  custom broken testSuite.sh script, no Jest
- `ilib-loctool-django`: no coverage :point_right:  no tests
- `ilib-loctool-ghfm-readmeio`: no coverage :point_right:  custom testSuite.js script, no Jest
- `ilib-loctool-react`: no coverage :point_right: no package.json
- `ilib-scanner`: no coverage :point_right: no tests
- `ilib-xliff`: no coverage :point_right: custom testSuite.js/.cjs/.sh
