### PR TITLE
Fix infinite fix loop in the quote style rule

### DIFF
--- a/.changeset/sweet-ads-brake.md
+++ b/.changeset/sweet-ads-brake.md
@@ -1,0 +1,8 @@
+---
+"ilib-lint": patch
+---
+
+- Fixed a bug in the quote style rule which would cause infinite fix loops
+  - Quote detection in the source was not working properly for quote-optional
+    languages, such as Italian or Swedish, causing it to apply the same fix
+    over and over again

--- a/packages/ilib-lint/src/rules/ResourceQuoteStyle.js
+++ b/packages/ilib-lint/src/rules/ResourceQuoteStyle.js
@@ -171,10 +171,7 @@ class ResourceQuoteStyle extends ResourceRule {
         // match the all types of Unicode non-breaking spaces which are used in some
         // locales to separate the quote from the text.
         let startQuote, endQuote;
-        if (isOptionalPunctuationLanguage) {
-            startQuote = new RegExp(`(^|\\W)(([${nonQuoteStartChars}'"])[\u00A0\u202F\u2060\u3000]?)([\\p{Letter}{])`, "gu");
-            endQuote = new RegExp(`([\\p{Letter}}])([\u00A0\u202F\u2060\u3000]?([${nonQuoteEndChars}'"]))(\\W|$)`, "gu");
-        } else if (sourceStyle.ascii) {
+        if (sourceStyle.ascii) {
             if (regExps.target.quotesAll.test(tar)) return;
             startQuote = new RegExp(`(^|\\W)(([${nonQuoteStartChars}'])[\u00A0\u202F\u2060\u3000]?)([\\p{Letter}{])`, "gu");
             endQuote = new RegExp(`([\\p{Letter}}])([\u00A0\u202F\u2060\u3000]?([${nonQuoteEndChars}']))(\\W|$)`, "gu");

--- a/packages/ilib-lint/test/ResourceQuoteStyle.test.js
+++ b/packages/ilib-lint/test/ResourceQuoteStyle.test.js
@@ -1214,18 +1214,8 @@ describe("testResourceQuoteStyle", () => {
             resource,
             file: "a/b/c.xliff"
         });
-        // For Italian, if quotes are present, they should be the correct style
-        const expected = expect.objectContaining({
-            severity: "warning",
-            description: "Quote style for the locale it-IT should be «text» or there should be no quotes in the target",
-            id: "quote.test",
-            source: 'This string contains "quotes" in it.',
-            highlight: 'Target: Questa stringa contiene <e0>"</e0>virgolette<e1>"</e1>.',
-            rule,
-            locale: "it-IT",
-            pathName: "a/b/c.xliff"
-        });
-        expect(actual).toEqual(expected);
+        // For Italian, if quotes are present, they are allowed to be ascii quotes
+        expect(actual).toBeFalsy();
     });
 
     test("ResourceQuoteStyleItalianOptionalQuotesWrongQuotesInTarget", () => {
@@ -1330,18 +1320,8 @@ describe("testResourceQuoteStyle", () => {
             resource,
             file: "a/b/c.xliff"
         });
-        // For Swedish, if quotes are present, they should be the correct style
-        const expected = expect.objectContaining({
-            severity: "warning",
-            description: "Quote style for the locale sv-SE should be ”text” or there should be no quotes in the target",
-            id: "quote.test",
-            source: 'This string contains "quotes" in it.',
-            highlight: 'Target: Denna sträng innehåller <e0>"</e0>citattecken<e1>"</e1>.',
-            rule,
-            locale: "sv-SE",
-            pathName: "a/b/c.xliff"
-        });
-        expect(actual).toEqual(expected);
+        // For Swedish, if quotes are present, they are allowed to be ascii quotes
+        expect(actual).toBeFalsy();
     });
 
     test("ResourceQuoteStyleSwedishOptionalQuotesWrongQuotesInTarget", () => {


### PR DESCRIPTION
- Fixed the quote detection code for optional-quote languages
    - Affects Italian and Swedish only
    - Need to use the normal method of quote detection that the other locales use and then bail out if no quotes are found in the target because that is valid for those languages.
