### PR TITLE
ilib-lint: Modify kebab rule to require at least 2 dashes

### DIFF
--- a/.changeset/tall-peas-hope.md
+++ b/.changeset/tall-peas-hope.md
@@ -1,0 +1,11 @@
+---
+"ilib-lint": patch
+---
+
+- Fixed resource-kebab-case rule so that there are no false
+  positives for simple hyphenated words
+  - now does not complain for simple English words that are
+    hyphenated, such as "co-owner" or "share-only"
+  - new rule is that there has to be at least 2 dashes in
+    the text, and the text can only be letters or numbers
+    in order to be considered kebab case

--- a/packages/ilib-lint/docs/resource-kebab-case.md
+++ b/packages/ilib-lint/docs/resource-kebab-case.md
@@ -11,24 +11,26 @@ Kebab case is a way of writing phrases without spaces, where spaces are replaced
 
 In this context, any string that conforms to the following rules is considered kebab case and should not be translated:
 
+> **Note:** This rule requires at least 2 hyphens to avoid false positives with common hyphenated English words like "self-driving", "co-owner", "well-known", etc. These words are legitimate translation candidates and should not be blocked by this rule.
 
 A string is considered to be in kebab case if:
 - It contains only letters, numbers, and hyphens
 - Words are separated by single hyphens
+- **It contains at least 2 hyphens** (to avoid false positives with common hyphenated English words)
 - It may have leading or trailing whitespace
 - It may have a leading or trailing hyphen
 - It may contain mixed case letters
 - It may contain only upper case letters
 
 Examples of kebab case strings:
-- `kebab-case`
+- `kebab-case-example`
 - `kebab-case-with-multiple-words`
-- `kebab-case-123`
-- `Kebab-Case-Mixed`
-- `KEBAB-CASE-UPPER`
-- ` kebab-case ` (with leading/trailing whitespace)
-- `kebab-case-` (with trailing hyphen)
-- `-kebab-case` (with leading hyphen)
+- `kebab-case-123-example`
+- `Kebab-Case-Mixed-Example`
+- `KEBAB-CASE-UPPER-EXAMPLE`
+- ` kebab-case-example ` (with leading/trailing whitespace)
+- `kebab-case-example-` (with trailing hyphen)
+- `-kebab-case-example` (with leading hyphen)
 
 Examples of strings that are not in kebab case:
 - `kebab case` (contains spaces)
@@ -37,6 +39,9 @@ Examples of strings that are not in kebab case:
 - `kebab_case` (snake case)
 - `kebab.case` (contains dots)
 - `kebab--case` (consecutive hyphens)
+- `kebab-case` (only 1 hyphen - common hyphenated English words are excluded)
+- `self-driving` (only 1 hyphen - common hyphenated English words are excluded)
+- `co-owner` (only 1 hyphen - common hyphenated English words are excluded)
 
 ## Examples
 
@@ -74,4 +79,4 @@ The rule can be configured to ignore certain strings using the `except` paramete
 
 ## Fix
 
-This rule provides an automatic fix that replaces the target string with the source string when a violation is detected. 
+This rule provides an automatic fix that replaces the target string with the source string when a violation is detected.

--- a/packages/ilib-lint/src/rules/ResourceKebabCase.js
+++ b/packages/ilib-lint/src/rules/ResourceKebabCase.js
@@ -20,10 +20,7 @@ class ResourceKebabCase extends ResourceRule {
         this.name = "resource-kebab-case";
         this.description = "Ensure that when source strings contain only kebab case and no whitespace, then the targets are the same";
         this.link = "https://gihub.com/iLib-js/ilib-mono/blob/main/packages/ilib-lint/docs/resource-kebab-case.md";
-        this.regexps = [
-            "^\\s*[a-zA-Z0-9]*(-[a-zA-Z0-9]+)+\\s*$",
-            "^\\s*[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*-\\s*$"
-        ];
+
         this.exceptions = Array.isArray(options?.except) ? options.except : [];
     }
 
