### PR TITLE
loctool: Add a property to store metadata elements within the ResourceString

### DIFF
--- a/.changeset/happy-toes-refuse.md
+++ b/.changeset/happy-toes-refuse.md
@@ -2,6 +2,7 @@
 "loctool": patch
 ---
 
-Add a property to store metadata elements that can exist in an XLIFF file within the ResourceString.
+- Add a property to store metadata elements that can exist in an XLIFF file within the ResourceString.
+- Update to pass `style` property in `GenerateMode` to work with correct XliffFile class.
 
 

--- a/.changeset/happy-toes-refuse.md
+++ b/.changeset/happy-toes-refuse.md
@@ -1,0 +1,7 @@
+---
+"loctool": patch
+---
+
+Add a property to store metadata elements that can exist in an XLIFF file within the ResourceString.
+
+

--- a/packages/loctool/lib/GenerateMode.js
+++ b/packages/loctool/lib/GenerateMode.js
@@ -92,7 +92,8 @@ GenerateMode.prototype.init = function() {
         }).forEach(function (pathName) {
             var intermediateFile = getIntermediateFile({
                 sourceLocale: this.sourceLocale,
-                path: pathName
+                path: pathName,
+                style: this.settings?.xliffStyle || "standard",
             });
             if (fs.existsSync(pathName)) {
                 this.ts.addSet(intermediateFile.read());

--- a/packages/loctool/lib/ResourceString.js
+++ b/packages/loctool/lib/ResourceString.js
@@ -44,6 +44,7 @@ var ResourceString = function(props) {
     if (props) {
         this.source = typeof(props.source) === 'string' ? props.source : props.text;
         this.target = props.target;
+        this.metadata = props.metadata || undefined;
     }
 
     this.origin = this.origin || "source";
@@ -92,6 +93,26 @@ ResourceString.prototype.setSource = function(str) {
 ResourceString.prototype.getTarget = function() {
     return this.target;
 };
+
+
+/**
+ * Get the metadata of this resource.
+ *
+ * @returns {Object} the metadata
+ */
+ResourceString.prototype.getMetadata = function() {
+    return this.metadata;
+};
+
+/**
+ * Set the metadata of this resource.
+ *
+ * @param {Object} data the metadata of this resource.
+ */
+ResourceString.prototype.setMetadata = function(data) {
+    this.metadata = data;
+};
+
 
 /**
  * Set the target string of this resource.

--- a/packages/loctool/lib/webOSXliff.js
+++ b/packages/loctool/lib/webOSXliff.js
@@ -167,21 +167,6 @@ webOSXliff.prototype.parse = function(xliff) {
 }
 
 /**
- * Get the target string corresponding to the metadata
- *
- * @returns {String} The target string corresponding to the metadata.
- */
-webOSXliff.prototype.getMetadataTarget = function(metadata, tuData) {
-    if (!metadata || !tuData) return undefined;
-
-    this.type = metadata["device-type"];
-    var dataArr = tuData["mda:metaGroup"]['mda:meta'];
-
-    var matchItem = dataArr.find(item => item['_attributes']['type'] === this.type);
-    return matchItem ? matchItem['_text'] : undefined;
-};
-
-/**
  * Get the translation units in this xliff.
  *
  * @returns {Array.<Object>} the translation units in this xliff
@@ -328,7 +313,8 @@ webOSXliff.prototype.getTranslationSet = function() {
                 resType: tu.resType,
                 datatype: tu.datatype,
                 state: tu.state,
-                flavor: tu.flavor
+                flavor: tu.flavor,
+                metadata: tu.metadata
             });
             
             if (tu.target) {

--- a/packages/loctool/test/ResourceString.test.js
+++ b/packages/loctool/test/ResourceString.test.js
@@ -252,6 +252,50 @@ describe("resourcestring", function() {
         expect(!rs.getSource()).toBeTruthy();
     });
 
+    test("ResourceStringGetMetadata", function() {
+        expect.assertions(2);
+
+        var rs = new ResourceString({
+            key: "foo",
+            source: "source string",
+            pathName: "a/b/c.txt",
+            sourceLocale: "de-DE",
+            metadata:  {
+                "test": "test-abcd"
+            }
+        });
+        expect(rs).toBeTruthy();
+        expect(rs.getMetadata()).toStrictEqual({"test": "test-abcd"});
+    });
+
+    test("ResourceStringGetMetadata2", function() {
+        expect.assertions(2);
+
+        var rs = new ResourceString({
+            key: "foo",
+            source: "source string",
+            pathName: "a/b/c.txt",
+            sourceLocale: "de-DE",
+        });
+        expect(rs).toBeTruthy();
+        expect(rs.getMetadata()).toBeFalsy();
+    });
+
+    test("ResourceStringSetMetadata", function() {
+        expect.assertions(2);
+
+        var rs = new ResourceString({
+            key: "foo",
+            source: "source string",
+            pathName: "a/b/c.txt",
+            sourceLocale: "de-DE",
+            metadata:{}
+        });
+        expect(rs).toBeTruthy();
+        rs.setMetadata({"test": "test-xyz"});
+        expect(rs.getMetadata()).toStrictEqual({"test": "test-xyz"});
+    });
+
     test("ResourceStringGeneratePseudo", function() {
         expect.assertions(2);
 

--- a/packages/loctool/test/webOSXliff.test.js
+++ b/packages/loctool/test/webOSXliff.test.js
@@ -425,7 +425,7 @@ describe("webOSxliff", function() {
         expect(result[0].getTarget()).toBe("foobarfoo");
     });
     test("webOSXliffDeserialize_metadata", function() {
-        expect.assertions(8);
+        expect.assertions(9);
 
         var x = new webOSXliff({
             metadata: {"device-type": "SoundBar"}
@@ -441,7 +441,7 @@ describe("webOSxliff", function() {
         '          <mda:metadata>\n' +
         '            <mda:metaGroup category="device-type">\n' +
         '              <mda:meta type="Monitor">"Monitor" 이용이 불가능합니다</mda:meta>\n' +
-        '              <mda:meta type="Boxc">"Box" 이용이 불가능합니다</mda:meta>\n' +
+        '              <mda:meta type="Box">"Box" 이용이 불가능합니다</mda:meta>\n' +
         '              <mda:meta type="SoundBar">"SoundBar" 이용이 불가능합니다</mda:meta>\n' +
         '            </mda:metaGroup>\n' +
         '          </mda:metadata>\n' +
@@ -460,11 +460,34 @@ describe("webOSxliff", function() {
         expect(result).toBeTruthy();
         expect(result.length).toBe(1);
 
+        var expectedMetadata = {
+                "mda:metaGroup": {
+                    "mda:meta": [
+                        {
+                            "_attributes" : {"type": "Monitor"},
+                            "_text": "\"Monitor\" 이용이 불가능합니다"
+                        },
+                        {
+                            "_attributes" : {"type": "Box"},
+                            "_text": "\"Box\" 이용이 불가능합니다"
+                        },
+                        {
+                            "_attributes" : {"type": "SoundBar"},
+                            "_text": "\"SoundBar\" 이용이 불가능합니다"
+                        }
+                    ],
+                    "_attributes": {
+                        "category": "device-type"
+                    }
+                }
+            }
+
         expect(result[0].getSource()).toBe("NOT AVAILABLE");
         expect(result[0].getSourceLocale()).toBe("en-KR");
         expect(result[0].getTargetLocale()).toBe("ko-KR");
         expect(result[0].getKey()).toBe("NOT AVAILABLE");
         expect(result[0].getTarget()).toBe("이용이 불가능합니다");
+        expect(result[0].getMetadata()).toStrictEqual(expectedMetadata);
     });
     test("webOSXliffDeserialize_metadata_undefined", function() {
         expect.assertions(8);
@@ -480,7 +503,7 @@ describe("webOSxliff", function() {
         '          <mda:metadata>\n' +
         '            <mda:metaGroup category="device-type">\n' +
         '              <mda:meta type="Monitor">"Monitor" 이용이 불가능합니다</mda:meta>\n' +
-        '              <mda:meta type="Boxc">"Box" 이용이 불가능합니다</mda:meta>\n' +
+        '              <mda:meta type="Box">"Box" 이용이 불가능합니다</mda:meta>\n' +
         '              <mda:meta type="SoundBar">"SoundBar" 이용이 불가능합니다</mda:meta>\n' +
         '            </mda:metaGroup>\n' +
         '          </mda:metadata>\n' +


### PR DESCRIPTION
* Add a property to store metadata elements that can exist in an XLIFF file within the ResourceString.
* Update to pass `style` property in `GenerateMode` to work with correct XliffFile class