### PR TITLE
Add Java and Kotlin parameter checking rules

### DIFF
--- a/.changeset/empty-shirts-beam.md
+++ b/.changeset/empty-shirts-beam.md
@@ -1,0 +1,12 @@
+---
+"ilib-lint": minor
+---
+
+- Added ResourceSentenceEnding rule with auto-fix support
+  - Matches the sentence ending punctuation in the English source string and
+    the locale-sensitive sentence-ending punctuation in the target string.
+  - Only checks the end of the string, not the middle.
+  - Ignores any quotation marks or whitespace at the end of the string
+  - Added support for both Unicode ellipsis (…) and three dots (...) in English
+  - Added configuration parameter support for custom punctuation mappings per locale
+  - Added documentation with developer-focused troubleshooting guide

--- a/packages/ilib-lint-java/CHANGELOG.md
+++ b/packages/ilib-lint-java/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Changelog
+

--- a/packages/ilib-lint-java/LICENSE
+++ b/packages/ilib-lint-java/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ilib-lint-java/README.md
+++ b/packages/ilib-lint-java/README.md
@@ -1,0 +1,53 @@
+# ilib-lint-java
+
+ilib-lint plugin that implements rules to check Java and Kotlin sources and translations.
+
+## Rules
+
+### resource-java-params
+
+Checks that Java MessageFormat replacement parameters in source strings are properly matched in target strings.
+
+**Example:**
+```java
+// Source: "Hello {0}, you have {1} messages"
+// Target: "Hola {0}, tienes {1} mensajes" ✓
+// Target: "Hola {0}, tienes mensajes" ✗ (missing {1})
+```
+
+### resource-kotlin-params
+
+Checks that Kotlin string template parameters in source strings are properly matched in target strings.
+
+**Example:**
+```kotlin
+// Source: "Hello $name, you have $count messages"
+// Target: "Hola $name, tienes $count mensajes" ✓
+// Target: "Hola $name, tienes mensajes" ✗ (missing $count)
+```
+
+## Installation
+
+```bash
+npm install ilib-lint-java
+```
+
+## Usage
+
+Add the plugin to your ilib-lint configuration:
+
+```javascript
+import JavaPlugin from 'ilib-lint-java';
+
+const config = {
+    plugins: [
+        JavaPlugin
+    ]
+};
+```
+
+## License
+
+Copyright © 2025 JEDLSoft
+
+Licensed under the Apache License, Version 2.0. 

--- a/packages/ilib-lint-java/docs/resource-java-params.md
+++ b/packages/ilib-lint-java/docs/resource-java-params.md
@@ -1,0 +1,69 @@
+# Resource Java Parameters
+
+## Description
+
+This rule checks that Java MessageFormat replacement parameters in source strings are properly matched in target strings.
+
+## Java MessageFormat Syntax
+
+Java MessageFormat uses indexed parameters with curly braces:
+
+- `{0}`, `{1}`, `{2}` - Simple indexed parameters
+- `{0,number,currency}` - Parameters with formatting
+- `{0,date,short}` - Date/time formatting
+- `{0,choice,0#no files|1#one file|1<{0,number,integer} files}` - Choice formatting
+
+## Examples
+
+### ✅ Correct Usage
+
+**Source:** `"Hello {0}, you have {1} messages"`
+**Target:** `"Hola {0}, tienes {1} mensajes"`
+
+**Source:** `"Price: {0,number,currency}"`
+**Target:** `"Precio: {0,number,currency}"`
+
+### ❌ Incorrect Usage
+
+**Source:** `"Hello {0}, you have {1} messages"`
+**Target:** `"Hola {0}, tienes mensajes"` (missing `{1}`)
+
+**Source:** `"Price: {0,number,currency}"`
+**Target:** `"Precio: {0}"` (missing formatting - must be `{0,number,currency}`)
+
+**Source:** `"Price: {0,number,currency}"`
+**Target:** `"Precio: {0,date}"` (wrong formatting - cannot change parameter type)
+
+## Error Messages
+
+- `"Missing Java MessageFormat parameters in target: {1}, {2}"`
+- `"Missing Java MessageFormat parameters in target: {0,number,currency}"` (for formatted parameters)
+- `"Missing Java MessageFormat parameters in target array item [0]: {1}"`
+- `"Missing Java MessageFormat parameters in target plural (other): {0}"`
+
+## Important Notes
+
+The rule checks that the **entire parameter specification** matches exactly between source and target. This means:
+
+- `{0,number,currency}` in source must be `{0,number,currency}` in target
+- `{0,date,short}` in source must be `{0,date,short}` in target  
+- You cannot change `{0,number,currency}` to `{0,date}` or `{0}` - the full specification must match
+
+## Configuration
+
+This rule is enabled by default in the `java` rule set.
+
+```javascript
+{
+    "ruleSets": {
+        "java": {
+            "resource-java-params": true
+        }
+    }
+}
+```
+
+## Related
+
+- [Java MessageFormat Documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/MessageFormat.html)
+- [resource-kotlin-params](./resource-kotlin-params.md) 