@@ -82,19 +79,27 @@ class ResourceKebabCase extends ResourceRule {
     /**
      * @public
      * @param {string} string A non-empty string to check.
-     * @returns {boolean} Returns true for a string that is in kebab case (matches one of the regular expressions declared in the constructor).
+     * @returns {boolean} Returns true for a string that is in kebab case with at least 2 dashes.
      * Otherwise, returns false.
      */
     isKebabCase(string) {
         const trimmed = string.trim();
-        for (const regexp of this.regexps) {
-            const match = RegExp(regexp).test(trimmed);
 
-            if (match) {
-                return true;
-            }
+        // Count the number of dashes in the string
+        const dashCount = (trimmed.match(/-/g) || []).length;
+
+        // Require at least 2 dashes to be considered kebab case
+        if (dashCount < 2) {
+            return false;
         }
-        return false;
+
+        // Basic pattern check: only letters, numbers, and hyphens allowed
+        // and no consecutive hyphens
+        if (!/^[a-zA-Z0-9\-]+$/.test(trimmed) || /--/.test(trimmed)) {
+            return false;
+        }
+
+        return true;
     }
 }
 

--- a/packages/ilib-lint/test/rules/ResourceKebabCase.test.js
+++ b/packages/ilib-lint/test/rules/ResourceKebabCase.test.js
@@ -172,7 +172,7 @@ describe("ResourceKebabCase", () => {
 
     test("returns `undefined` if source is in kebab case and target is the same", () => {
         const rule = new ResourceKebabCase({});
-        const resource = createTestResourceString({source: "kebab-case", target: "kebab-case"});
+        const resource = createTestResourceString({source: "kebab-case-example", target: "kebab-case-example"});
 
         const result = rule.matchString({
             source: resource.source,
@@ -186,7 +186,7 @@ describe("ResourceKebabCase", () => {
 
     test("returns error if source is in kebab case and target is different", () => {
         const rule = new ResourceKebabCase({});
-        const resource = createTestResourceString({source: "kebab-case", target: "different-target"});
+        const resource = createTestResourceString({source: "kebab-case-example", target: "different-target"});
 
         const result = rule.matchString({
             source: resource.source,
@@ -203,7 +203,7 @@ describe("ResourceKebabCase", () => {
 
     test("provides fix that replaces target with source", () => {
         const rule = new ResourceKebabCase({});
-        const resource = createTestResourceString({source: "kebab-case", target: "different-target"});
+        const resource = createTestResourceString({source: "kebab-case-example", target: "different-target"});
 
         const result = rule.matchString({
             source: resource.source,
@@ -228,14 +228,13 @@ describe("ResourceKebabCase", () => {
 describe('ResourceKebabCase.isKebabCase', () => {
     test.each(
         [
-            {name: "simple kebab case", source: "kebab-case"},
             {name: "multiple hyphens", source: "kebab-case-with-multiple-words"},
-            {name: "mixed case", source: "Kebab-Case-Mixed"},
-            {name: "upper case", source: "KEBAB-CASE-UPPER"},
-            {name: "with digits", source: "kebab-case-123"},
-            {name: "with leading and trailing whitespace", source: " kebab-case "},
-            {name: "with trailing hyphen", source: "kebab-case-"},
-            {name: "with leading hyphen", source: "-kebab-case"},
+            {name: "mixed case with multiple hyphens", source: "Kebab-Case-Mixed-Example"},
+            {name: "upper case with multiple hyphens", source: "KEBAB-CASE-UPPER-EXAMPLE"},
+            {name: "with digits and multiple hyphens", source: "kebab-case-123-example"},
+            {name: "with leading and trailing whitespace", source: " kebab-case-example "},
+            {name: "with trailing hyphen", source: "kebab-case-example-"},
+            {name: "with leading hyphen", source: "-kebab-case-example"},
         ]
     )("returns `true` if source string is $name", ({source}) => {
         const rule = new ResourceKebabCase({});
@@ -250,10 +249,16 @@ describe('ResourceKebabCase.isKebabCase', () => {
         {name: "digits solely", source: "123"},
         {name: "lowercase letters word solely", source: "word"},
         {name: "uppercase letters word solely", source: "WORD"},
-        {name: "uppercase letters word solely", source: "Word"},
+        {name: "mixed case word solely", source: "Word"},
+        {name: "single hyphen kebab case", source: "kebab-case"},
+        {name: "single hyphen with mixed case", source: "Kebab-Case"},
+        {name: "single hyphen with upper case", source: "KEBAB-CASE"},
+        {name: "single hyphen with leading/trailing whitespace", source: " kebab-case "},
+        {name: "single hyphen with trailing hyphen", source: "kebab-"},
+        {name: "single hyphen with leading hyphen", source: "-kebab"},
 
         {name: "text and whitespace", source: "kebab case"},
-        {name: "camel case and text", source: "kebab-case and kebab"},
+        {name: "camel case and text", source: "kebab-case-example and kebab"},
 
         {name: "text with underscores", source: "kebab_case"},
         {name: "text with dots", source: "kebab.case"},


### PR DESCRIPTION
- This avoids all the false positives with hyphenated words in English that only have a single dash in them.