### PR TITLE
ilib-lint: Fix an issue with the ResourceQuoteStyle rule where the fix is not created when the commands overlap

### DIFF
--- a/.changeset/fast-ducks-know.md
+++ b/.changeset/fast-ducks-know.md
@@ -1,0 +1,5 @@
+---
+"ilib-lint": patch
+---
+
+Fix an issue with the ResourceQuoteStyle rule where the fix is not created when the commands overlap.

--- a/packages/ilib-lint/src/rules/ResourceQuoteStyle.js
+++ b/packages/ilib-lint/src/rules/ResourceQuoteStyle.js
@@ -228,6 +228,9 @@ class ResourceQuoteStyle extends ResourceRule {
                     correctQuoteEnd
                 ));
             }
+
+            commands = this._removeDuplicatedCommands(commands);
+
             if (commands.length > 0) {
                 fix = ResourceFixer.createFix({ resource, commands, index, category });
             }
@@ -256,6 +259,20 @@ class ResourceQuoteStyle extends ResourceRule {
             params.fix = fix;
         }
         return new Result(params);
+    }
+
+    _removeDuplicatedCommands(commands) {
+        if (commands.length < 2) return commands;
+
+        const checkItem = new Set();
+        return commands.filter(command => {
+            const key = `cmd_${command.stringFix.position}_${command.stringFix.deleteCount}`;
+            if (!checkItem.has(key)) {
+                checkItem.add(key);
+                return true;
+            }
+            return false;
+        });
     }
 
     /**

--- a/packages/ilib-lint/test/ResourceQuoteStyle.test.js
+++ b/packages/ilib-lint/test/ResourceQuoteStyle.test.js
@@ -686,6 +686,52 @@ describe("testResourceQuoteStyle", () => {
         expect(!actual).toBeTruthy();
     });
 
+    test("ResourceQuoteStyleMatchAsciiQuotesKorean", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-KR",
+            source: 'You can launch the Instant Game Response by setting HDMI ULTRA HD Deep Color "On".',
+            targetLocale: "ko-KR",
+            target: "HDMI UHD Deep Color를 '켜짐'으로 설정해야 게임 최적화 모드를 실행할 수 있습니다",
+            pathName: "a/b/ko-KR.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/ko-KR.xliff"
+        });
+        expect(actual).toBeTruthy();
+    });
+
+    test("ResourceQuoteStyleMatchAsciiQuotesChines", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-KR",
+            source: "Prevent Input Delay (Input Lag) setting will return to Standard if 'Game Optimizer' is not used.",
+            targetLocale: "zh-Hans-CN",
+            target: '如果未使用“游戏优化器”，则“防止输入延迟（输入滞后）”设置将返回“标准”',
+            pathName: "a/b/zh-Hans-CN.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/zh-Hans-CN.xliff"
+        });
+        expect(actual).toBeTruthy();
+    });
+
     test("ResourceQuoteStyleMatchAlternate", () => {
         expect.assertions(2);
 


### PR DESCRIPTION
Fix an issue with the `ResourceQuoteStyle` rule where the fix is not created when the commands overlap.

When the quote is a single quote ('), it is redundantly detected in both startQuote and endQuote, and thus included in the command. Therefore, I made it so that duplicates are removed from the command list before generating the fix.