--- a/packages/ilib-lint-java/docs/resource-kotlin-params.md
+++ b/packages/ilib-lint-java/docs/resource-kotlin-params.md
@@ -1,0 +1,66 @@
+# Resource Kotlin Parameters
+
+## Description
+
+This rule checks that Kotlin string template parameters in source strings are properly matched in target strings.
+
+## Kotlin String Template Syntax
+
+Kotlin uses string templates with dollar signs:
+
+- `$variable` - Simple variable interpolation
+- `${expression}` - Expression interpolation
+- `${user.name}` - Property access
+- `${if (condition) "yes" else "no"}` - Complex expressions
+
+## Examples
+
+### ✅ Correct Usage
+
+**Source:** `"Hello $name, you have $count messages"`
+**Target:** `"Hola $name, tienes $count mensajes"`
+
+**Source:** `"Hello ${user.name}, you have ${messages.size} messages"`
+**Target:** `"Hola ${user.name}, tienes ${messages.size} mensajes"`
+
+**Source:** `"Price: $price"`
+**Target:** `"Precio: $price"`
+
+### ❌ Incorrect Usage
+
+**Source:** `"Hello $name, you have $count messages"`
+**Target:** `"Hola $name, tienes mensajes"` (missing `$count`)
+
+**Source:** `"Hello ${user.name}, you have ${messages.size} messages"`
+**Target:** `"Hola $user, tienes mensajes"` (missing `${messages.size}`)
+
+## Error Messages
+
+- `"Missing Kotlin string template parameters in target: $count, $price"`
+- `"Missing Kotlin string template parameters in target array item [0]: $name"`
+- `"Missing Kotlin string template parameters in target plural (other): $count"`
+
+## Configuration
+
+This rule is enabled by default in the `java` rule set.
+
+```javascript
+{
+    "ruleSets": {
+        "java": {
+            "resource-kotlin-params": true
+        }
+    }
+}
+```
+
+## Notes
+
+- The rule extracts the main variable name from expressions like `${user.name}` as `user`
+- Complex expressions are simplified to their primary variable when possible
+- Both simple (`$variable`) and expression (`${expression}`) syntax are supported
+
+## Related
+
+- [Kotlin String Templates Documentation](https://kotlinlang.org/docs/strings.html#string-templates)
+- [resource-java-params](./resource-java-params.md) 

--- a/packages/ilib-lint-java/jest.config.cjs
+++ b/packages/ilib-lint-java/jest.config.cjs
@@ -1,0 +1,11 @@
+const baseConfig = require('../../jest.config.js');
+
+const config = {
+    ...baseConfig,
+    displayName: {
+        name: "ilib-lint-java",
+        color: "blue",
+    },
+}
+
+module.exports = config; 

--- a/packages/ilib-lint-java/jsdoc.json
+++ b/packages/ilib-lint-java/jsdoc.json
@@ -1,0 +1,21 @@
+{
+    "source": {
+        "include": ["src"],
+        "includePattern": ".js$",
+        "excludePattern": "(node_modules/|docs)"
+    },
+    "plugins": ["plugins/markdown"],
+    "templates": {
+        "cleverLinks": false,
+        "monospaceLinks": false,
+        "default": {
+            "outputSourceFiles": true
+        },
+        "path": "node_modules/docdash"
+    },
+    "opts": {
+        "destination": "./docs/",
+        "recurse": true,
+        "readme": "./README.md"
+    }
+} 

--- a/packages/ilib-lint-java/package.json
+++ b/packages/ilib-lint-java/package.json
@@ -1,0 +1,43 @@
+{
+    "name": "ilib-lint-java",
+    "version": "1.0.0",
+    "type": "module",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "exports": {
+        ".": {
+            "import": "./src/index.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "description": "ilib-lint plugin to check for Java and Kotlin parameter replacement rules",
+    "files": [
+        "src",
+        "package.json",
+        "README.md"
+    ],
+    "engines": {
+        "node": ">=14.0.0"
+    },
+    "scripts": {
+        "coverage": "pnpm test -- --coverage",
+        "test": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js",
+        "test:watch": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
+        "debug": "LANG=en_US.UTF8 node --experimental-vm-modules --inspect-brk node_modules/jest/bin/jest.js -i",
+        "clean": "git clean -f -d src test",
+        "doc": "mkdir -p docs && jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/ilibLint.md && pnpm run doc:html",
+        "doc:html": "jsdoc -c jsdoc.json"
+    },
+    "devDependencies": {
+        "docdash": "^2.0.2",
+        "jest": "^29.7.0",
+        "jsdoc": "^4.0.2",
+        "jsdoc-to-markdown": "^8.0.1",
+        "npm-run-all": "^4.1.5"
+    },
+    "dependencies": {
+        "ilib-lint-common": "workspace:^",
+        "ilib-locale": "workspace:^",
+        "ilib-tools-common": "workspace:^"
+    }
+} 

--- a/packages/ilib-lint-java/src/ResourceJavaParams.js
+++ b/packages/ilib-lint-java/src/ResourceJavaParams.js
@@ -1,0 +1,205 @@
+/*
+ * ResourceJavaParams.js - Check for Java MessageFormat parameters in resources
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Result, Rule } from 'ilib-lint-common';
+
+/**
+ * @classdesc Class representing a check for Java MessageFormat parameters.
+ * @class
+ */
+class ResourceJavaParams extends Rule {
+    constructor(options) {
+        super(options);
+        this.name = "resource-java-params";
+        this.description = "Check that Java MessageFormat parameters in source strings are properly matched in target strings.";
+        this.sourceLocale = (options && options.sourceLocale) || "en-US";
+        this.link = "https://github.com/iLib-js/ilib-mono/blob/main/packages/ilib-lint-java/docs/resource-java-params.md";
+    }
+
+    getRuleType() {
+        return "resource";
+    }
+
+    /**
+     * Extract Java MessageFormat parameters from a string
+     * @param {string} str - The string to extract parameters from
+     * @returns {Array<string>} Array of full parameter specifications (e.g., ["{0}", "{1,number,currency}"])
+     */
+    extractJavaParams(str) {
+        if (!str || typeof str !== 'string') return [];
+        
+        // Match Java MessageFormat parameters: {0}, {1}, {2}, etc.
+        // Also handles complex format: {0,number,currency}, {1,date,short}, etc.
+        const paramRegex = /\{(\d+)(?:,[^}]*)?\}/g;
+        const params = [];
+        let match;
+        
+        while ((match = paramRegex.exec(str)) !== null) {
+            params.push(match[0]); // Extract the full parameter specification
+        }
+        
+        return [...new Set(params)]; // Remove duplicates
+    }
+
+    /**
+     * Check if target parameters include all required source parameters
+     * @param {Array<string>} sourceParams - Source parameters
+     * @param {Array<string>} targetParams - Target parameters
+     * @returns {boolean} True if target has all required parameters
+     */
+    hasAllRequiredParams(sourceParams, targetParams) {
+        // Check if all source parameters are present in target
+        return sourceParams.every(param => targetParams.includes(param));
+    }
+
+    /**
+     * Check parameters and return any errors or warnings
+     * @param {string} source - Source string
+     * @param {string} target - Target string
+     * @param {Object} resource - Resource object
+     * @param {Object} ir - Intermediate representation
+     * @param {Object} options - Options object
+     * @param {string} context - Context string for error messages (e.g., "array item [0]", "plural (other)")
+     * @returns {Array<Result>} Array of Result objects (errors and warnings)
+     */
+    checkParameters(source, target, resource, ir, options, context = '') {
+        const results = [];
+        const sourceParams = this.extractJavaParams(source);
+        const targetParams = this.extractJavaParams(target);
+        
+        // Check for missing parameters (error)
+        if (sourceParams.length > 0) {
+            if (!this.hasAllRequiredParams(sourceParams, targetParams)) {
+                const missingParams = sourceParams.filter(param => 
+                    !targetParams.includes(param)
+                );
+                
+                const description = context 
+                    ? `Missing Java MessageFormat parameters in target ${context}: ${missingParams.join(', ')}`
+                    : `Missing Java MessageFormat parameters in target: ${missingParams.join(', ')}`;
+                
+                const highlight = context 
+                    ? `${context} <e0>${target}</e0>`
+                    : `<e0>${target}</e0>`;
+                
+                results.push(new Result({
+                    severity: "error",
+                    id: resource.getKey(),
+                    source,
+                    description,
+                    rule: this,
+                    locale: resource.sourceLocale,
+                    pathName: ir.sourceFile.getPath(),
+                    highlight,
+                    lineNumber: options.lineNumber
+                }));
+            }
+        }
+        
+        // Check for extra parameters (warning)
+        const extraParams = targetParams.filter(param => !sourceParams.includes(param));
+        if (extraParams.length > 0) {
+            let highlightedTarget = target;
+            extraParams.forEach(param => {
+                // Escape regex special characters in param
+                const paramRegex = new RegExp(param.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+                highlightedTarget = highlightedTarget.replace(paramRegex, `<e0>${param}</e0>`);
+            });
+            
+            const description = context 
+                ? `Extra Java MessageFormat parameters in target ${context}: ${extraParams.join(', ')}`
+                : `Extra Java MessageFormat parameters in target: ${extraParams.join(', ')}`;
+            
+            const highlight = context 
+                ? `${context} <e0>${highlightedTarget}</e0>`
+                : highlightedTarget;
+            
+            results.push(new Result({
+                severity: "warning",
+                id: resource.getKey(),
+                source,
+                description,
+                rule: this,
+                locale: resource.sourceLocale,
+                pathName: ir.sourceFile.getPath(),
+                highlight,
+                lineNumber: options.lineNumber
+            }));
+        }
+        
+        return results;
+    }
+
+    /**
+     * @override
+     */
+    match(options) {
+        const { ir, locale } = options;
+
+        if (ir.getType() !== "resource") return;  // we can only process resources
+        const resources = ir.getRepresentation();
+
+        const results = resources.flatMap(resource => {
+            switch (resource.getType()) {
+                case 'string':
+                    const source = resource.getSource();
+                    const target = resource.getTarget();
+                    
+                    if (source && target) {
+                        return this.checkParameters(source, target, resource, ir, options);
+                    }
+                    break;
+
+                case 'array':
+                    const srcArray = resource.getSource();
+                    const tarArray = resource.getTarget();
+                    if (tarArray) {
+                        return srcArray.flatMap((item, i) => {
+                            if (i < tarArray.length && tarArray[i]) {
+                                return this.checkParameters(item, tarArray[i], resource, ir, options, `array item [${i}]`);
+                            }
+                            return [];
+                        }).filter(element => element);
+                    }
+                    break;
+
+                case 'plural':
+                    const srcPlural = resource.getSource();
+                    const tarPlural = resource.getTarget();
+                    if (tarPlural) {
+                        const categories = Array.from(new Set(Object.keys(tarPlural)).values());
+                        return categories.flatMap(category => {
+                            const item = srcPlural[category] || srcPlural.other;
+                            if (item && tarPlural[category]) {
+                                return this.checkParameters(item, tarPlural[category], resource, ir, options, `plural (${category})`);
+                            }
+                            return [];
+                        }).filter(element => element);
+                    }
+                    break;
+            }
+
+            return [];
+        }).filter(element => element);
+        
+        return results.length > 0 ? results : undefined;
+    }
+}
+
+export default ResourceJavaParams; 

--- a/packages/ilib-lint-java/src/ResourceKotlinParams.js
+++ b/packages/ilib-lint-java/src/ResourceKotlinParams.js
@@ -1,0 +1,219 @@
+/*
+ * ResourceKotlinParams.js - Check for Kotlin string template parameters in resources
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Result, Rule } from 'ilib-lint-common';
+
+/**
+ * @classdesc Class representing a check for Kotlin string template parameters.
+ * @class
+ */
+class ResourceKotlinParams extends Rule {
+    constructor(options) {
+        super(options);
+        this.name = "resource-kotlin-params";
+        this.description = "Check that Kotlin string template parameters in source strings are properly matched in target strings.";
+        this.sourceLocale = (options && options.sourceLocale) || "en-US";
+        this.link = "https://github.com/iLib-js/ilib-mono/blob/main/packages/ilib-lint-java/docs/resource-kotlin-params.md";
+    }
+
+    getRuleType() {
+        return "resource";
+    }
+
+    /**
+     * Extract Kotlin string template parameters from a string
+     * @param {string} str - The string to extract parameters from
+     * @returns {Array<string>} Array of parameter names (e.g., ["name", "count"])
+     */
+    extractKotlinParams(str) {
+        if (!str || typeof str !== 'string') return [];
+        
+        const params = [];
+        
+        // Match simple variable interpolation: $variable
+        // This regex matches $ followed by a valid Kotlin identifier, but not preceded by ${{
+        const simpleParamRegex = /\$([a-zA-Z_][a-zA-Z0-9_]*)\b(?![\w.]*\})/g;
+        let match;
+        
+        while ((match = simpleParamRegex.exec(str)) !== null) {
+            params.push(match[1]); // Extract the variable name
+        }
+        
+        // Match expression interpolation: ${expression}
+        // This regex matches ${...} where ... can contain anything except }
+        const expressionParamRegex = /\$\{([^}]+)\}/g;
+        
+        while ((match = expressionParamRegex.exec(str)) !== null) {
+            const expression = match[1].trim();
+            params.push(expression);
+        }
+        
+        return [...new Set(params)]; // Remove duplicates
+    }
+
+    /**
+     * Check if target parameters include all required source parameters
+     * @param {Array<string>} sourceParams - Source parameters
+     * @param {Array<string>} targetParams - Target parameters
+     * @returns {boolean} True if target has all required parameters
+     */
+    hasAllRequiredParams(sourceParams, targetParams) {
+        // Check if all source parameters are present in target
+        return sourceParams.every(param => targetParams.includes(param));
+    }
+
+    /**
+     * Check parameters and return any errors or warnings
+     * @param {string} source - Source string
+     * @param {string} target - Target string
+     * @param {Object} resource - Resource object
+     * @param {Object} ir - Intermediate representation
+     * @param {Object} options - Options object
+     * @param {string} context - Context string for error messages (e.g., "array item [0]", "plural (other)")
+     * @returns {Array<Result>} Array of Result objects (errors and warnings)
+     */
+    checkParameters(source, target, resource, ir, options, context = '') {
+        const results = [];
+        const sourceParams = this.extractKotlinParams(source);
+        const targetParams = this.extractKotlinParams(target);
+        
+        // Check for missing parameters (error)
+        if (sourceParams.length > 0) {
+            if (!this.hasAllRequiredParams(sourceParams, targetParams)) {
+                const missingParams = sourceParams.filter(param => 
+                    !targetParams.includes(param)
+                );
+                
+                const description = context 
+                    ? `Missing Kotlin string template parameters in target ${context}: $${missingParams.join(', $')}`
+                    : `Missing Kotlin string template parameters in target: $${missingParams.join(', $')}`;
+                
+                const highlight = context 
+                    ? `${context} <e0>${target}</e0>`
+                    : `<e0>${target}</e0>`;
+                
+                results.push(new Result({
+                    severity: "error",
+                    id: resource.getKey(),
+                    source,
+                    description,
+                    rule: this,
+                    locale: resource.sourceLocale,
+                    pathName: ir.sourceFile.getPath(),
+                    highlight,
+                    lineNumber: options.lineNumber
+                }));
+            }
+        }
+        
+        // Check for extra parameters (warning)
+        const extraParams = targetParams.filter(param => !sourceParams.includes(param));
+        if (extraParams.length > 0) {
+            let highlightedTarget = target;
+            extraParams.forEach(param => {
+                // For simple parameters ($variable), replace with highlighted version
+                const simpleParamRegex = new RegExp(`\\$${param.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b(?!\\w*\\.\\w*\\})`, 'g');
+                highlightedTarget = highlightedTarget.replace(simpleParamRegex, `<e0>$${param}</e0>`);
+                
+                // For expression parameters (${expression}), replace with highlighted version
+                const expressionParamRegex = new RegExp(`\\$\\{${param.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\}`, 'g');
+                highlightedTarget = highlightedTarget.replace(expressionParamRegex, `<e0>\${${param}}</e0>`);
+            });
+            
+            const description = context 
+                ? `Extra Kotlin string template parameters in target ${context}: $${extraParams.join(', $')}`
+                : `Extra Kotlin string template parameters in target: $${extraParams.join(', $')}`;
+            
+            const highlight = context 
+                ? `${context} <e0>${highlightedTarget}</e0>`
+                : highlightedTarget;
+            
+            results.push(new Result({
+                severity: "warning",
+                id: resource.getKey(),
+                source,
+                description,
+                rule: this,
+                locale: resource.sourceLocale,
+                pathName: ir.sourceFile.getPath(),
+                highlight,
+                lineNumber: options.lineNumber
+            }));
+        }
+        
+        return results;
+    }
+
+    /**
+     * @override
+     */
+    match(options) {
+        const { ir, locale } = options;
+
+        if (ir.getType() !== "resource") return;  // we can only process resources
+        const resources = ir.getRepresentation();
+
+        const results = resources.flatMap(resource => {
+            switch (resource.getType()) {
+                case 'string':
+                    const source = resource.getSource();
+                    const target = resource.getTarget();
+                    
+                    if (source && target) {
+                        return this.checkParameters(source, target, resource, ir, options);
+                    }
+                    break;
+
+                case 'array':
+                    const srcArray = resource.getSource();
+                    const tarArray = resource.getTarget();
+                    if (tarArray) {
+                        return srcArray.flatMap((item, i) => {
+                            if (i < tarArray.length && tarArray[i]) {
+                                return this.checkParameters(item, tarArray[i], resource, ir, options, `array item [${i}]`);
+                            }
+                            return [];
+                        });
+                    }
+                    break;
+
+                case 'plural':
+                    const srcPlural = resource.getSource();
+                    const tarPlural = resource.getTarget();
+                    if (tarPlural) {
+                        const categories = Array.from(new Set(Object.keys(tarPlural)).values());
+                        return categories.flatMap(category => {
+                            const item = srcPlural[category] || srcPlural.other;
+                            if (item && tarPlural[category]) {
+                                return this.checkParameters(item, tarPlural[category], resource, ir, options, `plural (${category})`);
+                            }
+                            return [];
+                        });
+                    }
+                    break;
+            }
+
+            return [];
+        });
+        
+        return results.length > 1 ? results : results[0];
+    }
+}
+
+export default ResourceKotlinParams; 

--- a/packages/ilib-lint-java/src/index.js
+++ b/packages/ilib-lint-java/src/index.js
@@ -1,0 +1,55 @@
+/*
+ * index.js - main entry point for the java plugin
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Plugin } from 'ilib-lint-common';
+
+import ResourceJavaParams from './ResourceJavaParams.js';
+import ResourceKotlinParams from './ResourceKotlinParams.js';
+
+class JavaPlugin extends Plugin {
+    constructor(options) {
+        super(options);
+    }
+
+    /** @override */
+    init() {
+    }
+
+    /** @override */
+    getRules() {
+        return [
+            ResourceJavaParams,
+            ResourceKotlinParams
+        ];
+    }
+
+    /** @override */
+    getRuleSets() {
+        return {
+            "java": {
+                "resource-java-params": true
+            },
+            "kotlin": {
+                "resource-kotlin-params": true
+            }
+        };
+    }
+}
+
+export default JavaPlugin; 

