### PR TITLE
Fix resource-url-match rule

### DIFF
--- a/.changeset/curvy-crabs-ring.md
+++ b/.changeset/curvy-crabs-ring.md
@@ -1,0 +1,7 @@
+---
+"ilib-lint": patch
+---
+
+- Fixed the regex for parsing URLs in the resource-url-match rule
+  - does not accept a dot as the last character in the string anymore
+  - now supports URL queries, hashes, and URL-encoded characters

--- a/packages/ilib-lint/src/plugins/BuiltinPlugin.js
+++ b/packages/ilib-lint/src/plugins/BuiltinPlugin.js
@@ -55,7 +55,7 @@ export const regexRules = [
         name: "resource-url-match",
         description: "Ensure that URLs that appear in the source string are also used in the translated string",
         note: "URL '{matchString}' from the source string does not appear in the target string",
-        regexps: [ "((https?|github|ftps?|mailto|file|data|irc):\\/\\/)([\\da-zA-Z\\.-]+)\\.([a-zA-Z\\.]{2,6})([\\/\w\\.-]*)*\\/?" ],
+        regexps: [ "((https?|github|ftps?|mailto|file|data|irc):\\/\\/)([\\da-zA-Z\\.-]+)\\.([a-zA-Z\\.]{2,6})([\\/#\\?=%&\\w\\.-]*)*[\\/#\\?=%&\\w-]" ],
         link: "https://github.com/iLib-js/ilib-mono/blob/main/packages/ilib-lint/docs/resource-url-match.md"
     },
     {


### PR DESCRIPTION
- Fixed the regex for parsing URLs in the resource-url-match rule
  - does not accept a dot as the last character in the string anymore
  - now supports URL queries, hashes, and URL-encoded characters