### PR TITLE
ilib-lint: Fix rule params from the linter config

### DIFF
--- a/.changeset/long-clocks-impress.md
+++ b/.changeset/long-clocks-impress.md
@@ -1,0 +1,7 @@
+---
+"ilib-lint": patch
+---
+
+- Fixed a bug where the exceptions for some rules were not taking effect
+  - resource-kebab-case, resource-camel-case, and resource-snake-case
+  - Syntax as noted in their documents for exceptions did not work

--- a/packages/ilib-lint/src/rules/ResourceCamelCase.js
+++ b/packages/ilib-lint/src/rules/ResourceCamelCase.js
@@ -32,8 +32,7 @@ class ResourceCamelCase extends ResourceRule {
     /**
      * Create a ResourceCamelCase rule instance.
      * @param {object} options
-     * @param {object} [options.param]
-     * @param {string[]} [options.param.except] An array of strings to exclude from the rule.
+     * @param {string[]} [options.except] An array of strings to exclude from the rule.
      */
     constructor(options) {
         super(options);
@@ -45,7 +44,7 @@ class ResourceCamelCase extends ResourceRule {
             "^\\s*[a-z\\d]+([A-Z][a-z\\d]+)+\\s*$",
             "^\\s*[A-Z][a-z\\d]+([A-Z][a-z\\d]+)+\\s*$",
         ];
-        this.exceptions = Array.isArray(options?.param?.except) ? options.param.except : [];
+        this.exceptions = Array.isArray(options?.except) ? options.except : [];
     }
 
     /**

--- a/packages/ilib-lint/src/rules/ResourceKebabCase.js
+++ b/packages/ilib-lint/src/rules/ResourceKebabCase.js
@@ -12,8 +12,7 @@ class ResourceKebabCase extends ResourceRule {
     /**
      * Create a ResourceKebabCase rule instance.
      * @param {object} options
-     * @param {object} [options.param]
-     * @param {string[]} [options.param.except] An array of strings to exclude from the rule.
+     * @param {string[]} [options.except] An array of strings to exclude from the rule.
      */
     constructor(options) {
         super(options);
@@ -25,7 +24,7 @@ class ResourceKebabCase extends ResourceRule {
             "^\\s*[a-zA-Z0-9]*(-[a-zA-Z0-9]+)+\\s*$",
             "^\\s*[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*-\\s*$"
         ];
-        this.exceptions = Array.isArray(options?.param?.except) ? options.param.except : [];
+        this.exceptions = Array.isArray(options?.except) ? options.except : [];
     }
 
     /**

--- a/packages/ilib-lint/src/rules/ResourceSnakeCase.js
+++ b/packages/ilib-lint/src/rules/ResourceSnakeCase.js
@@ -32,20 +32,19 @@ class ResourceSnakeCase extends ResourceRule {
     /**
      * Create a ResourceSnakeCase rule instance.
      * @param {object} options
-     * @param {object} [options.param]
-     * @param {string[]} [options.param.except] An array of strings to exclude from the rule.
+     * @param {string[]} [options.except] An array of strings to exclude from the rule.
      */
     constructor(options) {
         super(options);
 
         this.name = "resource-snake-case";
         this.description = "Ensure that when source strings contain only snake case and no whitespace, then the targets are the same";
-        this.link = "https://gihub.com/iLib-js/ilib-mono/blob/main/packages/ilib-lint/docs/resource-snake-case.md",
+        this.link = "https://gihub.com/iLib-js/ilib-mono/blob/main/packages/ilib-lint/docs/resource-snake-case.md";
         this.regexps = [
             "^\\s*[a-zA-Z0-9]*(_[a-zA-Z0-9]+)+\\s*$",
             "^\\s*[a-zA-Z0-9]+(_[a-zA-Z0-9]+)*_\\s*$"
-        ]
-        this.exceptions = Array.isArray(options?.param?.except) ? options.param.except : [];
+        ];
+        this.exceptions = Array.isArray(options?.except) ? options.except : [];
     }
 
     /**


### PR DESCRIPTION
- Fixed a bug where the exceptions for some rules were not taking effect
  - resource-kebab-case, resource-camel-case, and resource-snake-case
  - Syntax as noted in their documentation for exceptions did not work
  - Problem was that the constructor of these rules was checking the wrong properties that RuleManager.get() was passing in