### PR TITLE
[ilib-env] Fix ilib-env to return the right top scope

### DIFF
--- a/.changeset/dry-rice-type.md
+++ b/.changeset/dry-rice-type.md
@@ -1,0 +1,7 @@
+---
+"ilib-env": patch
+---
+
+- Fixed ilib-env to get the right top scope when the platform
+  is set to "mock" for testing. It will guess the top scope
+  of the actual platform by trying things in the right order.

--- a/.changeset/nervous-eyes-obey.md
+++ b/.changeset/nervous-eyes-obey.md
@@ -1,0 +1,7 @@
+---
+"ilib-localedata": patch
+"ilib-loader": patch
+---
+
+- re-enabled unit tests which weren't working properly
+  after the migration to ilib-mono

--- a/packages/ilib-env/src/index.js
+++ b/packages/ilib-env/src/index.js
@@ -67,7 +67,9 @@ export function top() {
             //console.log("top: top is " + (typeof(global) !== 'undefined' ? "global" : "this"));
             break;
         default:
-            topScope = window;
+            // in a browser, the top scope is always window
+            topScope = typeof(window) !== 'undefined' ? window :
+                (typeof(global) !== 'undefined' ? global : this);
             break;
     }
 

--- a/packages/ilib-env/src/index.js
+++ b/packages/ilib-env/src/index.js
@@ -67,7 +67,8 @@ export function top() {
             //console.log("top: top is " + (typeof(global) !== 'undefined' ? "global" : "this"));
             break;
         default:
-            // in a browser, the top scope is always window
+            // In a browser, the top scope is always window, but in a mocked environment,
+            // it could be something else, so we check for that too
             topScope = typeof(window) !== 'undefined' ? window :
                 (typeof(global) !== 'undefined' ? global : this);
             break;

--- a/packages/ilib-env/test/env.test.js
+++ b/packages/ilib-env/test/env.test.js
@@ -993,4 +993,19 @@ describe("testEnv", () => {
         expect(ilibEnv.isGlobal("locale")).toBeFalsy();
         expect(ilibEnv.globalVar("locale")).toBeUndefined();
     });
+
+    test("test setting the platform to mock on nodejs in case we need to test in a mock platform in packages that depend on this one", () => {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            return;
+        }
+        expect.assertions(3);
+        ilibEnv.clearCache();
+        expect(ilibEnv.platform).toBeUndefined();
+
+        ilibEnv.setPlatform("mock");
+
+        expect(ilibEnv.top()).toBe(global);
+        expect(ilibEnv.getPlatform()).toBe("mock");
+    });
 });

--- a/packages/ilib-loader/package.json
+++ b/packages/ilib-loader/package.json
@@ -55,7 +55,7 @@
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:test": "webpack-cli --config webpack-test.config.js",
         "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
-        "test": "echo Success: TODO fix this to pnpm test:all",
+        "test": "pnpm test:all",
         "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment node",
         "test:karma": "LANG=en_US.UTF8 NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" karma start --reporters dots",
         "test:cli": "LANG=en_US.UTF8 npm-run-all --npm-path pnpm build:dev test:jest",

--- a/packages/ilib-localedata/package.json
+++ b/packages/ilib-localedata/package.json
@@ -55,7 +55,7 @@
         "build:dev": "grunt babel --mode=dev && pnpm build:pkg",
         "build:test": "webpack-cli --config webpack-test.config.js",
         "build:pkg": "mkdir -p lib && echo '{\"type\": \"commonjs\"}' > lib/package.json",
-        "test": "echo success TODO fix this pnpm test:cli",
+        "test": "pnpm test:cli",
         "test:cli": "LANG=en_US.UTF8 pnpm build:dev && bash test/testSuite.sh",
         "test:all": "npm-run-all --npm-path pnpm test:cli test:web",
         "test:web": "LANG=en_US.UTF8 pnpm build:test && open-cli ./test/testSuite.html && open-cli ./test/testSuite.html -- firefox",


### PR DESCRIPTION
- if you set the platform to "mock" to test in a mock environment, ilib-env would get the top scope wrong under pnpm without the jsdom environment. To work around that, we first check for the existence of "window", then "global", then finally, "this" to guess at the actual right top scope properly under most platforms.