### PR TITLE
Put defensive code into the serializers in ilib-lint

### DIFF
--- a/.changeset/old-moles-brake.md
+++ b/.changeset/old-moles-brake.md
@@ -1,0 +1,6 @@
+---
+"ilib-lint": patch
+---
+
+- Add defensive code to the serializers so they don't
+  crash if they are given bogus input

--- a/.changeset/proud-rockets-whisper.md
+++ b/.changeset/proud-rockets-whisper.md
@@ -2,6 +2,6 @@
 "ilib-lint-common": minor
 ---
 
-- Serializer plugins can now return undefined if the
+- Serializer plugins can now throw an Error if the
   data they are trying to serialize is insufficient
-  and the output file cannot be generated
+  or the output file cannot be generated

--- a/.changeset/proud-rockets-whisper.md
+++ b/.changeset/proud-rockets-whisper.md
@@ -1,0 +1,7 @@
+---
+"ilib-lint-common": minor
+---
+
+- Serializer plugins can now return undefined if the
+  data they are trying to serialize is insufficient
+  and the output file cannot be generated

--- a/packages/ilib-lint-common/src/Serializer.js
+++ b/packages/ilib-lint-common/src/Serializer.js
@@ -68,8 +68,8 @@ class Serializer extends PipelineElement {
      * @abstract
      * @param {IntermediateRepresentation[]} representations the array of intermediate
      * representations to serialize
-     * @returns {SourceFile} the source file that contains the serialized form of the
-     * given intermediate representation
+     * @returns {SourceFile|undefined} the source file that contains the serialized form of the
+     * given intermediate representation, or undefined if the source file could not be created
      */
     serialize(representations) {
         throw new NotImplementedError();

--- a/packages/ilib-lint-common/src/Serializer.js
+++ b/packages/ilib-lint-common/src/Serializer.js
@@ -68,8 +68,9 @@ class Serializer extends PipelineElement {
      * @abstract
      * @param {IntermediateRepresentation[]} representations the array of intermediate
      * representations to serialize
-     * @returns {SourceFile|undefined} the source file that contains the serialized form of the
-     * given intermediate representation, or undefined if the source file could not be created
+     * @returns {SourceFile} the source file that contains the serialized form of the
+     * given intermediate representation
+     * @throws {Error} if the source file could not be created
      */
     serialize(representations) {
         throw new NotImplementedError();

--- a/packages/ilib-lint/src/Project.js
+++ b/packages/ilib-lint/src/Project.js
@@ -536,6 +536,9 @@ class Project extends DirItem {
      */
     findIssues(locales) {
         this.fileStats = new FileStats();
+        if (!this.files || this.files.length === 0) {
+            return [];
+        }
         return this.files.flatMap(file => {
             //logger.debug(`Examining ${file.filePath}`);
             if (!this.options.opt.quiet && this.options.opt.progressInfo) {

--- a/packages/ilib-lint/src/plugins/LineSerializer.js
+++ b/packages/ilib-lint/src/plugins/LineSerializer.js
@@ -39,13 +39,22 @@ class LineSerializer extends Serializer {
      *
      * @override
      * @param {IntermediateRepresentation[]} irs the intermediate representations to convert
-     * @returns {SourceFile} the source file with the contents of the intermediate
-     * representation
+     * @returns {SourceFile|undefined} the source file with the contents of the intermediate
+     * representation, or undefined if the source file could not be created
      */
     serialize(irs) {
         // should only be one ir in this array
+        if (!irs || irs.length === 0) {
+            return undefined;
+        }
         const ir = irs[0];
+        if (ir.getType() !== this.type) {
+            return undefined;
+        }
         const lines = ir.getRepresentation();
+        if (!lines || lines.length === 0) {
+            return undefined;
+        }
         const data = lines.join("\n");
         return new SourceFile(ir.sourceFile.getPath(), {
             file: ir.sourceFile,

--- a/packages/ilib-lint/src/plugins/LineSerializer.js
+++ b/packages/ilib-lint/src/plugins/LineSerializer.js
@@ -39,21 +39,22 @@ class LineSerializer extends Serializer {
      *
      * @override
      * @param {IntermediateRepresentation[]} irs the intermediate representations to convert
-     * @returns {SourceFile|undefined} the source file with the contents of the intermediate
-     * representation, or undefined if the source file could not be created
+     * @returns {SourceFile} the source file with the contents of the intermediate
+     * representation
+     * @throws {Error} if the source file could not be created
      */
     serialize(irs) {
         // should only be one ir in this array
         if (!irs || irs.length === 0) {
-            return undefined;
+            throw new Error("No intermediate representation provided");
         }
         const ir = irs[0];
         if (ir.getType() !== this.type) {
-            return undefined;
+            throw new Error("Invalid intermediate representation");
         }
         const lines = ir.getRepresentation();
         if (!lines || lines.length === 0) {
-            return undefined;
+            throw new Error("No lines found in intermediate representation");
         }
         const data = lines.join("\n");
         return new SourceFile(ir.sourceFile.getPath(), {

--- a/packages/ilib-lint/src/plugins/XliffSerializer.js
+++ b/packages/ilib-lint/src/plugins/XliffSerializer.js
@@ -41,21 +41,22 @@ class XliffSerializer extends Serializer {
      *
      * @override
      * @param {IntermediateRepresentation[]} irs the intermediate representations to convert
-     * @returns {SourceFile|undefined} the source file with the contents of the intermediate
-     * representation, or undefined if the source file could not be created
+     * @returns {SourceFile} the source file with the contents of the intermediate
+     * representation
+     * @throws {Error} if the source file could not be created
      */
     serialize(irs) {
         // should only be one ir in this array
         if (!irs || irs.length === 0) {
-            return undefined;
+            throw new Error("No intermediate representation provided");
         }
         const ir = irs[0];
         if (!ir || ir.getType() !== this.type) {
-            return undefined;
+            throw new Error("Invalid intermediate representation");
         }
         const resources = ir.getRepresentation();
         if (!resources || resources.length === 0) {
-            return undefined;
+            throw new Error("No resources found in intermediate representation");
         }
         // produce the same version as the original file
         const xliffVersion = this._getxliffVersion(ir.sourceFile.getContent());

--- a/packages/ilib-lint/src/plugins/XliffSerializer.js
+++ b/packages/ilib-lint/src/plugins/XliffSerializer.js
@@ -41,13 +41,23 @@ class XliffSerializer extends Serializer {
      *
      * @override
      * @param {IntermediateRepresentation[]} irs the intermediate representations to convert
-     * @returns {SourceFile} the source file with the contents of the intermediate
-     * representation
+     * @returns {SourceFile|undefined} the source file with the contents of the intermediate
+     * representation, or undefined if the source file could not be created
      */
     serialize(irs) {
         // should only be one ir in this array
+        if (!irs || irs.length === 0) {
+            return undefined;
+        }
         const ir = irs[0];
+        if (!ir || ir.getType() !== this.type) {
+            return undefined;
+        }
         const resources = ir.getRepresentation();
+        if (!resources || resources.length === 0) {
+            return undefined;
+        }
+        // produce the same version as the original file
         const xliffVersion = this._getxliffVersion(ir.sourceFile.getContent());
         const xliff = new ResourceXliff({
             path: ir.sourceFile.getPath(),

--- a/packages/ilib-lint/src/plugins/string/StringSerializer.js
+++ b/packages/ilib-lint/src/plugins/string/StringSerializer.js
@@ -41,14 +41,23 @@ class StringSerializer extends Serializer {
      *
      * @override
      * @param {IntermediateRepresentation[]} irs the intermediate representations to convert
-     * @returns {SourceFile} the source file with the contents of the intermediate
-     * representation
+     * @returns {SourceFile|undefined} the source file with the contents of the intermediate
+     * representation, or undefined if the source file could not be created
      */
     serialize(irs) {
         // should only have 1 intermediate representation in the array because the StringParser
         // only creates one
+        if (!irs || irs.length === 0) {
+            return undefined;
+        }
         const ir = irs[0];
+        if (ir.getType() !== this.type) {
+            return undefined;
+        }
         const data = ir.getRepresentation();
+        if (!data) {
+            return undefined;
+        }
         return new SourceFile(ir.sourceFile.getPath(), {
             file: ir.sourceFile,
             content: data

--- a/packages/ilib-lint/src/plugins/string/StringSerializer.js
+++ b/packages/ilib-lint/src/plugins/string/StringSerializer.js
@@ -41,22 +41,23 @@ class StringSerializer extends Serializer {
      *
      * @override
      * @param {IntermediateRepresentation[]} irs the intermediate representations to convert
-     * @returns {SourceFile|undefined} the source file with the contents of the intermediate
-     * representation, or undefined if the source file could not be created
+     * @returns {SourceFile} the source file with the contents of the intermediate
+     * representation
+     * @throws {Error} if the source file could not be created
      */
     serialize(irs) {
         // should only have 1 intermediate representation in the array because the StringParser
         // only creates one
         if (!irs || irs.length === 0) {
-            return undefined;
+            throw new Error("No intermediate representation provided");
         }
         const ir = irs[0];
         if (ir.getType() !== this.type) {
-            return undefined;
+            throw new Error("Invalid intermediate representation");
         }
         const data = ir.getRepresentation();
         if (!data) {
-            return undefined;
+            throw new Error("No data found in intermediate representation");
         }
         return new SourceFile(ir.sourceFile.getPath(), {
             file: ir.sourceFile,

--- a/packages/ilib-lint/test/XliffSerializer.test.js
+++ b/packages/ilib-lint/test/XliffSerializer.test.js
@@ -251,15 +251,19 @@ describe("test the XliffParser plugin", () => {
         expect(() => xs.serialize([ir])).toThrow("No resources found in intermediate representation");
     });
 
-    test("Serialize an intermediate representation with an undefined or null intermediate representation", () => {
-        expect.assertions(2);
+    test.each([undefined, null])(
+        "Serialize an intermediate representation with invalid argument type %s",
+        (invalidIr) => {
+            expect.assertions(1);
 
-        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
-        const xs = new XliffSerializer();
-        //@ts-ignore the expected value is an array with null, but TypeScript is throwing an error because it can't assign null to an array of IntermediateRepresentation
-        expect(() => xs.serialize([null])).toThrow("Invalid intermediate representation");
+            const xs = new XliffSerializer();
+            expect(() =>
+                // @ts-expect-error testing invalid argument types
+                xs.serialize([invalidIr])
+            ).toThrow("Invalid intermediate representation");
+        }
+    );
+});
 
-        //@ts-ignore the expected value is an array with undefined, but TypeScript is throwing an error because it can't assign undefined to an array of IntermediateRepresentation
-        expect(() => xs.serialize([undefined])).toThrow("Invalid intermediate representation");
     });
 });

--- a/packages/ilib-lint/test/XliffSerializer.test.js
+++ b/packages/ilib-lint/test/XliffSerializer.test.js
@@ -74,6 +74,7 @@ describe("test the XliffParser plugin", () => {
   </file>
 </xliff>`);
     });
+
     test("Serialize a regular xliff 2.0 file", () => {
         expect.assertions(3);
 
@@ -212,6 +213,58 @@ describe("test the XliffParser plugin", () => {
     </body>
   </file>
 </xliff>`);
+    });
 
+    test("Serialize a resource with an invalid resource type", () => {
+        expect.assertions(1);
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+        const ir = new IntermediateRepresentation({
+            type: "string",
+            ir: ["random string"],
+            sourceFile
+        });
+
+        const xs = new XliffSerializer();
+        const newSourceFile = xs.serialize([ir]);
+        expect(newSourceFile).toBeUndefined();
+    });
+
+    test("Serialize an intermediate representation with no representations", () => {
+        expect.assertions(1);
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+        const xs = new XliffSerializer();
+        const newSourceFile = xs.serialize([]);
+        expect(newSourceFile).toBeUndefined();
+    });
+
+    test("Serialize an intermediate representation with no resource representations", () => {
+        expect.assertions(1);
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [],
+            sourceFile
+        });
+
+        const xs = new XliffSerializer();
+        const newSourceFile = xs.serialize([ir]);
+        expect(newSourceFile).toBeUndefined();
+    });
+
+    test("Serialize an intermediate representation with an undefined or null intermediate representation", () => {
+        expect.assertions(2);
+
+        const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
+        const xs = new XliffSerializer();
+        //@ts-ignore the expected value is an array with null, but TypeScript is throwing an error because it can't assign null to an array of IntermediateRepresentation
+        let newSourceFile = xs.serialize([null]);
+        expect(newSourceFile).toBeUndefined();
+
+        //@ts-ignore the expected value is an array with undefined, but TypeScript is throwing an error because it can't assign undefined to an array of IntermediateRepresentation
+        newSourceFile = xs.serialize([undefined]);
+        expect(newSourceFile).toBeUndefined();
     });
 });

--- a/packages/ilib-lint/test/XliffSerializer.test.js
+++ b/packages/ilib-lint/test/XliffSerializer.test.js
@@ -226,8 +226,7 @@ describe("test the XliffParser plugin", () => {
         });
 
         const xs = new XliffSerializer();
-        const newSourceFile = xs.serialize([ir]);
-        expect(newSourceFile).toBeUndefined();
+        expect(() => xs.serialize([ir])).toThrow("Invalid intermediate representation");
     });
 
     test("Serialize an intermediate representation with no representations", () => {
@@ -235,8 +234,7 @@ describe("test the XliffParser plugin", () => {
 
         const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
         const xs = new XliffSerializer();
-        const newSourceFile = xs.serialize([]);
-        expect(newSourceFile).toBeUndefined();
+        expect(() => xs.serialize([])).toThrow("No intermediate representation provided");
     });
 
     test("Serialize an intermediate representation with no resource representations", () => {
@@ -250,8 +248,7 @@ describe("test the XliffParser plugin", () => {
         });
 
         const xs = new XliffSerializer();
-        const newSourceFile = xs.serialize([ir]);
-        expect(newSourceFile).toBeUndefined();
+        expect(() => xs.serialize([ir])).toThrow("No resources found in intermediate representation");
     });
 
     test("Serialize an intermediate representation with an undefined or null intermediate representation", () => {
@@ -260,11 +257,9 @@ describe("test the XliffParser plugin", () => {
         const sourceFile = new SourceFile("test/testfiles/xliff/test.xliff", {});
         const xs = new XliffSerializer();
         //@ts-ignore the expected value is an array with null, but TypeScript is throwing an error because it can't assign null to an array of IntermediateRepresentation
-        let newSourceFile = xs.serialize([null]);
-        expect(newSourceFile).toBeUndefined();
+        expect(() => xs.serialize([null])).toThrow("Invalid intermediate representation");
 
         //@ts-ignore the expected value is an array with undefined, but TypeScript is throwing an error because it can't assign undefined to an array of IntermediateRepresentation
-        newSourceFile = xs.serialize([undefined]);
-        expect(newSourceFile).toBeUndefined();
+        expect(() => xs.serialize([undefined])).toThrow("Invalid intermediate representation");
     });
 });

--- a/packages/ilib-lint/test/XliffSerializer.test.js
+++ b/packages/ilib-lint/test/XliffSerializer.test.js
@@ -264,6 +264,3 @@ describe("test the XliffParser plugin", () => {
         }
     );
 });
-
-    });
-});


### PR DESCRIPTION
... so that it doesn't crash when given bogus input. 

Given that I can't reproduce the problem from the lint report, all we can do is this defensive code.