### PR TITLE
ilib-lint: Fix false positives

### DIFF
--- a/.changeset/few-sheep-fly.md
+++ b/.changeset/few-sheep-fly.md
@@ -1,0 +1,18 @@
+---
+"ilib-lint": minor
+---
+
+- Added the ability to specify exceptions to the
+  resource-icu-plural-translated rule so that it does not produce
+  warnings for those exception words and phrases. Now you can list
+  the exceptions by locale in the parameters to the rule:
+
+  "rulesets": {
+  "myruleset": {
+  "resource-icu-plural-translated": {
+  "exceptions": {
+  "it-IT": ["File", "Files"]
+  }
+  }
+  }
+  }

--- a/.changeset/few-sheep-fly.md
+++ b/.changeset/few-sheep-fly.md
@@ -3,16 +3,22 @@
 ---
 
 - Added the ability to specify exceptions to the
-  resource-icu-plural-translated rule so that it does not produce
-  warnings for those exception words and phrases. Now you can list
-  the exceptions by locale in the parameters to the rule:
-
-  "rulesets": {
-  "myruleset": {
-  "resource-icu-plural-translated": {
-  "exceptions": {
-  "it-IT": ["File", "Files"]
-  }
-  }
-  }
-  }
+  resource-icu-plural-translated rule.
+    - It does not produce warnings for those exception phrases.
+      Now you can list the exceptions by locale in the parameters
+      to the rule:
+      ```
+      "rulesets": {
+        "myruleset": {
+          "resource-icu-plural-translated": {
+            "exceptions": {
+              "it-IT": ["File", "Files"]
+            }
+          }
+        }
+      }
+      ```
+    - Exceptions are entire phrases, not individual words. The idea
+      of the rule is to catch entire plural categories that the
+      translators missed, and the idea of the exceptions to avoid
+      those few false positives that pop up infrequently.

--- a/packages/ilib-lint/docs/resource-icu-plurals-translated.md
+++ b/packages/ilib-lint/docs/resource-icu-plurals-translated.md
@@ -22,3 +22,39 @@ German: "{numberOfFiles, plural, one {# file} other {# Dateien}}
 
 In this case, the German translator missed the "one" category. The string will
 need to be sent back to the translator for retranslation.
+
+## Exceptions
+
+Sometimes, certain words or phrases are intentionally the same in both source and target languages.
+For example, the word "File" in Italian is also "File" - the exact same spelling!
+In such cases, you can configure exceptions to prevent false warnings.
+
+### Configuration
+
+You can configure exceptions by passing an object parameter to the rule constructor:
+
+```javascript
+{
+    "rulesets":
+        "myruleset": {
+            "resource-icu-plurals-translated": {
+                "exceptions": {
+                    "it-IT": ["File", "Email", "Download"],
+                    "de-DE": ["Download", "Upload"],
+                    "fr-FR": ["Email", "Internet"]
+                }
+            }
+        }
+    }
+}
+```
+
+The `param` object should have locale codes as keys and arrays of exception words/phrases as values.
+The rule will ignore warnings when the source and target text contain any of the specified exceptions.
+
+### Exception Matching
+
+- Exceptions are matched case-insensitively
+- Exact matches only (no partial matching)
+- Exceptions are checked against the entire text content of the plural category
+- Exceptions are stored by language code (e.g., "it" for Italian) regardless of the full locale code provide

--- a/packages/ilib-lint/docs/resource-icu-plurals-translated.md
+++ b/packages/ilib-lint/docs/resource-icu-plurals-translated.md
@@ -26,8 +26,9 @@ need to be sent back to the translator for retranslation.
 ## Exceptions
 
 Sometimes, certain words or phrases are intentionally the same in both source and target languages.
-For example, the word "File" in Italian is also "File" - the exact same spelling!
-In such cases, you can configure exceptions to prevent false warnings.
+For example, the word "File" in Italian is also "File" - the exact same spelling! These exceptions
+may be phrases that happen to be the same, such as that example in Italian, or they may be loanwords
+from other languages, which is common for computer and software terms. In such cases, you can configure exceptions to prevent false warnings about untranslated plural categories.
 
 ### Configuration
 
@@ -39,9 +40,10 @@ You can configure exceptions by passing an object parameter to the rule construc
         "myruleset": {
             "resource-icu-plurals-translated": {
                 "exceptions": {
-                    "it-IT": ["File", "Email", "Download"],
+                    "it-IT": ["File", "Email", "Download", "File Download"],
                     "de-DE": ["Download", "Upload"],
-                    "fr-FR": ["Email", "Internet"]
+                    "fr-FR": ["Email", "Internet"],
+                    "pl-PL": ["App Center"]
                 }
             }
         }