--- a/packages/ilib-lint-java/test/ResourceJavaParams.test.js
+++ b/packages/ilib-lint-java/test/ResourceJavaParams.test.js
@@ -1,0 +1,193 @@
+/*
+ * ResourceJavaParams.test.js - Test for ResourceJavaParams rule
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ResourceJavaParams from '../src/ResourceJavaParams.js';
+import { ResourceString, ResourceArray, ResourcePlural } from 'ilib-tools-common';
+import { SourceFile, IntermediateRepresentation } from 'ilib-lint-common';
+
+describe('ResourceJavaParams', () => {
+    let rule;
+    let sourceFile;
+
+    beforeEach(() => {
+        rule = new ResourceJavaParams();
+        sourceFile = new SourceFile('test.properties');
+    });
+
+    test('should extract Java MessageFormat parameters correctly', () => {
+        expect(rule.extractJavaParams('Hello {0}, you have {1} messages')).toEqual(['{0}', '{1}']);
+        expect(rule.extractJavaParams('Price: {0,number,currency}')).toEqual(['{0,number,currency}']);
+        expect(rule.extractJavaParams('Date: {0,date,short} at {0,time,short}')).toEqual(['{0,date,short}', '{0,time,short}']);
+        expect(rule.extractJavaParams('No parameters here')).toEqual([]);
+        expect(rule.extractJavaParams('')).toEqual([]);
+        expect(rule.extractJavaParams(null)).toEqual([]);
+    });
+
+    test('should check if all required parameters are present', () => {
+        expect(rule.hasAllRequiredParams(['{0}'], ['{0}'])).toBe(true);
+        expect(rule.hasAllRequiredParams(['{0}', '{1}'], ['{0}', '{1}'])).toBe(true);
+        expect(rule.hasAllRequiredParams(['{0}', '{1}'], ['{0}'])).toBe(false);
+        expect(rule.hasAllRequiredParams(['{0}'], [])).toBe(false);
+        expect(rule.hasAllRequiredParams(['{0,number,currency}'], ['{0,number,currency}'])).toBe(true);
+        expect(rule.hasAllRequiredParams(['{0,number,currency}'], ['{0}'])).toBe(false);
+        expect(rule.hasAllRequiredParams(['{0,number,currency}'], ['{0,date}'])).toBe(false);
+    });
+
+    test('should detect missing parameters in string resources', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello {0}, you have {1} messages', target: 'Hola {0}, tienes mensajes' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const error = Array.isArray(results) ? results.find(r => r && r.severity === 'error') : results;
+        
+        expect(error).toBeTruthy();
+        expect(error.description).toContain('Missing Java MessageFormat parameters in target: {1}');
+    });
+
+    test('should not trigger when all parameters are present', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello {0}, you have {1} messages', target: 'Hola {0}, tienes {1} mensajes' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const results = rule.match({ ir, locale: 'es-ES' });
+        expect(results).toBeUndefined();
+    });
+
+    test('should not trigger when no parameters are present', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello world', target: 'Hola mundo' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const results = rule.match({ ir, locale: 'es-ES' });
+        expect(results).toBeUndefined();
+    });
+
+    test('should detect mismatched parameter formatting', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Price: {0,number,currency}', target: 'Precio: {0}' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const error = Array.isArray(results) ? results.find(r => r && r.severity === 'error') : results;
+        
+        expect(error).toBeTruthy();
+        expect(error.description).toContain('Missing Java MessageFormat parameters in target: {0,number,currency}');
+    });
+
+    test('should handle array resources', () => {
+        const resource = new ResourceArray({ key: 'test.key', source: ['Hello {0}', 'You have {1} messages'], target: ['Hola {0}', 'Tienes mensajes'] });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const error = Array.isArray(results) && results.find(r => r && r.severity === 'error');
+        expect(error).toBeTruthy();
+        expect(error.description).toContain('Missing Java MessageFormat parameters in target array item [1]: {1}');
+    });
+
+    test('should handle plural resources', () => {
+        const resource = new ResourcePlural({ 
+            key: 'test.key', 
+            source: { one: 'You have {0} message', other: 'You have {0} messages' },
+            target: { one: 'Tienes {0} mensaje', other: 'Tienes mensajes' }
+        });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const error = Array.isArray(results) && results.find(r => r && r.severity === 'error');
+        expect(error).toBeTruthy();
+        expect(error.description).toContain('Missing Java MessageFormat parameters in target plural (other): {0}');
+    });
+
+    test('should warn if there are extra parameters in the target (string)', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello {0}', target: 'Hola {0} y {1}' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const warning = Array.isArray(results) ? results.find(r => r && r.severity === 'warning') : results;
+        expect(warning).toBeTruthy();
+        expect(warning.severity).toBe('warning');
+        expect(warning.description).toContain('Extra Java MessageFormat parameters in target: {1}');
+    });
+
+    test('should warn if there are extra parameters in the target (array)', () => {
+        const resource = new ResourceArray({ key: 'test.key', source: ['Hello {0}', 'You have {1} messages'], target: ['Hola {0} y {2}', 'Tienes {1} mensajes'] });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const warning = Array.isArray(results) && results.find(r => r && r.severity === 'warning');
+        expect(warning).toBeTruthy();
+        expect(warning.description).toContain('Extra Java MessageFormat parameters in target array item [0]: {2}');
+    });
+
+    test('should warn if there are extra parameters in the target (plural)', () => {
+        const resource = new ResourcePlural({ 
+            key: 'test.key', 
+            source: { one: 'You have {0} message', other: 'You have {0} messages' },
+            target: { one: 'Tienes {0} mensaje', other: 'Tienes {0} mensajes y {1}' }
+        });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const warning = Array.isArray(results) && results.find(r => r && r.severity === 'warning');
+        expect(warning).toBeTruthy();
+        expect(warning.description).toContain('Extra Java MessageFormat parameters in target plural (other): {1}');
+    });
+
+    test('should highlight extra parameter in the target (string)', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello {0}', target: 'Hola {0} y {1}' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const warning = Array.isArray(results) ? results.find(r => r && r.severity === 'warning') : results;
+        expect(warning).toBeTruthy();
+        expect(warning.highlight).toContain('<e0>{1}</e0>');
+        expect(warning.highlight).toContain('Hola {0} y <e0>{1}</e0>');
+    });
+
+    test('should highlight extra parameter in the target (array)', () => {
+        const resource = new ResourceArray({ key: 'test.key', source: ['Hello {0}', 'You have {1} messages'], target: ['Hola {0} y {2}', 'Tienes {1} mensajes'] });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const warning = Array.isArray(results) && results.find(r => r && r.severity === 'warning');
+        expect(warning).toBeTruthy();
+        expect(warning.highlight).toContain('<e0>{2}</e0>');
+        expect(warning.highlight).toContain('Hola {0} y <e0>{2}</e0>');
+    });
+
+    test('should highlight extra parameter in the target (plural)', () => {
+        const resource = new ResourcePlural({ 
+            key: 'test.key', 
+            source: { one: 'You have {0} message', other: 'You have {0} messages' },
+            target: { one: 'Tienes {0} mensaje', other: 'Tienes {0} mensajes y {1}' }
+        });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const warning = Array.isArray(results) && results.find(r => r && r.severity === 'warning');
+        expect(warning).toBeTruthy();
+        expect(warning.highlight).toContain('<e0>{1}</e0>');
+        expect(warning.highlight).toContain('Tienes {0} mensajes y <e0>{1}</e0>');
+    });
+
+    test('should highlight multiple extra parameters in the target (string)', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello {0}', target: 'Hola {0} y {1} y {2}' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        const results = rule.match({ ir, locale: 'es-ES' });
+        const warning = Array.isArray(results) ? results.find(r => r && r.severity === 'warning') : results;
+        expect(warning).toBeTruthy();
+        expect(warning.highlight).toContain('<e0>{1}</e0>');
+        expect(warning.highlight).toContain('<e0>{2}</e0>');
+        expect(warning.highlight).toContain('Hola {0} y <e0>{1}</e0> y <e0>{2}</e0>');
+    });
+}); 

--- a/packages/ilib-lint-java/test/ResourceKotlinParams.test.js
+++ b/packages/ilib-lint-java/test/ResourceKotlinParams.test.js
@@ -1,0 +1,181 @@
+/*
+ * ResourceKotlinParams.test.js - Test for ResourceKotlinParams rule
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ResourceKotlinParams from '../src/ResourceKotlinParams.js';
+import { ResourceString, ResourceArray, ResourcePlural } from 'ilib-tools-common';
+import { SourceFile, IntermediateRepresentation } from 'ilib-lint-common';
+
+describe('ResourceKotlinParams', () => {
+    let rule;
+    let sourceFile;
+
+    beforeEach(() => {
+        rule = new ResourceKotlinParams();
+        sourceFile = new SourceFile('test.kt');
+    });
+
+    test('should extract Kotlin string template parameters correctly', () => {
+        expect(rule.extractKotlinParams('Hello $name, you have $count messages')).toEqual(['name', 'count']);
+        expect(rule.extractKotlinParams('Price: $price')).toEqual(['price']);
+        expect(rule.extractKotlinParams('Hello ${user.name}, you have ${messages.size} messages')).toEqual(['user.name', 'messages.size']);
+        expect(rule.extractKotlinParams('No parameters here')).toEqual([]);
+        expect(rule.extractKotlinParams('')).toEqual([]);
+        expect(rule.extractKotlinParams(null)).toEqual([]);
+    });
+
+    test('should handle complex expressions in Kotlin templates', () => {
+        expect(rule.extractKotlinParams('Hello ${if (age >= 18) "adult" else "minor"}')).toEqual(['if (age >= 18) "adult" else "minor"']);
+        expect(rule.extractKotlinParams('Count: ${items.size}')).toEqual(['items.size']);
+        expect(rule.extractKotlinParams('${user.firstName} ${user.lastName}')).toEqual(['user.firstName', 'user.lastName']);
+    });
+
+    test('should check if all required parameters are present', () => {
+        expect(rule.hasAllRequiredParams(['name'], ['name'])).toBe(true);
+        expect(rule.hasAllRequiredParams(['name', 'count'], ['name', 'count'])).toBe(true);
+        expect(rule.hasAllRequiredParams(['name', 'count'], ['name'])).toBe(false);
+        expect(rule.hasAllRequiredParams(['name'], [])).toBe(false);
+    });
+
+    test('should detect missing parameters in string resources', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello $name, you have $count messages', target: 'Hola $name, tienes mensajes' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeTruthy();
+        expect(result.description).toContain('Missing Kotlin string template parameters in target: $count');
+    });
+
+    test('should not trigger when all parameters are present', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello $name, you have $count messages', target: 'Hola $name, tienes $count mensajes' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeUndefined();
+    });
+
+    test('should not trigger when no parameters are present', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello world', target: 'Hola mundo' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeUndefined();
+    });
+
+    test('should handle array resources', () => {
+        const resource = new ResourceArray({ key: 'test.key', source: ['Hello $name', 'You have $count messages'], target: ['Hola $name', 'Tienes mensajes'] });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeTruthy();
+        expect(result.description).toContain('Missing Kotlin string template parameters in target array item [1]: $count');
+    });
+
+    test('should handle plural resources', () => {
+        const resource = new ResourcePlural({ 
+            key: 'test.key', 
+            source: { one: 'You have $count message', other: 'You have $count messages' },
+            target: { one: 'Tienes $count mensaje', other: 'Tienes mensajes' }
+        });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeTruthy();
+        expect(result.description).toContain('Missing Kotlin string template parameters in target plural (other): $count');
+    });
+
+    test('should handle mixed simple and expression parameters', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello $name, you have ${messages.size} messages', target: 'Hola $name, tienes mensajes' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeTruthy();
+        expect(result.description).toContain('Missing Kotlin string template parameters in target: $messages');
+    });
+
+    test('should warn about extra parameters in target string', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello $name', target: 'Hola $name, tienes $count mensajes' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeTruthy();
+        expect(result.severity).toBe('warning');
+        expect(result.description).toContain('Extra Kotlin string template parameters in target: $count');
+        expect(result.highlight).toContain('<e0>$count</e0>');
+    });
+
+    test('should warn about extra parameters in target array', () => {
+        const resource = new ResourceArray({ key: 'test.key', source: ['Hello $name'], target: ['Hola $name, tienes $count mensajes'] });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeTruthy();
+        expect(result.severity).toBe('warning');
+        expect(result.description).toContain('Extra Kotlin string template parameters in target array item [0]: $count');
+        expect(result.highlight).toContain('<e0>$count</e0>');
+    });
+
+    test('should warn about extra parameters in target plural', () => {
+        const resource = new ResourcePlural({ 
+            key: 'test.key', 
+            source: { one: 'You have $count message', other: 'You have $count messages' },
+            target: { one: 'Tienes $count mensaje, $extra', other: 'Tienes $count mensajes' }
+        });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeTruthy();
+        expect(result.severity).toBe('warning');
+        expect(result.description).toContain('Extra Kotlin string template parameters in target plural (one): $extra');
+        expect(result.highlight).toContain('<e0>$extra</e0>');
+    });
+
+    test('should handle multiple extra parameters', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello $name', target: 'Hola $name, tienes $count $extra mensajes' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeTruthy();
+        expect(result.severity).toBe('warning');
+        expect(result.description).toContain('Extra Kotlin string template parameters in target: $count, $extra');
+        expect(result.highlight).toContain('<e0>$count</e0>');
+        expect(result.highlight).toContain('<e0>$extra</e0>');
+    });
+
+    test('should handle extra expression parameters', () => {
+        const resource = new ResourceString({ key: 'test.key', source: 'Hello $name', target: 'Hola $name, tienes ${messages.size} mensajes' });
+        const ir = new IntermediateRepresentation({ type: 'resource', ir: [resource], sourceFile });
+        
+        const result = rule.match({ ir, locale: 'es-ES' });
+        
+        expect(result).toBeTruthy();
+        expect(result.severity).toBe('warning');
+        expect(result.description).toContain('Extra Kotlin string template parameters in target: $messages');
+        expect(result.highlight).toContain('<e0>${messages.size}</e0>');
+    });
+}); 

--- a/packages/ilib-lint-javascript/LICENSE
+++ b/packages/ilib-lint-javascript/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ilib-lint/docs/resource-sentence-ending.md
+++ b/packages/ilib-lint/docs/resource-sentence-ending.md
@@ -50,15 +50,22 @@ If you need different punctuation rules for your project, add this to your confi
 
 ```json
 {
-  "rules": {
-    "resource-sentence-ending": {
-      "fr": {
-        "period": "!",
-        "question": "?",
-        "exclamation": "!",
-        "ellipsis": "...",
-        "colon": ":"
+  "rulesets": {
+    "myset": {
+      "resource-sentence-ending": {
+        "fr": {
+          "period": "!",
+          "question": "?",
+          "exclamation": "!",
+          "ellipsis": "...",
+          "colon": ":"
+        }
       }
+    }
+  },
+  "filetypes": {
+    "mytype": {
+      "ruleset": [ "myset" ]
     }
   }
 }

--- a/packages/ilib-lint/docs/resource-sentence-ending.md
+++ b/packages/ilib-lint/docs/resource-sentence-ending.md
@@ -4,18 +4,18 @@
 
 This rule ensures that sentence-ending punctuation in translated strings matches the conventions of the target language.
 
-**Example Issue:**
+**Example Issues:**
 ```
 Sentence ending punctuation should be "。" for ja-JP locale, not "."
 ```
 
 ## How to Fix
 
-### For Japanese, Chinese, and Korean
+### For Japanese and Chinese
 Replace English punctuation with the appropriate full-width characters:
 
-| English | Japanese/Chinese/Korean |
-|---------|------------------------|
+| English | Japanese/Chinese |
+|---------|-----------------|
 | `.` | `。` |
 | `?` | `？` |
 | `!` | `！` |
@@ -40,8 +40,13 @@ Replace English punctuation with the appropriate full-width characters:
 | Tibetan | `།` | `།` | `།` |
 | Amharic | `።` | `፧` | `!` |
 | Urdu | `۔` | `؟` | `!` |
+| Assamese | `।` | `?` | `!` |
+| Hindi | `।` | `?` | `!` |
+| Oriya | `।` | `?` | `!` |
+| Punjabi | `।` | `?` | `!` |
+| Kannada | `।` | `?` | `!` |
 
-### For Unsupported Languages
+### For Other Languages
 The rule defaults to English punctuation. If you need different punctuation for your language, use custom configuration.
 
 ## Custom Configuration
@@ -91,7 +96,7 @@ The rule handles quotes correctly. Focus on the punctuation before the quotes:
 ### Ellipsis
 Replace `...` with the appropriate character for your language:
 
-**Japanese/Chinese/Korean:**
+**Japanese/Chinese:**
 ```xml
 <source>Loading...</source>
 <target>読み込み中…</target>

--- a/packages/ilib-lint/docs/resource-sentence-ending.md
+++ b/packages/ilib-lint/docs/resource-sentence-ending.md
@@ -1,0 +1,103 @@
+# Resource Sentence Ending Rule
+
+## What This Rule Checks
+
+This rule ensures that sentence-ending punctuation in translated strings matches the conventions of the target language.
+
+**Example Issue:**
+```
+Sentence ending punctuation should be "。" for ja-JP locale, not "."
+```
+
+## How to Fix
+
+### For Japanese, Chinese, and Korean
+Replace English punctuation with the appropriate full-width characters:
+
+| English | Japanese/Chinese/Korean |
+|---------|------------------------|
+| `.` | `。` |
+| `?` | `？` |
+| `!` | `！` |
+| `:` | `：` |
+
+**Before:**
+```xml
+<target>こんにちは世界.</target>
+```
+
+**After:**
+```xml
+<target>こんにちは世界。</target>
+```
+
+### For Other Supported Languages
+
+| Language | Period | Question | Exclamation |
+|----------|--------|----------|-------------|
+| Greek | `.` | `;` | `!` |
+| Arabic | `.` | `؟` | `!` |
+| Tibetan | `།` | `།` | `།` |
+| Amharic | `።` | `፧` | `!` |
+| Urdu | `۔` | `؟` | `!` |
+
+### For Unsupported Languages
+The rule defaults to English punctuation. If you need different punctuation for your language, use custom configuration.
+
+## Custom Configuration
+
+If you need different punctuation rules for your project, add this to your config:
+
+```json
+{
+  "rules": {
+    "resource-sentence-ending": {
+      "fr": {
+        "period": "!",
+        "question": "?",
+        "exclamation": "!",
+        "ellipsis": "...",
+        "colon": ":"
+      }
+    }
+  }
+}
+```
+
+## Common Scenarios
+
+### Quotes at the End
+The rule handles quotes correctly. Focus on the punctuation before the quotes:
+
+**Correct:**
+```xml
+<source>He said "Hello."</source>
+<target>彼は「こんにちは。」と言いました</target>
+```
+
+**Incorrect:**
+```xml
+<source>He said "Hello."</source>
+<target>彼は「こんにちは。」と言いました.</target>
+```
+
+### Ellipsis
+Replace `...` with the appropriate character for your language:
+
+**Japanese/Chinese/Korean:**
+```xml
+<source>Loading...</source>
+<target>読み込み中…</target>
+```
+
+## Disabling the Rule
+
+If you need to disable this rule for specific cases, add it to your ignore list:
+
+```json
+{
+  "rules": {
+    "resource-sentence-ending": false
+  }
+}
+```

--- a/packages/ilib-lint/src/plugins/BuiltinPlugin.js
+++ b/packages/ilib-lint/src/plugins/BuiltinPlugin.js
@@ -31,6 +31,7 @@ import JsonFormatter from '../formatters/JsonFormatter.js';
 import ResourceICUPlurals from '../rules/ResourceICUPlurals.js';
 import ResourceICUPluralTranslation from '../rules/ResourceICUPluralTranslation.js';
 import ResourceQuoteStyle from '../rules/ResourceQuoteStyle.js';
+import ResourceSentenceEnding from '../rules/ResourceSentenceEnding.js';
 import ResourceUniqueKeys from '../rules/ResourceUniqueKeys.js';
 import ResourceEdgeWhitespace from '../rules/ResourceEdgeWhitespace.js';
 import ResourceCompleteness from '../rules/ResourceCompleteness.js';
@@ -440,6 +441,9 @@ export const builtInRulesets = {
     "windows": {
         "resource-return-char": true
     },
+    "punctuation-checks": {
+        "resource-sentence-ending": true
+    },
     "tap": {
         "resource-tap-named-params": true
     }
@@ -498,6 +502,7 @@ class BuiltinPlugin extends Plugin {
             ResourceICUPlurals,
             ResourceICUPluralTranslation,
             ResourceQuoteStyle,
+            ResourceSentenceEnding,
             ResourceUniqueKeys,
             ResourceEdgeWhitespace,
             ResourceCompleteness,

--- a/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
+++ b/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
@@ -1,0 +1,311 @@
+/*
+ * ResourceSentenceEnding.js - rule to check sentence-ending punctuation in the target string
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ResourceSentenceEnding - Checks that sentence-ending punctuation is appropriate for the target locale
+ * 
+ * This rule checks if the source string ends with certain punctuation marks and ensures
+ * the target uses the locale-appropriate equivalent.
+ * 
+ * Examples:
+ * - English period (.) should become Japanese maru (。) in Japanese
+ * - English question mark (?) should become Japanese question mark (？) in Japanese
+ * - English exclamation mark (!) should become Japanese exclamation mark (！) in Japanese
+ * - English ellipsis (...) should become Japanese ellipsis (…) in Japanese
+ * - English colon (:) should become Japanese colon (：) in Japanese
+ */
+
+import { Result } from 'ilib-lint-common';
+import ResourceRule from './ResourceRule.js';
+import Locale from 'ilib-locale';
+import ResourceFixer from '../plugins/resource/ResourceFixer.js';
+
+/** @ignore @typedef {import("ilib-tools-common").Resource} Resource */
+
+/**
+ * @class ResourceSentenceEnding
+ * @extends ResourceRule
+ */
+class ResourceSentenceEnding extends ResourceRule {
+    constructor(options) {
+        super(options);
+        this.name = "resource-sentence-ending";
+        this.description = "Checks that sentence-ending punctuation is appropriate for the target locale";
+        this.link = "https://github.com/iLib-js/ilib-lint/blob/main/docs/resource-sentence-ending.md";
+        
+        // Initialize custom punctuation mappings from configuration
+        this.customPunctuationMap = {};
+        
+        if (options && options.param) {
+            if (typeof options.param === 'object' && !Array.isArray(options.param)) {
+                // param is an object with locale codes as keys and punctuation mappings as values
+                this.customPunctuationMap = options.param;
+            }
+        }
+    }
+
+    /**
+     * Check if the given string ends with any of the specified punctuation patterns
+     * @param {string} str - The string to check
+     * @returns {Object|null} - Object with type and original punctuation, or null if no match
+     */
+    getEndingPunctuation(str) {
+        if (!str || typeof str !== 'string') return null;
+        
+        const trimmed = str.trim();
+        if (!trimmed) return null;
+
+        // Patterns to match, in order of specificity (longer patterns first)
+        const patterns = [
+            // Ellipsis patterns (three dots or Unicode ellipsis)
+            { regex: /\.\.\.$/, type: 'ellipsis', original: '...' },
+            { regex: /…$/, type: 'ellipsis', original: '…' },
+            
+            // Punctuation followed by quotes
+            { regex: /\.["']$/, type: 'period', original: trimmed.slice(-2) },
+            { regex: /\?["']$/, type: 'question', original: trimmed.slice(-2) },
+            { regex: /!["']$/, type: 'exclamation', original: trimmed.slice(-2) },
+            { regex: /:["']$/, type: 'colon', original: trimmed.slice(-2) },
+            
+            // Single punctuation marks
+            { regex: /\.$/, type: 'period', original: '.' },
+            { regex: /\?$/, type: 'question', original: '?' },
+            { regex: /!$/, type: 'exclamation', original: '!' },
+            { regex: /:$/, type: 'colon', original: ':' }
+        ];
+
+        for (const pattern of patterns) {
+            if (pattern.regex.test(trimmed)) {
+                return pattern;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the expected punctuation for the given locale and punctuation type
+     * @param {Locale} localeObj - The parsed locale object
+     * @param {string} type - The punctuation type
+     * @param {string} sourceOriginal - The original punctuation from the source
+     * @returns {string|string[]|null} - The expected punctuation(s) for the locale, or null if punctuation is optional
+     */
+    getExpectedPunctuation(localeObj, type, sourceOriginal) {
+        const baseLocale = localeObj.getLanguage();
+        if (!baseLocale) return null;
+        // Custom config
+        if (this.customPunctuationMap[baseLocale] && this.customPunctuationMap[baseLocale][type]) {
+            return this.customPunctuationMap[baseLocale][type];
+        }
+        // For English ellipsis, allow both forms (return array)
+        if (baseLocale === 'en' && type === 'ellipsis') {
+            if (sourceOriginal === '...') return ['...', '…'];
+            if (sourceOriginal === '…') return ['…', '...'];
+            return ['...', '…'];
+        }
+        // For all other cases, always return a string
+        const punctuationMap = {
+            'ja': { 'period': '。', 'question': '？', 'exclamation': '！', 'ellipsis': '…', 'colon': '：' },
+            'zh': { 'period': '。', 'question': '？', 'exclamation': '！', 'ellipsis': '…', 'colon': '：' },
+            'ko': { 'period': '。', 'question': '？', 'exclamation': '！', 'ellipsis': '…', 'colon': '：' },
+            'el': { 'period': '.', 'question': ';', 'exclamation': '!', 'ellipsis': '...', 'colon': ':' },
+            'ar': { 'period': '.', 'question': '؟', 'exclamation': '!', 'ellipsis': '…', 'colon': ':' },
+            'bo': { 'period': '།', 'question': '།', 'exclamation': '།', 'ellipsis': '…', 'colon': '།' },
+            'am': { 'period': '።', 'question': '፧', 'exclamation': '!', 'ellipsis': '…', 'colon': ':' },
+            'ur': { 'period': '۔', 'question': '؟', 'exclamation': '!', 'ellipsis': '…', 'colon': ':' }
+        };
+        const result = punctuationMap[baseLocale]?.[type] || this.getDefaultPunctuation(type);
+        return result;
+    }
+
+    /**
+     * Get default punctuation (Western/English style)
+     * @param {string} type - The punctuation type
+     * @returns {string} - The default punctuation
+     */
+    getDefaultPunctuation(type) {
+        const defaults = {
+            'period': '.',
+            'question': '?',
+            'exclamation': '!',
+            'ellipsis': '…',
+            'colon': ':'
+        };
+        return defaults[type] || '.';
+    }
+
+    // Superset of quote characters from ResourceQuoteStyle.js, plus ASCII quotes
+    static allQuoteChars = '"' + "'" + "«»‘“”„「」’‚‹›『』";
+
+    /**
+     * Find the last non-quote, non-whitespace character, and return the substring up to and including it.
+     * This is used to check the actual sentence-ending punctuation before any trailing quotes or spaces.
+     * @param {string} str
+     * @returns {string}
+     */
+    static stripTrailingQuotesAndWhitespace(str) {
+        if (!str) return str;
+        // Find the last non-quote, non-whitespace character
+        const quoteChars = ResourceSentenceEnding.allQuoteChars;
+        // This regex matches trailing quotes and whitespace
+        const regex = new RegExp(`[${quoteChars.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}\s]+$`, 'u');
+        // Remove trailing quotes/whitespace
+        let trimmed = str.replace(regex, '');
+        // Now, find the last non-quote, non-whitespace character
+        let i = trimmed.length - 1;
+        while (i >= 0 && (quoteChars.includes(trimmed[i]) || /\s/.test(trimmed[i]))) {
+            i--;
+        }
+        return trimmed.substring(0, i + 1);
+    }
+
+    /**
+     * Check if the target string has the expected ending punctuation
+     * @param {string} target - The target string
+     * @param {string|string[]} expected - The expected punctuation(s)
+     * @param {string} original - The original punctuation from source
+     * @returns {boolean} - True if the target has the expected ending
+     */
+    hasExpectedEnding(target, expected, original) {
+        if (!target || typeof target !== 'string') return false;
+        const stripped = ResourceSentenceEnding.stripTrailingQuotesAndWhitespace(target.trim());
+        if (!stripped) return false;
+        if (Array.isArray(expected)) {
+            return expected.some(e => stripped.endsWith(e));
+        }
+        return stripped.endsWith(expected);
+    }
+
+    /**
+     * Find the position of the incorrect punctuation in the target string
+     * @param {string} target - The target string
+     * @param {string} incorrectPunctuation - The incorrect punctuation to find
+     * @returns {Object|null} - Object with position and length, or null if not found
+     */
+    findIncorrectPunctuationPosition(target, incorrectPunctuation) {
+        if (!target || !incorrectPunctuation) return null;
+        
+        const stripped = ResourceSentenceEnding.stripTrailingQuotesAndWhitespace(target.trim());
+        if (!stripped) return null;
+        
+        // Find the position of the incorrect punctuation at the end
+        const punctuationLength = incorrectPunctuation.length;
+        const endPosition = stripped.length - punctuationLength;
+        
+        if (endPosition >= 0 && stripped.substring(endPosition) === incorrectPunctuation) {
+            // Calculate the position in the original target string
+            const originalEndPosition = target.length - (target.trim().length - stripped.length) - punctuationLength;
+            return {
+                position: originalEndPosition,
+                length: punctuationLength
+            };
+        }
+        
+        return null;
+    }
+
+    /**
+     * Create a fix to replace the incorrect punctuation with the correct one
+     * @param {Resource} resource - The resource object
+     * @param {string} target - The target string
+     * @param {string} incorrectPunctuation - The incorrect punctuation
+     * @param {string} correctPunctuation - The correct punctuation
+     * @returns {Object|null} - The fix object or null if no fix can be created
+     */
+    createPunctuationFix(resource, target, incorrectPunctuation, correctPunctuation) {
+        const positionInfo = this.findIncorrectPunctuationPosition(target, incorrectPunctuation);
+        if (!positionInfo) return null;
+        
+        return ResourceFixer.createFix({
+            resource,
+            commands: [
+                ResourceFixer.createStringCommand(
+                    positionInfo.position,
+                    positionInfo.length,
+                    correctPunctuation
+                )
+            ]
+        });
+    }
+
+    /**
+     * Match the source and target strings for sentence ending punctuation issues
+     * @param {Object} params - Parameters object
+     * @param {string} params.source - The source string
+     * @param {string} params.target - The target string
+     * @param {Resource} params.resource - The resource object
+     * @param {string} params.file - The file path
+     * @returns {Result|null} - A Result object if there's an issue, null otherwise
+     */
+    matchString({ source, target, resource, file }) {
+        if (!source || !target || !resource) return null;
+        const sourceEnding = this.getEndingPunctuation(source);
+        if (!sourceEnding) return null;
+        const targetLocale = resource.getTargetLocale();
+        if (!targetLocale) return null;
+        const localeObj = new Locale(targetLocale);
+        const baseLocale = localeObj.getLanguage();
+        if (!baseLocale) return null;
+        const optionalPunctuationLanguages = ['th', 'lo', 'my', 'km'];
+        if (optionalPunctuationLanguages.includes(baseLocale)) return null;
+        // Pass sourceEnding.original to getExpectedPunctuation for ellipsis
+        const expectedPunctuation = this.getExpectedPunctuation(localeObj, sourceEnding.type, sourceEnding.original);
+        if (expectedPunctuation && this.hasExpectedEnding(target, expectedPunctuation, sourceEnding.original)) {
+            return null;
+        }
+        if (!expectedPunctuation) return null;
+        const strippedTarget = ResourceSentenceEnding.stripTrailingQuotesAndWhitespace(target.trim());
+        let actualPunctuation = null;
+        const patterns = [
+            { regex: /\.{3}$/, punctuation: '...' },
+            { regex: /…$/, punctuation: '…' },
+            { regex: /\.$/, punctuation: '.' },
+            { regex: /\?$/, punctuation: '?' },
+            { regex: /!$/, punctuation: '!' },
+            { regex: /:$/, punctuation: ':' }
+        ];
+        for (const pattern of patterns) {
+            if (pattern.regex.test(strippedTarget)) {
+                actualPunctuation = pattern.punctuation;
+                break;
+            }
+        }
+        // For English ellipsis, prefer the form used in the source for the fix
+        let fix = null;
+        if (Array.isArray(expectedPunctuation) && actualPunctuation && !expectedPunctuation.includes(actualPunctuation)) {
+            // Prefer the first form in expectedPunctuation (source form)
+            fix = this.createPunctuationFix(resource, target, actualPunctuation, expectedPunctuation[0]);
+        } else if (actualPunctuation && actualPunctuation !== expectedPunctuation) {
+            fix = this.createPunctuationFix(resource, target, actualPunctuation, Array.isArray(expectedPunctuation) ? expectedPunctuation[0] : expectedPunctuation);
+        }
+        return new Result({
+            rule: this,
+            severity: "warning",
+            id: "sentence-ending-punctuation",
+            description: `Sentence ending punctuation should be "${Array.isArray(expectedPunctuation) ? expectedPunctuation[0] : expectedPunctuation}" for ${targetLocale} locale, not "${actualPunctuation || sourceEnding.original}"`,
+            source: source,
+            highlight: `Target should end with "${Array.isArray(expectedPunctuation) ? expectedPunctuation[0] : expectedPunctuation}"`,
+            pathName: file,
+            fix,
+            lineNumber: typeof(resource.lineNumber) !== 'undefined' ? resource.lineNumber : undefined
+        });
+    }
+}
+
+export default ResourceSentenceEnding; 

--- a/packages/ilib-lint/test/PluginManager.test.js
+++ b/packages/ilib-lint/test/PluginManager.test.js
@@ -365,7 +365,7 @@ __Rule_(resource-test):_Test_for_the_existence_of_the_word_'test'_in_the_strings
         const rm = plgmgr.getRuleManager();
         expect(rm).toBeTruthy();
 
-        expect(rm.sizeRuleSetDefinitions()).toBe(8);
+        expect(rm.sizeRuleSetDefinitions()).toBe(9);
 
         const genericRuleset = rm.getRuleSetDefinition("generic");
         expect(genericRuleset).toBeTruthy();

--- a/packages/ilib-lint/test/ResourceSentenceEnding.test.js
+++ b/packages/ilib-lint/test/ResourceSentenceEnding.test.js
@@ -54,7 +54,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Japanese target already has correct maru (。)
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Japanese period triggers warning if not maru", () => {
@@ -103,7 +103,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Japanese target already has correct question mark (？)
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Japanese question mark triggers warning if not fullwidth", () => {
@@ -152,7 +152,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Japanese target already has correct exclamation mark (！)
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Japanese exclamation mark triggers warning if not fullwidth", () => {
@@ -201,7 +201,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Japanese target already has correct ellipsis (…)
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Japanese ellipsis triggers warning if not Unicode ellipsis", () => {
@@ -250,7 +250,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because both source and target have Unicode ellipsis
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("English: source can end with ... or …, but target must end with Unicode ellipsis", () => {
@@ -274,7 +274,7 @@ describe("ResourceSentenceEnding rule", function() {
             resource: resource1,
             file: resource1.pathName
         });
-        expect(result1).toBeNull();
+        expect(result1).toBeUndefined();
 
         // Source: …, Target: … (should not trigger)
         const resource2 = new ResourceString({
@@ -292,7 +292,7 @@ describe("ResourceSentenceEnding rule", function() {
             resource: resource2,
             file: resource2.pathName
         });
-        expect(result2).toBeNull();
+        expect(result2).toBeUndefined();
 
         // Source: ..., Target: ... (should trigger warning)
         const resource3 = new ResourceString({
@@ -335,7 +335,7 @@ describe("ResourceSentenceEnding rule", function() {
             resource: resource1,
             file: resource1.pathName
         });
-        expect(result1).toBeNull();
+        expect(result1).toBeUndefined();
 
         // Source: …, Target: … (should not trigger)
         const resource2 = new ResourceString({
@@ -353,7 +353,7 @@ describe("ResourceSentenceEnding rule", function() {
             resource: resource2,
             file: resource2.pathName
         });
-        expect(result2).toBeNull();
+        expect(result2).toBeUndefined();
 
         // Source: ..., Target: ... (should trigger warning)
         const resource3 = new ResourceString({
@@ -396,7 +396,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Japanese target already has correct colon (：)
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Japanese colon triggers warning if not fullwidth", () => {
@@ -445,7 +445,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Chinese target already has correct period (。)
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Chinese period triggers warning if not ideographic full stop", () => {
@@ -473,33 +473,8 @@ describe("ResourceSentenceEnding rule", function() {
         expect(actual.description).toContain("Sentence ending punctuation should be \"。\" for zh-CN locale");
     });
 
-    test("Korean period is converted to ideographic full stop", () => {
+    test("Korean period is the same as a Western period", () => {
         expect.assertions(2);
-
-        const rule = new ResourceSentenceEnding();
-        expect(rule).toBeTruthy();
-
-        const resource = new ResourceString({
-            key: "korean.period.test",
-            sourceLocale: "en-US",
-            source: "This is a sentence.",
-            targetLocale: "ko-KR",
-            target: "이것은 문장입니다。",
-            pathName: "a/b/c.xliff",
-            lineNumber: 1
-        });
-        const actual = rule.matchString({
-            source: resource.getSource(),
-            target: resource.getTarget(),
-            resource,
-            file: "a/b/c.xliff"
-        });
-        // Should not trigger because Korean target already has correct period (。)
-        expect(actual === null).toBeTruthy();
-    });
-
-    test("Korean period triggers warning if not ideographic full stop", () => {
-        expect.assertions(3);
 
         const rule = new ResourceSentenceEnding();
         expect(rule).toBeTruthy();
@@ -511,6 +486,31 @@ describe("ResourceSentenceEnding rule", function() {
             targetLocale: "ko-KR",
             target: "이것은 문장입니다.",
             pathName: "a/b/c.xliff",
+            lineNumber: 1
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Korean target already has correct Western period (.)
+        expect(actual === undefined).toBeTruthy();
+    });
+
+    test("Korean period triggers warning if not Western period", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "korean.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "ko-KR",
+            target: "이것은 문장입니다。",
+            pathName: "a/b/c.xliff",
             lineNumber: 2
         });
         const actual = rule.matchString({
@@ -519,9 +519,9 @@ describe("ResourceSentenceEnding rule", function() {
             resource,
             file: "a/b/c.xliff"
         });
-        // Should trigger because Korean target has English period instead of Korean one
+        // Should trigger because Korean target has Japanese period instead of Western one
         expect(actual).toBeTruthy();
-        expect(actual.description).toContain("Sentence ending punctuation should be \"。\" for ko-KR locale");
+        expect(actual.description).toContain("Sentence ending punctuation should be \".\" for ko-KR locale");
     });
 
     test("English to English does not trigger", () => {
@@ -545,7 +545,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because English to English uses same punctuation
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("No ending punctuation does not trigger", () => {
@@ -569,7 +569,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because source has no ending punctuation
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Correct punctuation inside quotes is accepted", () => {
@@ -593,7 +593,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Japanese target has correct punctuation inside quotes and sentence-ending maru
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Incorrect punctuation after quotes triggers warning", () => {
@@ -642,7 +642,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Japanese target has correct punctuation and sentence-ending maru
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("No target locale does not trigger", () => {
@@ -666,7 +666,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because there's no target locale
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Empty strings do not trigger", () => {
@@ -690,7 +690,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because strings are empty
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Whitespace only does not trigger", () => {
@@ -714,7 +714,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because strings are only whitespace
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Greek period is accepted", () => {
@@ -736,7 +736,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Greek target has correct period
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Greek question mark is accepted (semicolon)", () => {
@@ -758,7 +758,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Greek target has correct question mark (semicolon)
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Greek exclamation mark is accepted", () => {
@@ -780,7 +780,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Greek target has correct exclamation mark
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Greek ellipsis is accepted", () => {
@@ -802,7 +802,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Greek target has correct ellipsis
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Greek colon is accepted", () => {
@@ -824,7 +824,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Greek target has correct colon
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Arabic period is accepted", () => {
@@ -846,7 +846,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Arabic target has correct period
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Arabic question mark is accepted", () => {
@@ -868,7 +868,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Arabic target has correct question mark
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Arabic exclamation mark is accepted", () => {
@@ -890,7 +890,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Arabic target has correct exclamation mark
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Arabic ellipsis is accepted", () => {
@@ -912,7 +912,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Arabic target has correct ellipsis
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Arabic colon is accepted", () => {
@@ -934,7 +934,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Arabic target has correct colon
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Tibetan period is accepted", () => {
@@ -956,7 +956,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Tibetan target has correct period
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Tibetan question mark is accepted", () => {
@@ -978,7 +978,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Tibetan target has correct question mark (shad)
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Tibetan exclamation mark is accepted", () => {
@@ -1000,7 +1000,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Tibetan target has correct exclamation mark (shad)
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Tibetan ellipsis is accepted", () => {
@@ -1022,7 +1022,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Tibetan target has correct ellipsis
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Tibetan colon is accepted", () => {
@@ -1044,7 +1044,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Tibetan target has correct colon (shad)
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Amharic period is accepted", () => {
@@ -1066,7 +1066,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Amharic target has correct period
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Amharic question mark is accepted", () => {
@@ -1088,7 +1088,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Amharic target has correct question mark
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Amharic exclamation mark is accepted", () => {
@@ -1110,7 +1110,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Amharic target has correct exclamation mark
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Amharic ellipsis is accepted", () => {
@@ -1132,7 +1132,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Amharic target has correct ellipsis
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Amharic colon is accepted", () => {
@@ -1154,7 +1154,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Amharic target has correct colon
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Urdu period is accepted", () => {
@@ -1176,7 +1176,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Urdu target has correct period
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Urdu question mark is accepted", () => {
@@ -1198,7 +1198,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Urdu target has correct question mark
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Urdu exclamation mark is accepted", () => {
@@ -1220,7 +1220,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Urdu target has correct exclamation mark
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Urdu ellipsis is accepted", () => {
@@ -1242,7 +1242,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Urdu target has correct ellipsis
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Urdu colon is accepted", () => {
@@ -1264,7 +1264,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Urdu target has correct colon
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Thai punctuation is optional and does not trigger", () => {
@@ -1286,7 +1286,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Thai punctuation is optional
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Lao punctuation is optional and does not trigger", () => {
@@ -1308,7 +1308,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Lao punctuation is optional
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Burmese punctuation is optional and does not trigger", () => {
@@ -1330,7 +1330,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Burmese punctuation is optional
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Khmer punctuation is optional", () => {
@@ -1354,7 +1354,254 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because Khmer punctuation is optional
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
+    });
+
+    test("Assamese period is accepted", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "assamese.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "as-IN",
+            target: "এইটো এটা বাক্য।",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Assamese target has correct period (।)
+        expect(actual === undefined).toBeTruthy();
+    });
+
+    test("Assamese period triggers warning if not correct", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "assamese.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "as-IN",
+            target: "এইটো এটা বাক্য.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Assamese target has English period instead of Assamese one
+        expect(actual).toBeTruthy();
+        expect(actual?.description).toContain("Sentence ending punctuation should be \"।\" for as-IN locale");
+    });
+
+
+
+    test("Hindi period is accepted", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "hindi.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "hi-IN",
+            target: "यह एक वाक्य है।",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Hindi target has correct period (।)
+        expect(actual === undefined).toBeTruthy();
+    });
+
+    test("Hindi period triggers warning if not correct", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "hindi.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "hi-IN",
+            target: "यह एक वाक्य है.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Hindi target has English period instead of Hindi one
+        expect(actual).toBeTruthy();
+        expect(actual?.description).toContain("Sentence ending punctuation should be \"।\" for hi-IN locale");
+    });
+
+    test("Oriya period is accepted", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "oriya.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "or-IN",
+            target: "ଏହା ଏକ ବାକ୍ୟ ଅଟେ।",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Oriya target has correct period (।)
+        expect(actual === undefined).toBeTruthy();
+    });
+
+    test("Oriya period triggers warning if not correct", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "oriya.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "or-IN",
+            target: "ଏହା ଏକ ବାକ୍ୟ ଅଟେ.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Oriya target has English period instead of Oriya one
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"।\" for or-IN locale");
+    });
+
+    test("Punjabi period is accepted", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "punjabi.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "pa-IN",
+            target: "ਇਹ ਇੱਕ ਵਾਕ ਹੈ।",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Punjabi target has correct period (।)
+        expect(actual === undefined).toBeTruthy();
+    });
+
+    test("Punjabi period triggers warning if not correct", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "punjabi.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "pa-IN",
+            target: "ਇਹ ਇੱਕ ਵਾਕ ਹੈ.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Punjabi target has English period instead of Punjabi one
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"।\" for pa-IN locale");
+    });
+
+    test("Kannada period is accepted", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "kannada.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "kn-IN",
+            target: "ಇದು ಒಂದು ವಾಕ್ಯವಾಗಿದೆ।",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Kannada target has correct period (।)
+        expect(actual === undefined).toBeTruthy();
+    });
+
+    test("Kannada period triggers warning if not correct", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "kannada.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "kn-IN",
+            target: "ಇದು ಒಂದು ವಾಕ್ಯವಾಗಿದೆ.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Kannada target has English period instead of Kannada one
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"।\" for kn-IN locale");
     });
 
     test("French guillemets at end are handled correctly", () => {
@@ -1379,7 +1626,7 @@ describe("ResourceSentenceEnding rule", function() {
             file: "a/b/c.xliff"
         });
         // Should not trigger because French target has correct punctuation with guillemets at the end
-        expect(actual === null).toBeTruthy();
+        expect(actual === undefined).toBeTruthy();
     });
 
     test("Custom punctuation mappings from configuration are applied", () => {
@@ -1417,7 +1664,7 @@ describe("ResourceSentenceEnding rule", function() {
         });
 
         // Should not trigger a warning because the custom config allows "!" for periods in French
-        expect(result).toBeNull();
+        expect(result).toBeUndefined();
 
         // Test with incorrect punctuation
         const resource2 = new ResourceString({
@@ -1440,6 +1687,107 @@ describe("ResourceSentenceEnding rule", function() {
         // Should trigger a warning because the target uses "." instead of "!" (custom config)
         expect(result2).toBeTruthy();
         expect(result2?.description).toContain('Sentence ending punctuation should be "!" for fr-FR locale');
+    });
+
+    test("Custom punctuation mappings merge with defaults correctly", () => {
+        expect.assertions(5);
+
+        // Test that custom punctuation only overrides specific punctuation types
+        // without requiring all punctuation types to be specified
+        const customPunctuationConfig = {
+            "es": {
+                "period": "¡"  // Only override period, leave others as default
+            }
+        };
+
+        const rule = new ResourceSentenceEnding({
+            param: customPunctuationConfig
+        });
+
+        // Test that custom period is applied
+        const resource1 = new ResourceString({
+            key: "custom.merge.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "es-ES",
+            target: "Esto es una frase¡",
+            pathName: "a/b/c.xliff",
+            lineNumber: 8
+        });
+
+        const result1 = rule.matchString({
+            source: resource1.getSource(),
+            target: resource1.getTarget(),
+            resource: resource1,
+            file: "a/b/c.xliff"
+        });
+
+        // Should not trigger because custom config allows "¡" for periods in Spanish
+        expect(result1).toBeUndefined();
+
+        // Test that default question mark is still applied (not overridden)
+        const resource2 = new ResourceString({
+            key: "custom.merge.question.test",
+            sourceLocale: "en-US",
+            source: "Is this a question?",
+            targetLocale: "es-ES",
+            target: "¿Es esto una pregunta?",
+            pathName: "a/b/c.xliff",
+            lineNumber: 9
+        });
+
+        const result2 = rule.matchString({
+            source: resource2.getSource(),
+            target: resource2.getTarget(),
+            resource: resource2,
+            file: "a/b/c.xliff"
+        });
+
+        // Should not trigger because default question mark "?" is still valid for Spanish
+        expect(result2).toBeUndefined();
+
+        // Test that default exclamation mark is still applied
+        const resource3 = new ResourceString({
+            key: "custom.merge.exclamation.test",
+            sourceLocale: "en-US",
+            source: "This is exciting!",
+            targetLocale: "es-ES",
+            target: "¡Esto es emocionante!",
+            pathName: "a/b/c.xliff",
+            lineNumber: 10
+        });
+
+        const result3 = rule.matchString({
+            source: resource3.getSource(),
+            target: resource3.getTarget(),
+            resource: resource3,
+            file: "a/b/c.xliff"
+        });
+
+        // Should not trigger because default exclamation mark "!" is still valid for Spanish
+        expect(result3).toBeUndefined();
+
+        // Test that incorrect punctuation still triggers warnings
+        const resource4 = new ResourceString({
+            key: "custom.merge.incorrect.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "es-ES",
+            target: "Esto es una frase.",
+            pathName: "a/b/c.xliff",
+            lineNumber: 11
+        });
+
+        const result4 = rule.matchString({
+            source: resource4.getSource(),
+            target: resource4.getTarget(),
+            resource: resource4,
+            file: "a/b/c.xliff"
+        });
+
+        // Should trigger because target uses "." instead of custom "¡"
+        expect(result4).toBeTruthy();
+        expect(result4?.description).toContain('Sentence ending punctuation should be "¡" for es-ES locale');
     });
 
     test("Auto-fix replaces incorrect punctuation with correct punctuation", () => {
@@ -1467,7 +1815,7 @@ describe("ResourceSentenceEnding rule", function() {
         // Should trigger a warning because the target uses "." instead of "。"
         expect(result).toBeTruthy();
         expect(result?.description).toContain('Sentence ending punctuation should be "。" for ja-JP locale');
-        
+
         // Check that auto-fix is available
         expect(result?.fix).toBeTruthy();
         // At this point we know result and result.fix exist
@@ -1518,4 +1866,260 @@ describe("ResourceSentenceEnding rule", function() {
         expect(fixedResource).toBeTruthy();
         expect(fixedResource.getTarget()).toBe("これは文です。");
     });
-}); 
+
+    test("Spanish question mark requires inverted punctuation at beginning", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "spanish.question.test",
+            sourceLocale: "en-US",
+            source: "What is this?",
+            targetLocale: "es-ES",
+            target: "¿Qué es esto?",
+            pathName: "a/b/c.xliff",
+            lineNumber: 12
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource: resource,
+            file: "a/b/c.xliff"
+        });
+
+        // Should not trigger because Spanish target has correct inverted question mark at beginning
+        expect(actual === undefined).toBeTruthy();
+    });
+
+    test("Spanish question mark triggers warning if missing inverted punctuation at beginning", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "spanish.question.missing.test",
+            sourceLocale: "en-US",
+            source: "What is this?",
+            targetLocale: "es-ES",
+            target: "Qué es esto?",
+            pathName: "a/b/c.xliff",
+            lineNumber: 13
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource: resource,
+            file: "a/b/c.xliff"
+        });
+
+        // Should trigger because Spanish target is missing inverted question mark at beginning
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain('Spanish question should start with "¿" for es-ES locale');
+    });
+
+    test("Spanish exclamation mark requires inverted punctuation at beginning", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "spanish.exclamation.test",
+            sourceLocale: "en-US",
+            source: "This is amazing!",
+            targetLocale: "es-ES",
+            target: "¡Esto es increíble!",
+            pathName: "a/b/c.xliff",
+            lineNumber: 14
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource: resource,
+            file: "a/b/c.xliff"
+        });
+
+        // Should not trigger because Spanish target has correct inverted exclamation mark at beginning
+        expect(actual === undefined).toBeTruthy();
+    });
+
+    test("Spanish exclamation mark triggers warning if missing inverted punctuation at beginning", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "spanish.exclamation.missing.test",
+            sourceLocale: "en-US",
+            source: "This is amazing!",
+            targetLocale: "es-ES",
+            target: "Esto es increíble!",
+            pathName: "a/b/c.xliff",
+            lineNumber: 15
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource: resource,
+            file: "a/b/c.xliff"
+        });
+
+        // Should trigger because Spanish target is missing inverted exclamation mark at beginning
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain('Spanish exclamation should start with "¡" for es-ES locale');
+    });
+
+    test("Spanish period does not require inverted punctuation", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "spanish.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "es-ES",
+            target: "Esto es una frase.",
+            pathName: "a/b/c.xliff",
+            lineNumber: 16
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource: resource,
+            file: "a/b/c.xliff"
+        });
+
+        // Should not trigger because Spanish period doesn't require inverted punctuation
+        expect(actual === undefined).toBeTruthy();
+    });
+
+    test("Spanish: only last sentence requires inverted question mark", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        // Correct: only last sentence is a question, and has inverted mark at start of last sentence
+        const resource = new ResourceString({
+            key: "spanish.multisentence.question.correct",
+            sourceLocale: "en-US",
+            source: "This is a statement. Is this a question?",
+            targetLocale: "es-ES",
+            target: "Esto es una declaración. ¿Es esto una pregunta?",
+            pathName: "a/b/c.xliff",
+            lineNumber: 20
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(actual).toBeUndefined();
+    });
+
+    test("Spanish: missing inverted question mark at start of last sentence triggers warning", () => {
+        expect.assertions(3);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        // Incorrect: last sentence is a question, but missing inverted mark at start of last sentence
+        const resource = new ResourceString({
+            key: "spanish.multisentence.question.missing",
+            sourceLocale: "en-US",
+            source: "This is a statement. Is this a question?",
+            targetLocale: "es-ES",
+            target: "Esto es una declaración. Es esto una pregunta?",
+            pathName: "a/b/c.xliff",
+            lineNumber: 21
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain('Spanish question should start with "¿" for es-ES locale');
+    });
+
+    test("Spanish: inverted question mark at start of first sentence does not affect last sentence", () => {
+        expect.assertions(3);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        // Incorrect: inverted mark at start of first sentence, not at start of last question sentence
+        const resource = new ResourceString({
+            key: "spanish.multisentence.question.wrongplace",
+            sourceLocale: "en-US",
+            source: "This is a statement. Is this a question?",
+            targetLocale: "es-ES",
+            target: "¿Esto es una declaración. Es esto una pregunta?",
+            pathName: "a/b/c.xliff",
+            lineNumber: 22
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain('Spanish question should start with "¿" for es-ES locale');
+    });
+
+    test("Spanish: quoted question at end requires inverted punctuation", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        // Correct: quoted question at end has inverted mark at start of the quoted question
+        const resource = new ResourceString({
+            key: "spanish.quoted.question.correct",
+            sourceLocale: "en-US",
+            source: "She said, \"Where is it?\"",
+            targetLocale: "es-ES",
+            target: "Ella dijo, \"¿Dónde está?\"",
+            pathName: "a/b/c.xliff",
+            lineNumber: 23
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(actual).toBeUndefined();
+    });
+
+    test("Spanish: quoted question at end missing inverted punctuation triggers warning", () => {
+        expect.assertions(3);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+debugger;
+        // Incorrect: quoted question at end missing inverted mark at start of the quoted question
+        const resource = new ResourceString({
+            key: "spanish.quoted.question.missing",
+            sourceLocale: "en-US",
+            source: "She said, \"Where is it?\"",
+            targetLocale: "es-ES",
+            target: "Ella dijo, \"Dónde está?\"",
+            pathName: "a/b/c.xliff",
+            lineNumber: 24
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain('Spanish question should start with "¿" for es-ES locale');
+    });
+});

--- a/packages/ilib-lint/test/ResourceSentenceEnding.test.js
+++ b/packages/ilib-lint/test/ResourceSentenceEnding.test.js
@@ -2102,7 +2102,7 @@ describe("ResourceSentenceEnding rule", function() {
         expect.assertions(3);
         const rule = new ResourceSentenceEnding();
         expect(rule).toBeTruthy();
-debugger;
+
         // Incorrect: quoted question at end missing inverted mark at start of the quoted question
         const resource = new ResourceString({
             key: "spanish.quoted.question.missing",

--- a/packages/ilib-lint/test/ResourceSentenceEnding.test.js
+++ b/packages/ilib-lint/test/ResourceSentenceEnding.test.js
@@ -253,31 +253,126 @@ describe("ResourceSentenceEnding rule", function() {
         expect(actual === null).toBeTruthy();
     });
 
-    test("Unicode ellipsis is recognized in English", () => {
-        expect.assertions(2);
+    test("English: source can end with ... or …, but target must end with Unicode ellipsis", () => {
+        expect.assertions(4);
 
         const rule = new ResourceSentenceEnding();
 
-        const resource = new ResourceString({
-            key: "unicode.ellipsis.test",
+        // Source: ..., Target: … (should not trigger)
+        const resource1 = new ResourceString({
+            key: "en.ellipsis.1",
+            sourceLocale: "en-US",
+            source: "This is a sentence...",
+            targetLocale: "en-US",
+            target: "This is a sentence…",
+            pathName: "a/b/c.xliff",
+            lineNumber: 201
+        });
+        const result1 = rule.matchString({
+            source: resource1.getSource(),
+            target: resource1.getTarget(),
+            resource: resource1,
+            file: resource1.pathName
+        });
+        expect(result1).toBeNull();
+
+        // Source: …, Target: … (should not trigger)
+        const resource2 = new ResourceString({
+            key: "en.ellipsis.2",
             sourceLocale: "en-US",
             source: "This is a sentence…",
             targetLocale: "en-US",
+            target: "This is a sentence…",
+            pathName: "a/b/c.xliff",
+            lineNumber: 202
+        });
+        const result2 = rule.matchString({
+            source: resource2.getSource(),
+            target: resource2.getTarget(),
+            resource: resource2,
+            file: resource2.pathName
+        });
+        expect(result2).toBeNull();
+
+        // Source: ..., Target: ... (should trigger warning)
+        const resource3 = new ResourceString({
+            key: "en.ellipsis.3",
+            sourceLocale: "en-US",
+            source: "This is a sentence...",
+            targetLocale: "en-US",
             target: "This is a sentence...",
             pathName: "a/b/c.xliff",
-            lineNumber: 101
+            lineNumber: 203
         });
-
-        const result = rule.matchString({
-            source: resource.getSource(),
-            target: resource.getTarget(),
-            resource: resource,
-            file: resource.pathName
+        const result3 = rule.matchString({
+            source: resource3.getSource(),
+            target: resource3.getTarget(),
+            resource: resource3,
+            file: resource3.pathName
         });
+        expect(result3).toBeTruthy();
+        expect(result3?.description).toContain('Sentence ending punctuation should be "…" for en-US locale');
+    });
 
-        // Should trigger a warning because the target uses "..." instead of "…"
-        expect(result).toBeTruthy();
-        expect(result?.description).toContain('Sentence ending punctuation should be "…" for en-US locale');
+    test("English: source can end with ... or …, but target must end with Unicode ellipsis", () => {
+        expect.assertions(4);
+
+        const rule = new ResourceSentenceEnding();
+
+        // Source: ..., Target: … (should not trigger)
+        const resource1 = new ResourceString({
+            key: "en.ellipsis.1",
+            sourceLocale: "en-US",
+            source: "This is a sentence...",
+            targetLocale: "en-US",
+            target: "This is a sentence…",
+            pathName: "a/b/c.xliff",
+            lineNumber: 201
+        });
+        const result1 = rule.matchString({
+            source: resource1.getSource(),
+            target: resource1.getTarget(),
+            resource: resource1,
+            file: resource1.pathName
+        });
+        expect(result1).toBeNull();
+
+        // Source: …, Target: … (should not trigger)
+        const resource2 = new ResourceString({
+            key: "en.ellipsis.2",
+            sourceLocale: "en-US",
+            source: "This is a sentence…",
+            targetLocale: "en-US",
+            target: "This is a sentence…",
+            pathName: "a/b/c.xliff",
+            lineNumber: 202
+        });
+        const result2 = rule.matchString({
+            source: resource2.getSource(),
+            target: resource2.getTarget(),
+            resource: resource2,
+            file: resource2.pathName
+        });
+        expect(result2).toBeNull();
+
+        // Source: ..., Target: ... (should trigger warning)
+        const resource3 = new ResourceString({
+            key: "en.ellipsis.3",
+            sourceLocale: "en-US",
+            source: "This is a sentence...",
+            targetLocale: "en-US",
+            target: "This is a sentence...",
+            pathName: "a/b/c.xliff",
+            lineNumber: 203
+        });
+        const result3 = rule.matchString({
+            source: resource3.getSource(),
+            target: resource3.getTarget(),
+            resource: resource3,
+            file: resource3.pathName
+        });
+        expect(result3).toBeTruthy();
+        expect(result3?.description).toContain('Sentence ending punctuation should be "…" for en-US locale');
     });
 
     test("Japanese colon is converted to fullwidth", () => {

--- a/packages/ilib-lint/test/ResourceSentenceEnding.test.js
+++ b/packages/ilib-lint/test/ResourceSentenceEnding.test.js
@@ -1,0 +1,1426 @@
+/*
+ * ResourceSentenceEnding.test.js - test the ResourceSentenceEnding rule
+ *
+ * Copyright © 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceString } from 'ilib-tools-common';
+import { IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
+
+import ResourceSentenceEnding from '../src/rules/ResourceSentenceEnding.js';
+import ResourceFixer from '../src/plugins/resource/ResourceFixer.js';
+
+describe("ResourceSentenceEnding rule", function() {
+    test("constructs the rule", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        expect(rule.name).toBe("resource-sentence-ending");
+        expect(rule.description).toBe("Checks that sentence-ending punctuation is appropriate for the target locale");
+    });
+
+    test("Japanese period is converted to maru", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "sentence.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "ja-JP",
+            target: "これは文です。",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Japanese target already has correct maru (。)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Japanese period triggers warning if not maru", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "sentence.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "ja-JP",
+            target: "これは文です.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Japanese target has English period instead of maru
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"。\" for ja-JP locale");
+    });
+
+    test("Japanese question mark is converted to fullwidth", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "question.test",
+            sourceLocale: "en-US",
+            source: "What is this?",
+            targetLocale: "ja-JP",
+            target: "これは何ですか？",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Japanese target already has correct question mark (？)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Japanese question mark triggers warning if not fullwidth", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "question.test",
+            sourceLocale: "en-US",
+            source: "What is this?",
+            targetLocale: "ja-JP",
+            target: "これは何ですか?",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Japanese target has English question mark instead of Japanese one
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"？\" for ja-JP locale");
+    });
+
+    test("Japanese exclamation mark is converted to fullwidth", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "exclamation.test",
+            sourceLocale: "en-US",
+            source: "This is amazing!",
+            targetLocale: "ja-JP",
+            target: "これは素晴らしいです！",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Japanese target already has correct exclamation mark (！)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Japanese exclamation mark triggers warning if not fullwidth", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "exclamation.test",
+            sourceLocale: "en-US",
+            source: "This is amazing!",
+            targetLocale: "ja-JP",
+            target: "これは素晴らしいです!",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Japanese target has English exclamation mark instead of Japanese one
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"！\" for ja-JP locale");
+    });
+
+    test("Japanese ellipsis is converted to Unicode ellipsis", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "ellipsis.test",
+            sourceLocale: "en-US",
+            source: "This is incomplete...",
+            targetLocale: "ja-JP",
+            target: "これは不完全です…",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Japanese target already has correct ellipsis (…)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Japanese ellipsis triggers warning if not Unicode ellipsis", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "ellipsis.test",
+            sourceLocale: "en-US",
+            source: "This is incomplete...",
+            targetLocale: "ja-JP",
+            target: "これは不完全です...",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Japanese target has English ellipsis instead of Japanese one
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"…\" for ja-JP locale");
+    });
+
+    test("Japanese Unicode ellipsis is accepted", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "unicode.ellipsis.test",
+            sourceLocale: "en-US",
+            source: "This is incomplete…",
+            targetLocale: "ja-JP",
+            target: "これは不完全です…",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because both source and target have Unicode ellipsis
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Unicode ellipsis is recognized in English", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+
+        const resource = new ResourceString({
+            key: "unicode.ellipsis.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence…",
+            targetLocale: "en-US",
+            target: "This is a sentence...",
+            pathName: "a/b/c.xliff",
+            lineNumber: 101
+        });
+
+        const result = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource: resource,
+            file: resource.pathName
+        });
+
+        // Should trigger a warning because the target uses "..." instead of "…"
+        expect(result).toBeTruthy();
+        expect(result?.description).toContain('Sentence ending punctuation should be "…" for en-US locale');
+    });
+
+    test("Japanese colon is converted to fullwidth", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "colon.test",
+            sourceLocale: "en-US",
+            source: "The options are:",
+            targetLocale: "ja-JP",
+            target: "オプションは：",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Japanese target already has correct colon (：)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Japanese colon triggers warning if not fullwidth", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "colon.test",
+            sourceLocale: "en-US",
+            source: "The options are:",
+            targetLocale: "ja-JP",
+            target: "オプションは:",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Japanese target has English colon instead of Japanese one
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"：\" for ja-JP locale");
+    });
+
+    test("Chinese period is converted to ideographic full stop", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "chinese.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "zh-CN",
+            target: "这是一个句子。",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Chinese target already has correct period (。)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Chinese period triggers warning if not ideographic full stop", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "chinese.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "zh-CN",
+            target: "这是一个句子.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Chinese target has English period instead of Chinese one
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"。\" for zh-CN locale");
+    });
+
+    test("Korean period is converted to ideographic full stop", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "korean.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "ko-KR",
+            target: "이것은 문장입니다。",
+            pathName: "a/b/c.xliff",
+            lineNumber: 1
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Korean target already has correct period (。)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Korean period triggers warning if not ideographic full stop", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "korean.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "ko-KR",
+            target: "이것은 문장입니다.",
+            pathName: "a/b/c.xliff",
+            lineNumber: 2
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Korean target has English period instead of Korean one
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"。\" for ko-KR locale");
+    });
+
+    test("English to English does not trigger", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "english.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "en-GB",
+            target: "This is a sentence.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because English to English uses same punctuation
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("No ending punctuation does not trigger", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "no.punctuation.test",
+            sourceLocale: "en-US",
+            source: "This has no ending punctuation",
+            targetLocale: "ja-JP",
+            target: "これには終止符がありません",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because source has no ending punctuation
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Correct punctuation inside quotes is accepted", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quotes.test",
+            sourceLocale: "en-US",
+            source: "He said \"Hello.\"",
+            targetLocale: "ja-JP",
+            target: "彼は「こんにちは。」と言いました。",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Japanese target has correct punctuation inside quotes and sentence-ending maru
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Incorrect punctuation after quotes triggers warning", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quotes.test",
+            sourceLocale: "en-US",
+            source: "He said \"Hello.\"",
+            targetLocale: "ja-JP",
+            target: "彼は「こんにちは。」と言いました.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should trigger because Japanese target has English period at the end
+        expect(actual).toBeTruthy();
+        expect(actual.description).toContain("Sentence ending punctuation should be \"。\" for ja-JP locale");
+    });
+
+    test("Correct punctuation with single quotes is accepted", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "single.quotes.test",
+            sourceLocale: "en-US",
+            source: "He said 'Hello.'",
+            targetLocale: "ja-JP",
+            target: "彼は「こんにちは。」と言いました。",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Japanese target has correct punctuation and sentence-ending maru
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("No target locale does not trigger", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "no.locale.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: undefined,
+            target: "これは文です。",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because there's no target locale
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Empty strings do not trigger", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "empty.test",
+            sourceLocale: "en-US",
+            source: "",
+            targetLocale: "ja-JP",
+            target: "",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because strings are empty
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Whitespace only does not trigger", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "whitespace.test",
+            sourceLocale: "en-US",
+            source: "   ",
+            targetLocale: "ja-JP",
+            target: "   ",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because strings are only whitespace
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Greek period is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "greek.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "el-GR",
+            target: "Αυτή είναι μια πρόταση.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Greek target has correct period
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Greek question mark is accepted (semicolon)", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "greek.question.test",
+            sourceLocale: "en-US",
+            source: "Is this a question?",
+            targetLocale: "el-GR",
+            target: "Είναι αυτή μια ερώτηση;",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Greek target has correct question mark (semicolon)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Greek exclamation mark is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "greek.exclamation.test",
+            sourceLocale: "en-US",
+            source: "This is amazing!",
+            targetLocale: "el-GR",
+            target: "Αυτό είναι καταπληκτικό!",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Greek target has correct exclamation mark
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Greek ellipsis is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "greek.ellipsis.test",
+            sourceLocale: "en-US",
+            source: "This is incomplete...",
+            targetLocale: "el-GR",
+            target: "Αυτό είναι ημιτελές...",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Greek target has correct ellipsis
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Greek colon is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "greek.colon.test",
+            sourceLocale: "en-US",
+            source: "This is a list:",
+            targetLocale: "el-GR",
+            target: "Αυτό είναι μια λίστα:",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Greek target has correct colon
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Arabic period is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "arabic.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "ar-EG",
+            target: "هذه جملة.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Arabic target has correct period
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Arabic question mark is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "arabic.question.test",
+            sourceLocale: "en-US",
+            source: "Is this a question?",
+            targetLocale: "ar-EG",
+            target: "هل هذا سؤال؟",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Arabic target has correct question mark
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Arabic exclamation mark is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "arabic.exclamation.test",
+            sourceLocale: "en-US",
+            source: "This is amazing!",
+            targetLocale: "ar-EG",
+            target: "هذا مذهل!",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Arabic target has correct exclamation mark
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Arabic ellipsis is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "arabic.ellipsis.test",
+            sourceLocale: "en-US",
+            source: "This is incomplete...",
+            targetLocale: "ar-EG",
+            target: "هذا غير مكتمل…",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Arabic target has correct ellipsis
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Arabic colon is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "arabic.colon.test",
+            sourceLocale: "en-US",
+            source: "This is a list:",
+            targetLocale: "ar-EG",
+            target: "هذه قائمة:",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Arabic target has correct colon
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Tibetan period is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "tibetan.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "bo-CN",
+            target: "འདི་ནི་ཚིག་ཡིན།",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Tibetan target has correct period
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Tibetan question mark is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "tibetan.question.test",
+            sourceLocale: "en-US",
+            source: "Is this a question?",
+            targetLocale: "bo-CN",
+            target: "འདི་ནི་དྲིས་བརྡ་ཡིན།",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Tibetan target has correct question mark (shad)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Tibetan exclamation mark is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "tibetan.exclamation.test",
+            sourceLocale: "en-US",
+            source: "This is amazing!",
+            targetLocale: "bo-CN",
+            target: "འདི་ནི་ཧ་ཅང་ཡིན།",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Tibetan target has correct exclamation mark (shad)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Tibetan ellipsis is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "tibetan.ellipsis.test",
+            sourceLocale: "en-US",
+            source: "This is incomplete...",
+            targetLocale: "bo-CN",
+            target: "འདི་ནི་མཇུག་མེད…",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Tibetan target has correct ellipsis
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Tibetan colon is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "tibetan.colon.test",
+            sourceLocale: "en-US",
+            source: "This is a list:",
+            targetLocale: "bo-CN",
+            target: "འདི་ནི་ཐོ།",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Tibetan target has correct colon (shad)
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Amharic period is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "amharic.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "am-ET",
+            target: "ይህ አንድ ዓረፍተ ነገር ነው።",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Amharic target has correct period
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Amharic question mark is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "amharic.question.test",
+            sourceLocale: "en-US",
+            source: "Is this a question?",
+            targetLocale: "am-ET",
+            target: "ይህ ጥያቄ ነው፧",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Amharic target has correct question mark
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Amharic exclamation mark is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "amharic.exclamation.test",
+            sourceLocale: "en-US",
+            source: "This is amazing!",
+            targetLocale: "am-ET",
+            target: "ይህ ቆንጆ ነው!",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Amharic target has correct exclamation mark
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Amharic ellipsis is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "amharic.ellipsis.test",
+            sourceLocale: "en-US",
+            source: "This is incomplete...",
+            targetLocale: "am-ET",
+            target: "ይህ ያልተጠናቀቀ ነው…",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Amharic target has correct ellipsis
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Amharic colon is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "amharic.colon.test",
+            sourceLocale: "en-US",
+            source: "This is a list:",
+            targetLocale: "am-ET",
+            target: "ይህ ዝርዝር ነው:",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Amharic target has correct colon
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Urdu period is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "urdu.period.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "ur-PK",
+            target: "یہ ایک جملہ ہے۔",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Urdu target has correct period
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Urdu question mark is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "urdu.question.test",
+            sourceLocale: "en-US",
+            source: "Is this a question?",
+            targetLocale: "ur-PK",
+            target: "کیا یہ ایک سوال ہے؟",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Urdu target has correct question mark
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Urdu exclamation mark is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "urdu.exclamation.test",
+            sourceLocale: "en-US",
+            source: "This is amazing!",
+            targetLocale: "ur-PK",
+            target: "یہ حیرت انگیز ہے!",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Urdu target has correct exclamation mark
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Urdu ellipsis is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "urdu.ellipsis.test",
+            sourceLocale: "en-US",
+            source: "This is incomplete...",
+            targetLocale: "ur-PK",
+            target: "یہ نامکمل ہے…",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Urdu target has correct ellipsis
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Urdu colon is accepted", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "urdu.colon.test",
+            sourceLocale: "en-US",
+            source: "This is a list:",
+            targetLocale: "ur-PK",
+            target: "یہ ایک فہرست ہے:",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Urdu target has correct colon
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Thai punctuation is optional and does not trigger", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "thai.optional.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "th-TH",
+            target: "นี่คือประโยค",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Thai punctuation is optional
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Lao punctuation is optional and does not trigger", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "lao.optional.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "lo-LA",
+            target: "ນີ້ແມ່ນປະໂຫຍກ",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Lao punctuation is optional
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Burmese punctuation is optional and does not trigger", () => {
+        expect.assertions(2);
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+        const resource = new ResourceString({
+            key: "burmese.optional.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "my-MM",
+            target: "ဒါဟာ ဝါကျဖြစ်တယ်",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Burmese punctuation is optional
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Khmer punctuation is optional", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "khmer.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "km-KH",
+            target: "នេះគឺជាប្រយោគមួយ។",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because Khmer punctuation is optional
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("French guillemets at end are handled correctly", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "french.quotes.test",
+            sourceLocale: "en-US",
+            source: "He said \"Hello.\"",
+            targetLocale: "fr-FR",
+            target: "Il a dit « Bonjour. »",
+            pathName: "a/b/c.xliff",
+            lineNumber: 3
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // Should not trigger because French target has correct punctuation with guillemets at the end
+        expect(actual === null).toBeTruthy();
+    });
+
+    test("Custom punctuation mappings from configuration are applied", () => {
+        expect.assertions(3);
+
+        const customPunctuationConfig = {
+            "fr": {
+                "period": "!",
+                "question": "?",
+                "exclamation": "!",
+                "ellipsis": "...",
+                "colon": ":"
+            }
+        };
+
+        const rule = new ResourceSentenceEnding({
+            param: customPunctuationConfig
+        });
+
+        const resource = new ResourceString({
+            key: "custom.punctuation.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "fr-FR",
+            target: "Ceci est une phrase!",
+            pathName: "a/b/c.xliff",
+            lineNumber: 4
+        });
+
+        const result = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource: resource,
+            file: "a/b/c.xliff"
+        });
+
+        // Should not trigger a warning because the custom config allows "!" for periods in French
+        expect(result).toBeNull();
+
+        // Test with incorrect punctuation
+        const resource2 = new ResourceString({
+            key: "custom.punctuation.test2",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "fr-FR",
+            target: "Ceci est une phrase.",
+            pathName: "a/b/c.xliff",
+            lineNumber: 5
+        });
+
+        const result2 = rule.matchString({
+            source: resource2.getSource(),
+            target: resource2.getTarget(),
+            resource: resource2,
+            file: "a/b/c.xliff"
+        });
+
+        // Should trigger a warning because the target uses "." instead of "!" (custom config)
+        expect(result2).toBeTruthy();
+        expect(result2?.description).toContain('Sentence ending punctuation should be "!" for fr-FR locale');
+    });
+
+    test("Auto-fix replaces incorrect punctuation with correct punctuation", () => {
+        expect.assertions(7);
+
+        const rule = new ResourceSentenceEnding();
+
+        const resource = new ResourceString({
+            key: "autofix.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "ja-JP",
+            target: "これは文です.",
+            pathName: "a/b/c.xliff",
+            lineNumber: 6
+        });
+
+        const result = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource: resource,
+            file: resource.pathName
+        });
+
+        // Should trigger a warning because the target uses "." instead of "。"
+        expect(result).toBeTruthy();
+        expect(result?.description).toContain('Sentence ending punctuation should be "。" for ja-JP locale');
+        
+        // Check that auto-fix is available
+        expect(result?.fix).toBeTruthy();
+        // At this point we know result and result.fix exist
+        const fix = result.fix;
+        expect(fix.commands).toHaveLength(1);
+        expect(fix.commands[0].stringFix.position).toBeGreaterThan(0);
+        expect(fix.commands[0].stringFix.deleteCount).toBe(1);
+        expect(fix.commands[0].stringFix.insertContent).toBe("。");
+    });
+
+    test("ResourceSentenceEnding apply fix to correct the punctuation", () => {
+        expect.assertions(5);
+
+        const rule = new ResourceSentenceEnding();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "punctuation.fix.test",
+            sourceLocale: "en-US",
+            source: "This is a sentence.",
+            targetLocale: "ja-JP",
+            target: "これは文です.",
+            pathName: "a/b/c.xliff",
+            lineNumber: 7
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource: resource,
+            file: resource.pathName
+        });
+
+        expect(actual).toBeTruthy();
+        expect(actual?.fix).toBeTruthy();
+
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [resource],
+            sourceFile: new SourceFile("a/b/c.xliff"),
+            dirty: false
+        });
+
+        const fixer = new ResourceFixer();
+        fixer.applyFixes(ir, [actual.fix]);
+
+        const fixedResource = ir.getRepresentation()[0];
+        expect(fixedResource).toBeTruthy();
+        expect(fixedResource.getTarget()).toBe("これは文です。");
+    });
+}); 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -830,6 +830,34 @@ importers:
         specifier: ^5.3.3
         version: 5.6.3
 
+  packages/ilib-lint-java:
+    dependencies:
+      ilib-lint-common:
+        specifier: workspace:^
+        version: link:../ilib-lint-common
+      ilib-locale:
+        specifier: workspace:^
+        version: link:../ilib-locale
+      ilib-tools-common:
+        specifier: workspace:^
+        version: link:../ilib-tools-common
+    devDependencies:
+      docdash:
+        specifier: ^2.0.2
+        version: 2.0.2
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.10.2)(node-notifier@8.0.2)
+      jsdoc:
+        specifier: ^4.0.2
+        version: 4.0.4
+      jsdoc-to-markdown:
+        specifier: ^8.0.1
+        version: 8.0.3
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+
   packages/ilib-lint-javascript:
     dependencies:
       ilib-lint-common:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2165,7 +2165,7 @@ importers:
         version: 3.2.0
       grunt-contrib-nodeunit:
         specifier: ^4.0.0
-        version: 4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
+        version: 4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
       grunt-contrib-uglify:
         specifier: ^5.2.2
         version: 5.2.2
@@ -12117,15 +12117,6 @@ snapshots:
       hooker: 0.2.3
       jshint: 2.13.6
 
-  grunt-contrib-nodeunit@4.0.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      nodeunit-x: 0.15.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
-    transitivePeerDependencies:
-      - flow-remove-types
-      - supports-color
-      - ts-node
-      - typescript
-
   grunt-contrib-nodeunit@4.0.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
       nodeunit-x: 0.15.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3)
@@ -14420,16 +14411,6 @@ snapshots:
       socks: 1.1.9
     optional: true
 
-  nodeunit-x@0.15.0(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      ejs: 3.1.10
-      tap: 15.2.3(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10)
-    transitivePeerDependencies:
-      - flow-remove-types
-      - supports-color
-      - ts-node
-      - typescript
-
   nodeunit-x@0.15.0(ts-node@8.10.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
       ejs: 3.1.10
@@ -15943,36 +15924,6 @@ snapshots:
       typescript: 3.9.10
       write-file-atomic: 2.4.3
       yapool: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  tap@15.2.3(ts-node@8.10.2(typescript@3.9.10))(typescript@3.9.10):
-    dependencies:
-      chokidar: 3.6.0
-      coveralls: 3.1.1
-      findit: 2.0.0
-      foreground-child: 2.0.0
-      fs-exists-cached: 1.0.0
-      glob: 7.2.3
-      isexe: 2.0.0
-      istanbul-lib-processinfo: 2.0.3
-      jackspeak: 1.4.2
-      libtap: 1.4.1
-      minipass: 3.3.6
-      mkdirp: 1.0.4
-      nyc: 15.1.0
-      opener: 1.5.2
-      rimraf: 3.0.2
-      signal-exit: 3.0.7
-      source-map-support: 0.5.21
-      tap-mocha-reporter: 5.0.4
-      tap-parser: 11.0.2
-      tap-yaml: 1.0.2
-      tcompare: 5.0.7
-      which: 2.0.2
-    optionalDependencies:
-      ts-node: 8.10.2(typescript@3.9.10)
-      typescript: 3.9.10
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
- new lint plugin ilib-lint-java
- Added rule to check Java MessageFormat replacement parameters
- Added rule to check Kotlin MessageFormat replacement parameters
- Added a "java" and a "kotlin" ruleset
- The printf-style replacement parameters that both support is a subset of the GNU printf-style parameters we implemented previously, so we do not need to create a new rule there. We can just apply the GNU rule to strings from Java or Kotlin