### PR TITLE
Fix ilib-lint hang

### DIFF
--- a/.changeset/hungry-bugs-lie.md
+++ b/.changeset/hungry-bugs-lie.md
@@ -1,0 +1,5 @@
+---
+"ilib-lint-apple": patch
+---
+
+- Fixed ilib-lint-apple packaging to allow the linter to be able to load it properly

--- a/.changeset/lemon-dots-sparkle.md
+++ b/.changeset/lemon-dots-sparkle.md
@@ -1,0 +1,6 @@
+---
+"ilib-lint": patch
+---
+
+- fixed null pointer exception in the ascii formatter if
+  the Result.fix is set to null instead of undefined

--- a/packages/ilib-lint-apple/package.json
+++ b/packages/ilib-lint-apple/package.json
@@ -3,6 +3,13 @@
     "version": "1.0.0",
     "description": "ilib-lint plugin for Apple platform string parameter validation",
     "main": "src/index.js",
+    "module": "src/index.js",
+    "exports": {
+        ".": {
+            "import": "./src/index.js"
+        },
+        "./package.json": "./package.json"
+    },
     "type": "module",
     "scripts": {
         "coverage": "pnpm test -- --coverage",

--- a/packages/ilib-lint/src/formatters/AnsiConsoleFormatter.js
+++ b/packages/ilib-lint/src/formatters/AnsiConsoleFormatter.js
@@ -56,8 +56,8 @@ class AnsiConsoleFormatter extends Formatter {
             output += `  Source: ${result.source}\n`;
         }
         output += `  ${result.highlight}
-  Auto-fix: ${result.fix === undefined ? "unavailable" : result.fix.applied ? "\u001B[92mapplied\u001B[0m" : "\u001B[91mnot applied\u001B[0m"}
-  Rule (${result.rule.getName()}): ${result.rule.getDescription()}
+  Auto-fix: ${!result.fix ? "unavailable" : result.fix.applied ? "\u001B[92mapplied\u001B[0m" : "\u001B[91mnot applied\u001B[0m"}
+  Rule (${result?.rule?.getName()}): ${result?.rule?.getDescription()}
 `;
         if (result.locale) {
             output += `  Locale: ${result.locale}\n`;
@@ -68,7 +68,7 @@ class AnsiConsoleFormatter extends Formatter {
         output = output.replace(/<e\d\/>/g, "\u001B[91m␣\u001B[0m");
         output = output.replace(/<e\d>/g, "\u001B[91m");
         output = output.replace(/<\/e\d>/g, "\u001B[0m");
-        if (typeof(result.rule.getLink) === 'function' && result.rule.getLink()) {
+        if (typeof(result?.rule?.getLink) === 'function' && result?.rule?.getLink()) {
             output += `  More info: ${result.rule.getLink()}\n`;
         }
         return output;


### PR DESCRIPTION
- fixed ansi console formatter to not throw exceptions if the Result object it is trying to format doesn't have all of the properties it is expecting to find.
- fix ilib-lint-apple package.json so that the linter can load it properly