@@ -49,8 +51,10 @@ You can configure exceptions by passing an object parameter to the rule construc
 }
 ```
 
-The `param` object should have locale codes as keys and arrays of exception words/phrases as values.
-The rule will ignore warnings when the source and target text contain any of the specified exceptions.
+The `param` object should have locale codes as keys and arrays of exception phrases as values. The
+entire source string must match the exception phrase in order for the exception to apply. (They are not
+single word exceptions.) The rule will ignore warnings when the source and target text both contain any
+of the specified exceptions phrases.
 
 ### Exception Matching
 

--- a/packages/ilib-lint/docs/resource-icu-plurals-translated.md
+++ b/packages/ilib-lint/docs/resource-icu-plurals-translated.md
@@ -28,7 +28,9 @@ need to be sent back to the translator for retranslation.
 Sometimes, certain words or phrases are intentionally the same in both source and target languages.
 For example, the word "File" in Italian is also "File" - the exact same spelling! These exceptions
 may be phrases that happen to be the same, such as that example in Italian, or they may be loanwords
-from other languages, which is common for computer and software terms. In such cases, you can configure exceptions to prevent false warnings about untranslated plural categories.
+from other languages, which is common for computer and software terms.
+
+In such cases, you can configure exceptions to suppress false warnings about untranslated plural categories.
 
 ### Configuration
 
@@ -36,14 +38,14 @@ You can configure exceptions by passing an object parameter to the rule construc
 
 ```javascript
 {
-    "rulesets":
+    "rulesets": {
         "myruleset": {
             "resource-icu-plurals-translated": {
                 "exceptions": {
-                    "it-IT": ["File", "Email", "Download", "File Download"],
-                    "de-DE": ["Download", "Upload"],
-                    "fr-FR": ["Email", "Internet"],
-                    "pl-PL": ["App Center"]
+                    "it": ["File", "Email", "Download", "File Download"],
+                    "de": ["Download", "Upload"],
+                    "fr": ["Email", "Internet"],
+                    "pl": ["App Center"]
                 }
             }
         }
@@ -51,14 +53,17 @@ You can configure exceptions by passing an object parameter to the rule construc
 }
 ```
 
-The `param` object should have locale codes as keys and arrays of exception phrases as values. The
-entire source string must match the exception phrase in order for the exception to apply. (They are not
-single word exceptions.) The rule will ignore warnings when the source and target text both contain any
-of the specified exceptions phrases.
+The `exceptions` property should be an object with language codes as keys and arrays of exception phrases as values.
+Note that differences in region or script are ignored (e.g., exceptions for `it-IT` and `it-CH` will be folded into the same language `it`).
 
 ### Exception Matching
 
-- Exceptions are matched case-insensitively
-- Exact matches only (no partial matching)
-- Exceptions are checked against the entire text content of the plural category
-- Exceptions are stored by language code (e.g., "it" for Italian) regardless of the full locale code provide
+Once an untranslated plural category is found, the rule will check if it matches any of the exceptions configured for its target language.
+
+Matching rules:
+
+-   Exact matches only (no partial matching)
+-   Case-insensitive
+-   ICU MessageFormat syntax is NOT ignored (e.g. string `# File` will not match exception `File`)
+-   Leading and trailing whitespace is ignored
+-   Only language is considered (region and script are ignored; e.g., both `it-IT` and `it-CH` strings will be checked against exceptions configured for `it`)

--- a/packages/ilib-lint/src/rules/ResourceICUPluralTranslation.js
+++ b/packages/ilib-lint/src/rules/ResourceICUPluralTranslation.js
@@ -38,6 +38,64 @@ class ResourceICUPluralTranslation extends ResourceRule {
         this.description = "Ensure that plurals in translated resources are also translated";
         this.sourceLocale = (options && options.sourceLocale) || "en-US";
         this.link = "https://github.com/iLib-js/ilib-mono/blob/main/packages/ilib-lint/docs/resource-icu-plurals-translated.md";
+
+        // Initialize exceptions from configuration
+        this.exceptions = {};
+
+        if (options && options.exceptions) {
+            if (typeof options.exceptions === 'object' && !Array.isArray(options.exceptions)) {
+                // exceptions is an object with locale codes as keys and arrays of exception words/phrases as values
+                // Validate locales and store by language only
+                for (const [locale, exceptionList] of Object.entries(options.exceptions)) {
+                    if (Array.isArray(exceptionList)) {
+                        const localeObj = new Locale(locale);
+                        if (localeObj.isValid()) {
+                            const language = localeObj.getLanguage();
+                            if (language) {
+                                if (!this.exceptions[language]) {
+                                    this.exceptions[language] = [];
+                                }
+                                this.exceptions[language].push(...exceptionList);
+                            }
+                        } else {
+                            // Skip invalid locales
+                            console.warn(`Invalid locale in exceptions configuration: ${locale}`);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if the given text contains any exceptions for the given locale.
+     * @private
+     * @param {string} text the text to check
+     * @param {string} locale the locale to check against
+     * @returns {boolean} true if the text contains any exceptions
+     */
+    containsExceptions(text, locale) {
+        try {
+            const localeObj = new Locale(locale);
+            if (!localeObj.isValid()) {
+                return false;
+            }
+            const language = localeObj.getLanguage();
+            if (!language || !this.exceptions[language]) {
+                return false;
+            }
+
+            const languageExceptions = this.exceptions[language];
+            const normalizedText = text.toLowerCase().trim();
+
+            // Check if any exception exactly matches the text
+            return languageExceptions.some(exception => {
+                const normalizedException = exception.toLowerCase().trim();
+                return normalizedText === normalizedException;
+            });
+        } catch (e) {
+            return false;
+        }
     }
 
     /**
@@ -161,12 +219,12 @@ class ResourceICUPluralTranslation extends ResourceRule {
             return Object.keys(targetPlural.options).flatMap(category => {
                 const sourceCategory = sourcePlural.options[category] ? category : "other";
                 const sourcePluralCat = sourcePlural.options[sourceCategory];
-                if (!sourcePluralCat) return; // nothing to check!
+                if (!sourcePluralCat) return []; // nothing to check!
 
                 // Only compare the source and target if there is some text there to
                 // translate. This will avoid the false positives for the situation where
                 // the only thing in the plural category string is just a {variable}.
-                if (this.textNodes(sourcePluralCat.value).length === 0) return;
+                if (this.textNodes(sourcePluralCat.value).length === 0) return [];
 
                 const sourceStr = this.reconstruct(sourcePluralCat.value).replace(/\s+/g, " ").trim();
                 const targetStr = this.reconstruct(targetPlural.options[category].value).replace(/\s+/g, " ").trim();
@@ -175,20 +233,25 @@ class ResourceICUPluralTranslation extends ResourceRule {
                 // use case- and whitespace-insensitive match. Also, don't produce a result
                 // if the source string is empty
                 if (sourceStr.length && sourceStr.toLowerCase() === targetStr.toLowerCase()) {
-                    let value = {
-                        severity: "warning",
-                        description: `Translation of the category \'${category}\' is the same as the source.`,
-                        rule: this,
-                        id: resource.getKey(),
-                        source: `${sourceCategory} {${sourceStr}}`,
-                        highlight: `Target: <e0>${category} {${targetStr}}</e0>`,
-                        pathName: file,
-                        locale: resource.getTargetLocale()
-                    };
-                    if (typeof(resource.lineNumber) !== 'undefined') {
-                        value.lineNumber = resource.lineNumber;
+                    // Check if this text contains any exceptions for the target locale
+                    const targetLocale = resource.getTargetLocale();
+                    const hasExceptions = this.containsExceptions(sourceStr, targetLocale);
+                    if (!hasExceptions) {
+                        let value = {
+                            severity: /** @type {"warning"} */ ("warning"),
+                            description: `Translation of the category \'${category}\' is the same as the source.`,
+                            rule: this,
+                            id: resource.getKey(),
+                            source: `${sourceCategory} {${sourceStr}}`,
+                            highlight: `Target: <e0>${category} {${targetStr}}</e0>`,
+                            pathName: file,
+                            locale: targetLocale
+                        };
+                        if (typeof(resource.lineNumber) !== 'undefined') {
+                            value.lineNumber = resource.lineNumber;
+                        }
+                        result.push(new Result(value));
                     }
-                    result.push(new Result(value));
                 }
 
                 // now the plurals may have plurals nested in them, so recursively check them too

--- a/packages/ilib-lint/src/rules/ResourceICUPluralTranslation.js
+++ b/packages/ilib-lint/src/rules/ResourceICUPluralTranslation.js
@@ -240,7 +240,7 @@ class ResourceICUPluralTranslation extends ResourceRule {
                 if (sourceStr.length && sourceStr.toLowerCase() === targetStr.toLowerCase()) {
                     // Check if this text contains any exceptions for the target locale
                     const targetLocale = resource.getTargetLocale();
-                    const hasExceptions = this.containsExceptions(sourceStr, targetLocale);
+                    const hasExceptions = this.matchesException(sourceStr, targetLocale);
                     if (!hasExceptions) {
                         let value = {
                             severity: /** @type {"warning"} */ ("warning"),

--- a/packages/ilib-lint/src/rules/ResourceICUPluralTranslation.js
+++ b/packages/ilib-lint/src/rules/ResourceICUPluralTranslation.js
@@ -73,13 +73,13 @@ class ResourceICUPluralTranslation extends ResourceRule {
     }
 
     /**
-     * Check if the given text contains any exceptions for the given locale.
+     * Check if the given text matches any exception for the given language.
      * @private
      * @param {string} text the text to check
      * @param {string} locale the locale to check against
-     * @returns {boolean} true if the text contains any exceptions
+     * @returns {boolean} true if the text matches any exception
      */
-    containsExceptions(text, locale) {
+    matchesException(text, locale) {
         try {
             const localeObj = new Locale(locale);
             if (!localeObj.isValid()) {


### PR DESCRIPTION
- Added the ability to specify exceptions to the resource-icu-plural-translated rule so that it does not produce warnings for those exception words and phrases. Now you can list the exceptions by locale in the parameters to the rule:

```
"rulesets": {
  "myruleset": {
    "resource-icu-plural-translated": {
      "exceptions": {
        "it-IT": ["File", "Files"]
      }
    }
  }
}
```