### PR TITLE
Made quotes be optional for it and sv

### DIFF
--- a/.changeset/red-kangaroos-float.md
+++ b/.changeset/red-kangaroos-float.md
@@ -1,0 +1,13 @@
+---
+"ilib-lint": patch
+---
+
+- Fix quote handling for Swedish and Italian
+  - Quotes are optional in those languages for many places
+    where were would use quotes in English
+  - The rule now checks for the presence of quotes in the
+    source and target, and if the quotes are not present
+    in the target, no Result is generated. (For other locales
+    a result is generated for this case.) If the quotes are
+    present in the target, they must be the native quotes.
+    They cannot be the ascii ones.


### PR DESCRIPTION
- quotes may be missing in the target string and no Result is generated in that case
- if a quote is present, it must be the native type