### PR TITLE
Get and use the right locales in the linter

### DIFF
--- a/.changeset/sour-plants-flow.md
+++ b/.changeset/sour-plants-flow.md
@@ -1,0 +1,7 @@
+---
+"ilib-lint": patch
+---
+
+- Fixed bug: now get and use the right locales
+  - command-line overrides the config file which overrides the default
+  - before, it only ever used the defaults!

--- a/packages/ilib-lint/src/FileType.js
+++ b/packages/ilib-lint/src/FileType.js
@@ -152,7 +152,7 @@ class FileType {
 
         this.name = options.name;
         this.project = options.project;
-        this.locales = options.locales;
+        this.locales = options.locales || this.project.getLocales();
         this.template = options.template;
 
         const parserNames = options.parsers;
@@ -244,7 +244,7 @@ class FileType {
     }
 
     getLocales() {
-        return this.locales || this.project.getLocales();
+        return this.locales;
     }
 
     getTemplate() {

--- a/packages/ilib-lint/src/FileType.js
+++ b/packages/ilib-lint/src/FileType.js
@@ -29,6 +29,42 @@ import Project from "./Project.js";
 const logger = log4js.getLogger("ilib-lint.FileType");
 
 /**
+ * Default locales for the linter if none are specified on the command line or in the config file. These are the top
+ * 27 locales on the internet by volume as of 2015. (Maybe we should update this list?)
+ * @type {readonly string[]}
+ */
+const defaultLocales = [
+    "en-AU",
+    "en-CA",
+    "en-GB",
+    "en-IN",
+    "en-NG",
+    "en-PH",
+    "en-PK",
+    "en-US",
+    "en-ZA",
+    "de-DE",
+    "fr-CA",
+    "fr-FR",
+    "es-AR",
+    "es-ES",
+    "es-MX",
+    "id-ID",
+    "it-IT",
+    "ja-JP",
+    "ko-KR",
+    "pt-BR",
+    "ru-RU",
+    "tr-TR",
+    "vi-VN",
+    "zxx-XX",
+    "zh-Hans-CN",
+    "zh-Hant-HK",
+    "zh-Hant-TW",
+    "zh-Hans-SG"
+];
+
+/**
  * @class Represent a type of file in an ilib-lint project.
  *
  * Each file is classified into a particular file type. If
@@ -152,7 +188,7 @@ class FileType {
 
         this.name = options.name;
         this.project = options.project;
-        this.locales = options.locales || this.project.getLocales();
+        this.locales = options.locales || this.project.getLocales() || defaultLocales;
         this.template = options.template;
 
         const parserNames = options.parsers;

--- a/packages/ilib-lint/src/FileType.js
+++ b/packages/ilib-lint/src/FileType.js
@@ -29,42 +29,6 @@ import Project from "./Project.js";
 const logger = log4js.getLogger("ilib-lint.FileType");
 
 /**
- * Default locales for the linter if none are specified on the command line or in the config file. These are the top
- * 27 locales on the internet by volume as of 2015. (Maybe we should update this list?)
- * @type {readonly string[]}
- */
-const defaultLocales = [
-    "en-AU",
-    "en-CA",
-    "en-GB",
-    "en-IN",
-    "en-NG",
-    "en-PH",
-    "en-PK",
-    "en-US",
-    "en-ZA",
-    "de-DE",
-    "fr-CA",
-    "fr-FR",
-    "es-AR",
-    "es-ES",
-    "es-MX",
-    "id-ID",
-    "it-IT",
-    "ja-JP",
-    "ko-KR",
-    "pt-BR",
-    "ru-RU",
-    "tr-TR",
-    "vi-VN",
-    "zxx-XX",
-    "zh-Hans-CN",
-    "zh-Hant-HK",
-    "zh-Hant-TW",
-    "zh-Hans-SG"
-];
-
-/**
  * @class Represent a type of file in an ilib-lint project.
  *
  * Each file is classified into a particular file type. If
@@ -86,13 +50,6 @@ class FileType {
      * @readonly
      */
     name;
-
-    /**
-     * The list of locales to use with this file type
-     * @type {Array.<String>|undefined}
-     * @readonly
-     */
-    locales;
 
     /**
      * The intermediate representation type of this file type.
@@ -150,7 +107,6 @@ class FileType {
      * of this file type as documented above
      * @param {String} options.name the name or glob spec for this file type
      * @param {Project} options.project the Project that this file type is a part of
-     * @param {Array.<String>} [options.locales] list of locales to use with this file type
      * @param {String} [options.template] the path name template for this file type
      * which shows how to extract the locale from the path
      * name if the path includes it. Many file types
@@ -188,7 +144,6 @@ class FileType {
 
         this.name = options.name;
         this.project = options.project;
-        this.locales = options.locales || this.project.getLocales() || defaultLocales;
         this.template = options.template;
 
         const parserNames = options.parsers;
@@ -277,10 +232,6 @@ class FileType {
 
     getProject() {
         return this.project;
-    }
-
-    getLocales() {
-        return this.locales;
     }
 
     getTemplate() {

--- a/packages/ilib-lint/src/Project.js
+++ b/packages/ilib-lint/src/Project.js
@@ -78,6 +78,42 @@ function isOwnMethod(instance, methodName, parentClass) {
 }
 
 /**
+ * Default locales for the linter if none are specified on the command line or in the config file. These are the top
+ * 27 locales on the internet by volume as of 2015. (Maybe we should update this list?)
+ * @type {string[]}
+ */
+const defaultLocales = [
+    "en-AU",
+    "en-CA",
+    "en-GB",
+    "en-IN",
+    "en-NG",
+    "en-PH",
+    "en-PK",
+    "en-US",
+    "en-ZA",
+    "de-DE",
+    "fr-CA",
+    "fr-FR",
+    "es-AR",
+    "es-ES",
+    "es-MX",
+    "id-ID",
+    "it-IT",
+    "ja-JP",
+    "ko-KR",
+    "pt-BR",
+    "ru-RU",
+    "tr-TR",
+    "vi-VN",
+    "zxx-XX",
+    "zh-Hans-CN",
+    "zh-Hant-HK",
+    "zh-Hant-TW",
+    "zh-Hans-SG"
+];
+
+/**
  * @class Represent an ilin-lint project.
  *
  * A project is defined as a root directory and a configuration that
@@ -124,7 +160,11 @@ class Project extends DirItem {
         }
 
         this.sourceLocale = config?.sourceLocale || options?.opt?.sourceLocale;
-        this.locales = this.options?.opt?.locales || this.config.locales;
+        /**
+         * @readonly
+         * @type {string[]}
+         */
+        this.locales = this.options?.opt?.locales || this.config.locales || defaultLocales;
 
         this.config.autofix = options?.opt?.fix === true || config?.autofix === true;
 

--- a/packages/ilib-lint/src/Project.js
+++ b/packages/ilib-lint/src/Project.js
@@ -78,43 +78,6 @@ function isOwnMethod(instance, methodName, parentClass) {
 }
 
 /**
- * Default locales for the linter if none are specified on the command line or in the config file. These are the top
- * 27 locales on the internet by volume as of 2015. (Maybe we should update this list?)
- * @private
- * @type {Array.<String>}
- */
-const defaultLocales = [
-    "en-AU",
-    "en-CA",
-    "en-GB",
-    "en-IN",
-    "en-NG",
-    "en-PH",
-    "en-PK",
-    "en-US",
-    "en-ZA",
-    "de-DE",
-    "fr-CA",
-    "fr-FR",
-    "es-AR",
-    "es-ES",
-    "es-MX",
-    "id-ID",
-    "it-IT",
-    "ja-JP",
-    "ko-KR",
-    "pt-BR",
-    "ru-RU",
-    "tr-TR",
-    "vi-VN",
-    "zxx-XX",
-    "zh-Hans-CN",
-    "zh-Hant-HK",
-    "zh-Hant-TW",
-    "zh-Hans-SG"
-];
-
-/**
  * @class Represent an ilin-lint project.
  *
  * A project is defined as a root directory and a configuration that
@@ -161,7 +124,7 @@ class Project extends DirItem {
         }
 
         this.sourceLocale = config?.sourceLocale || options?.opt?.sourceLocale;
-        this.locales = this.options?.opt?.locales || this.config.locales || defaultLocales;
+        this.locales = this.options?.opt?.locales || this.config.locales;
 
         this.config.autofix = options?.opt?.fix === true || config?.autofix === true;
 
@@ -438,14 +401,6 @@ class Project extends DirItem {
      */
     getSourceLocale() {
         return this.sourceLocale || "en-US";
-    }
-
-    /**
-     * Return the list of global locales for this project.
-     * @returns {Array.<String>} the list of global locales for this project
-     */
-    getLocales() {
-        return this.locales;
     }
 
     /**

--- a/packages/ilib-lint/src/Project.js
+++ b/packages/ilib-lint/src/Project.js
@@ -78,6 +78,43 @@ function isOwnMethod(instance, methodName, parentClass) {
 }
 
 /**
+ * Default locales for the linter if none are specified on the command line or in the config file. These are the top
+ * 27 locales on the internet by volume as of 2015. (Maybe we should update this list?)
+ * @private
+ * @type {Array.<String>}
+ */
+const defaultLocales = [
+    "en-AU",
+    "en-CA",
+    "en-GB",
+    "en-IN",
+    "en-NG",
+    "en-PH",
+    "en-PK",
+    "en-US",
+    "en-ZA",
+    "de-DE",
+    "fr-CA",
+    "fr-FR",
+    "es-AR",
+    "es-ES",
+    "es-MX",
+    "id-ID",
+    "it-IT",
+    "ja-JP",
+    "ko-KR",
+    "pt-BR",
+    "ru-RU",
+    "tr-TR",
+    "vi-VN",
+    "zxx-XX",
+    "zh-Hans-CN",
+    "zh-Hant-HK",
+    "zh-Hant-TW",
+    "zh-Hans-SG"
+];
+
+/**
  * @class Represent an ilin-lint project.
  *
  * A project is defined as a root directory and a configuration that
@@ -124,6 +161,8 @@ class Project extends DirItem {
         }
 
         this.sourceLocale = config?.sourceLocale || options?.opt?.sourceLocale;
+        this.locales = this.options?.opt?.locales || this.config.locales || defaultLocales;
+
         this.config.autofix = options?.opt?.fix === true || config?.autofix === true;
 
         this.pluginMgr = this.options.pluginManager;
@@ -406,7 +445,7 @@ class Project extends DirItem {
      * @returns {Array.<String>} the list of global locales for this project
      */
     getLocales() {
-        return this.options.locales || this.config.locales;
+        return this.locales;
     }
 
     /**
@@ -627,7 +666,7 @@ class Project extends DirItem {
     run() {
         let startTime = new Date();
 
-        const results = this.findIssues(this.options.opt.locales);
+        const results = this.findIssues(this.locales);
         this.applyTransformers(results);
         this.serialize();
         let endTime = new Date();

--- a/packages/ilib-lint/src/Project.js
+++ b/packages/ilib-lint/src/Project.js
@@ -80,7 +80,7 @@ function isOwnMethod(instance, methodName, parentClass) {
 /**
  * Default locales for the linter if none are specified on the command line or in the config file. These are the top
  * 27 locales on the internet by volume as of 2015. (Maybe we should update this list?)
- * @type {string[]}
+ * @type {readonly string[]}
  */
 const defaultLocales = [
     "en-AU",
@@ -164,7 +164,7 @@ class Project extends DirItem {
          * @readonly
          * @type {string[]}
          */
-        this.locales = this.options?.opt?.locales || this.config.locales || defaultLocales;
+        this.locales = this.options?.opt?.locales || this.config.locales || [...defaultLocales];
 
         this.config.autofix = options?.opt?.fix === true || config?.autofix === true;
 

--- a/packages/ilib-lint/src/index.js
+++ b/packages/ilib-lint/src/index.js
@@ -79,7 +79,6 @@ const optionConfig = {
     locales: {
         short: "l",
         varName: "LOCALES",
-        "default": "en-AU,en-CA,en-GB,en-IN,en-NG,en-PH,en-PK,en-US,en-ZA,de-DE,fr-CA,fr-FR,es-AR,es-ES,es-MX,id-ID,it-IT,ja-JP,ko-KR,pt-BR,ru-RU,tr-TR,vi-VN,zxx-XX,zh-Hans-CN,zh-Hant-HK,zh-Hant-TW,zh-Hans-SG",
         help: "Locales you want your app to support. Value is a comma-separated list of BCP-47 style locale tags. Default: the top 20 locales on the internet by traffic."
     },
     sourceLocale: {
@@ -188,15 +187,15 @@ if (paths.length === 0) {
 
 if (options.opt.locales) {
     options.opt.locales = options.opt.locales.split(/,/g);
+    // normalize the locale specs
+    options.opt.locales = options.opt.locales.map(spec => {
+        let loc = new Locale(spec);
+        if (!loc.getLanguage()) {
+            loc = new Locale("und", loc.getRegion(), loc.getVariant(), loc.getScript());
+        }
+        return loc.getSpec();
+    });
 }
-// normalize the locale specs
-options.opt.locales = options.opt.locales.map(spec => {
-    let loc = new Locale(spec);
-    if (!loc.getLanguage()) {
-        loc = new Locale("und", loc.getRegion(), loc.getVariant(), loc.getScript());
-    }
-    return loc.getSpec();
-});
 
 if (options.opt.fix || options.opt.overwrite) {
     // The write option indicates that modified files should be written back to disk.

--- a/packages/ilib-lint/test/FileType.test.js
+++ b/packages/ilib-lint/test/FileType.test.js
@@ -341,20 +341,6 @@ describe("testFileType", () => {
         expect(ft.getProject()).toBe(project);
     });
 
-    test("FileTypeGetLocales", () => {
-        expect.assertions(2);
-
-        const locales = ["en-US", "de-DE"];
-        const ft = new FileType({
-            name: "test",
-            locales,
-            project,
-        });
-        expect(ft).toBeTruthy();
-
-        expect(ft.getLocales()).toBe(locales);
-    });
-
     test("FileType get the intermediate representation type", () => {
         expect.assertions(2);
         const ft = new FileType({
@@ -416,18 +402,6 @@ describe("testFileType", () => {
         const serializer = ft.getSerializer();
         expect(serializer).toBeTruthy();
         expect(serializer?.getName()).toBe("serializer-xyz");
-    });
-
-    test("FileTypeGetLocalesFromProject", () => {
-        expect.assertions(2);
-
-        const ft = new FileType({
-            name: "test",
-            project,
-        });
-        expect(ft).toBeTruthy();
-
-        expect(ft.getLocales()).toEqual(["fr-FR", "nl-NL"]);
     });
 
     test("FileTypeGetTemplate", () => {

--- a/packages/ilib-lint/test/FileType.test.js
+++ b/packages/ilib-lint/test/FileType.test.js
@@ -38,20 +38,21 @@ ruleMgr.addRuleSetDefinition("no-state-checker", {
 const project = new Project(
     "x",
     {
-        locales: ["fr-FR", "nl-NL"],
         pluginManager,
     },
-    {}
+    {
+        locales: ["fr-FR", "nl-NL"],
+    }
 );
 
 const projectWithValidPlugins = new Project(
     "y",
     {
-        locales: ["fr-FR", "nl-NL"],
         pluginManager,
     },
     {
         plugins: ["ilib-lint-plugin-test"],
+        locales: ["fr-FR", "nl-NL"],
         fileTypes: {
             test: {
                 name: "test",
@@ -67,11 +68,11 @@ const projectWithValidPlugins = new Project(
 const projectWithParserAndUnknownSerializer = new Project(
     "z",
     {
-        locales: ["fr-FR", "nl-NL"],
         pluginManager,
     },
     {
         plugins: ["ilib-lint-plugin-test"],
+        locales: ["fr-FR", "nl-NL"],
         fileTypes: {
             test: {
                 name: "test",
@@ -105,11 +106,11 @@ serializerMgr.add([MockSerializer]);
 const projectWithWrongTypeOfSerializer = new Project(
     "a",
     {
-        locales: ["fr-FR", "nl-NL"],
         pluginManager,
     },
     {
         plugins: ["ilib-lint-plugin-test"],
+        locales: ["fr-FR", "nl-NL"],
         fileTypes: {
             test: {
                 name: "test",
@@ -126,11 +127,11 @@ const projectWithWrongTypeOfSerializer = new Project(
 const projectWithParserAndUnknownTransformers = new Project(
     "q",
     {
-        locales: ["fr-FR", "nl-NL"],
         pluginManager,
     },
     {
         plugins: ["ilib-lint-plugin-test"],
+        locales: ["fr-FR", "nl-NL"],
         fileTypes: {
             test: {
                 name: "test",
@@ -162,11 +163,11 @@ transformerMgr.add([MockTransformer]);
 const projectWithWrongTypeOfTransformers = new Project(
     "a",
     {
-        locales: ["fr-FR", "nl-NL"],
         pluginManager,
     },
     {
         plugins: ["ilib-lint-plugin-test"],
+        locales: ["fr-FR", "nl-NL"],
         fileTypes: {
             test: {
                 name: "test",
@@ -183,10 +184,10 @@ const projectWithWrongTypeOfTransformers = new Project(
 const projectWithDefaultParser = new Project(
     "a",
     {
-        locales: ["fr-FR", "nl-NL"],
         pluginManager,
     },
     {
+        locales: ["fr-FR", "nl-NL"],
         fileTypes: {
             test: {
                 name: "test",

--- a/packages/ilib-lint/test/Project.test.js
+++ b/packages/ilib-lint/test/Project.test.js
@@ -291,14 +291,18 @@ describe("testProject", () => {
     test("ProjectGetLocalesOptions", () => {
         expect.assertions(2);
 
+        const locales = ["en-US", "ko-KR"];
+
         const options = {
-            locales: ["en-US", "ko-KR"],
-            pluginManager,
+            pluginManager
         };
-        const project = new Project("x", options, genericConfig);
+        const project = new Project("x", options, {
+            ...genericConfig,
+            locales
+        });
         expect(project).toBeTruthy();
 
-        expect(project.getLocales()).toBe(options.locales);
+        expect(project.getLocales()).toBe(locales);
     });
 
     test("ProjectGetLocalesFallbackToConfig", () => {

--- a/packages/ilib-lint/test/Project.test.js
+++ b/packages/ilib-lint/test/Project.test.js
@@ -288,7 +288,7 @@ describe("testProject", () => {
         expect(project.getOptions()).toBe(options);
     });
 
-    test("ProjectGetLocalesOptions", () => {
+    test("ProjectLocalesOptions", () => {
         expect.assertions(2);
 
         const locales = ["en-US", "ko-KR"];
@@ -302,10 +302,10 @@ describe("testProject", () => {
         });
         expect(project).toBeTruthy();
 
-        expect(project.getLocales()).toBe(locales);
+        expect(project.locales).toEqual(locales);
     });
 
-    test("ProjectGetLocalesFallbackToConfig", () => {
+    test("ProjectLocalesFallbackToConfig", () => {
         expect.assertions(2);
 
         const options = {
@@ -314,7 +314,7 @@ describe("testProject", () => {
         const project = new Project("x", options, genericConfig);
         expect(project).toBeTruthy();
 
-        expect(project.getLocales()).toBe(genericConfig.locales);
+        expect(project.locales).toEqual(genericConfig.locales);
     });
 
     test("ProjectGetSourceLocaleFallbackToConfig", () => {


### PR DESCRIPTION
- now gets and uses the right locales
    - command-line overrides the config file which overrides the default
    - before, it only used the defaults!