### PR TITLE
Added support for exceptions in the resource sentence ending rule

### DIFF
--- a/.changeset/mighty-lemons-visit.md
+++ b/.changeset/mighty-lemons-visit.md
@@ -1,0 +1,10 @@
+---
+"ilib-lint": minor
+---
+
+- ResourceSentenceEnding rule enhancements to support various exception
+  - Added minimumLength configuration option (default: 10) to skip checking short strings/abbreviations
+  - Added automatic skipping of strings with no spaces
+  - Added exceptions array per locale to skip specific source strings from checking
+  - Enhanced punctuation detection for quoted content to handle punctuation after closing quotes
+  - Updated rule documentation with new configuration options and examples

--- a/packages/ilib-lint/docs/resource-sentence-ending.md
+++ b/packages/ilib-lint/docs/resource-sentence-ending.md
@@ -53,7 +53,54 @@ The rule defaults to English punctuation. If you need different punctuation for 
 
 You can override the default punctuation rules for specific locales by providing custom configuration. The configuration uses locale codes as keys and punctuation mappings as values.
 
-### Full Custom Configuration
+### Rule Behavior Configuration
+
+The rule includes several built-in behaviors to avoid false positives:
+
+#### Minimum Length Threshold
+By default, the rule skips strings shorter than 10 characters to avoid checking abbreviations and short phrases that aren't grammatical sentences.
+
+```json
+{
+  "rulesets": {
+    "myset": {
+      "resource-sentence-ending": {
+        "minimumLength": 15
+      }
+    }
+  }
+}
+```
+
+#### Automatic Exception Handling
+The rule automatically skips checking strings that:
+- Have no spaces (likely identifiers or single words)
+- Are shorter than the minimum length threshold
+
+#### Exception Lists
+You can specify exact source strings to skip checking for specific locales:
+
+```json
+{
+  "rulesets": {
+    "myset": {
+      "resource-sentence-ending": {
+        "de-DE": {
+          "exceptions": [
+            "See the Dr.",
+            "Visit the Prof.",
+            "Check with Mr."
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### Custom Punctuation Configuration
+
+#### Full Custom Configuration
 
 To completely override all punctuation types for a locale:
 
@@ -80,7 +127,7 @@ To completely override all punctuation types for a locale:
 }
 ```
 
-### Partial Custom Configuration
+#### Partial Custom Configuration
 
 You can override only specific punctuation types. Unspecified types will use the default rules for that language:
 
@@ -108,7 +155,7 @@ In this example, Japanese will use:
 - **Custom**: Question mark (`?`) and exclamation mark (`!`)
 - **Default**: Period (`。`), ellipsis (`…`), and colon (`：`)
 
-### Multiple Locales
+#### Multiple Locales
 
 You can configure different punctuation rules for multiple locales:
 
@@ -139,6 +186,52 @@ You can configure different punctuation rules for multiple locales:
 }
 ```
 
+#### Combined Configuration Example
+
+Here's a comprehensive example showing all configuration options together:
+
+```json
+{
+  "rulesets": {
+    "myset": {
+      "resource-sentence-ending": {
+        "minimumLength": 8,
+        "ja-JP": {
+          "period": "。",
+          "question": "？",
+          "exclamation": "！",
+          "exceptions": [
+            "Loading...",
+            "Please wait..."
+          ]
+        },
+        "de-DE": {
+          "exceptions": [
+            "See the Dr.",
+            "Visit the Prof.",
+            "Check with Mr."
+          ]
+        },
+        "fr-FR": {
+          "ellipsis": "..."
+        }
+      }
+    }
+  },
+  "filetypes": {
+    "mytype": {
+      "ruleset": [ "myset" ]
+    }
+  }
+}
+```
+
+This configuration:
+- Sets minimum length to 8 characters
+- Configures Japanese punctuation and exceptions
+- Adds German exceptions for common abbreviations
+- Overrides French ellipsis behavior
+
 ### Supported Punctuation Types
 
 The following punctuation types can be customized:
@@ -157,6 +250,49 @@ The following punctuation types can be customized:
 - **Language-Based Storage**: Custom configurations are stored by language code (e.g., "ja" for Japanese) and apply to all locales of that language.
 - **Merging**: Custom configurations merge with the default locale-specific rules, so you only need to specify the punctuation types you want to override.
 - **Fallback**: If a punctuation type is not specified in the custom configuration, the rule uses the default punctuation for that language.
+- **Exception Processing**: Exception lists are processed before punctuation checking, so strings in the exception list will never trigger warnings regardless of punctuation mismatches.
+- **Automatic Skipping**: The rule automatically skips strings that are shorter than `minimumLength` or have no spaces (unless they end with sentence-ending punctuation).
+
+## Exception Behaviors
+
+The rule includes several built-in behaviors to avoid false positives on non-sentence content:
+
+### Short Strings
+Strings shorter than the `minimumLength` threshold (default: 10 characters) are automatically skipped:
+
+**Examples of skipped strings:**
+- `"A.M."` (4 characters)
+- `"Tues."` (6 characters)
+- `"Dr."` (3 characters)
+
+**Examples of checked strings:**
+- `"Welcome to our site!"` (21 characters)
+- `"Please see the Doctor."` (18 characters)
+
+### No-Space Strings
+Strings with no spaces are automatically skipped:
+
+**Examples of skipped strings:**
+- `"FONT_NAME_FRONTEND_ADMIN!"` (no spaces, identifier pattern)
+- `"sentence-ending-rule:"` (no spaces, identifier pattern)
+
+**Examples of checked strings:**
+- `"Hi."` (no spaces but ends with period)
+- `"Loading..."` (no spaces but ends with ellipsis)
+
+### Exception Lists
+Strings in locale-specific exception lists are always skipped:
+
+**Example:**
+```json
+{
+  "de-DE": {
+    "exceptions": ["See the Dr.", "Visit the Prof."]
+  }
+}
+```
+
+Even if the target lacks punctuation, these source strings will never trigger warnings.
 
 ## Common Scenarios
 

--- a/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
+++ b/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-/**
+/*
  * ResourceSentenceEnding - Checks that sentence-ending punctuation is appropriate for the target locale
  *
  * This rule checks if the source string ends with certain punctuation marks and ensures
@@ -43,16 +43,21 @@ import Locale from 'ilib-locale';
 import ResourceFixer from '../plugins/resource/ResourceFixer.js';
 import { isSpace } from 'ilib-ctype';
 
-/** @ignore
- * @typedef {import("ilib-tools-common").Resource} Resource */
-/** @ignore
- * @typedef {import("ilib-lint-common").Fix} Fix */
-/** @ignore
- * @typedef {import("../plugins/resource/ResourceFix.js").default} ResourceFix */
-
 /**
- * Default punctuation for each punctuation type
  * @ignore
+ * @typedef {import("ilib-tools-common").Resource} Resource
+ */
+/**
+ * @ignore
+ * @typedef {import("ilib-lint-common").Fix} Fix
+ */
+/**
+ * @ignore
+ * @typedef {import("../plugins/resource/ResourceFix.js").default} ResourceFix
+ */
+
+/*
+ * Default punctuation for each punctuation type
  */
 const defaults = {
     'period': '.',
@@ -62,9 +67,8 @@ const defaults = {
     'colon': ':'
 };
 
-/**
+/*
  * Punctuation map for each language, with default punctuation for each punctuation type
- * @ignore
  */
 const punctuationMap = {
     'ja': { 'period': '。', 'question': '？', 'exclamation': '！', 'ellipsis': '…', 'colon': '：' },
@@ -93,13 +97,15 @@ const punctuationMap = {
  * @property {string} [colon] - Custom colon punctuation for this locale
  * @property {string[]} [exceptions] - Array of source strings to skip checking for this locale.
  *   Useful for handling special cases like abbreviations that should not be checked for sentence-ending punctuation.
-*/
+ */
+
 /**
  * @ignore
  * @typedef {{minimumLength?: number}} ResourceSentenceEndingFixedOptions
  * @property {number} [minimumLength=10] - Minimum length of source string before the rule is applied.
  *   Strings shorter than this length will be skipped (useful for avoiding false positives on abbreviations).
  */
+
 /**
  * @ignore
  * @typedef {ResourceSentenceEndingFixedOptions | Record<string, LocaleOptions>} ResourceSentenceEndingOptions

--- a/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
+++ b/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
@@ -169,7 +169,7 @@ class ResourceSentenceEnding extends ResourceRule {
         this.link = "https://github.com/iLib-js/ilib-lint/blob/main/docs/resource-sentence-ending.md";
 
         // Initialize minimum length configuration
-        this.minimumLength = options?.minimumLength ?? 10;
+        this.minimumLength = Math.max(0, options?.minimumLength ?? 10);
 
         // Initialize custom punctuation mappings from configuration
         this.customPunctuationMap = {};
@@ -840,7 +840,12 @@ class ResourceSentenceEnding extends ResourceRule {
 
         // Exception 2: Check if source has no spaces AND doesn't end with sentence-ending punctuation (not a sentence)
         if (!source.includes(' ')) {
-            return undefined;
+            const trimmed = source.trim();
+            const lastChar = trimmed.charAt(trimmed.length - 1);
+            const sentenceEndingChars = ['.', '?', '!', '。', '？', '！', '…', ':'];
+            if (!sentenceEndingChars.includes(lastChar)) {
+                return undefined; // Not a sentence
+            }
         }
 
         // Exception 3: Check if source is in exception list

--- a/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
+++ b/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
@@ -85,24 +85,24 @@ const punctuationMap = {
 
 /**
  * @ignore
- * @typedef {{period: string, question: string, exclamation: string, ellipsis: string, colon: string, exceptions?: string[]}} LocaleOptions
- * @property {string} period - Custom period punctuation for this locale
- * @property {string} question - Custom question mark punctuation for this locale
- * @property {string} exclamation - Custom exclamation mark punctuation for this locale
- * @property {string} ellipsis - Custom ellipsis punctuation for this locale
- * @property {string} colon - Custom colon punctuation for this locale
+ * @typedef {{period?: string, question?: string, exclamation?: string, ellipsis?: string, colon?: string, exceptions?: string[]}} LocaleOptions
+ * @property {string} [period] - Custom period punctuation for this locale
+ * @property {string} [question] - Custom question mark punctuation for this locale
+ * @property {string} [exclamation] - Custom exclamation mark punctuation for this locale
+ * @property {string} [ellipsis] - Custom ellipsis punctuation for this locale
+ * @property {string} [colon] - Custom colon punctuation for this locale
  * @property {string[]} [exceptions] - Array of source strings to skip checking for this locale.
  *   Useful for handling special cases like abbreviations that should not be checked for sentence-ending punctuation.
 */
 /**
  * @ignore
- * @typedef {{minimumLength: number}} ResourceSentenceEndingFixedOptions
+ * @typedef {{minimumLength?: number}} ResourceSentenceEndingFixedOptions
  * @property {number} [minimumLength=10] - Minimum length of source string before the rule is applied.
  *   Strings shorter than this length will be skipped (useful for avoiding false positives on abbreviations).
  */
 /**
  * @ignore
- * @typedef {ResourceSentenceEndingFixedOptions & Record<string, LocaleOptions>} ResourceSentenceEndingOptions
+ * @typedef {ResourceSentenceEndingFixedOptions | Record<string, LocaleOptions>} ResourceSentenceEndingOptions
  */
 
 /**

--- a/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
+++ b/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
@@ -23,6 +23,12 @@
  * This rule checks if the source string ends with certain punctuation marks and ensures
  * the target uses the locale-appropriate equivalent.
  *
+ * Features:
+ * - Configurable minimum length threshold to skip short strings (abbreviations)
+ * - Automatic skipping of strings with no spaces (non-sentences)
+ * - Custom punctuation mappings per locale
+ * - Exception lists to skip specific source strings
+ *
  * Examples:
  * - English period (.) should become Japanese maru (。) in Japanese
  * - English question mark (?) should become Japanese question mark (？) in Japanese
@@ -34,15 +40,19 @@
 import { Result } from 'ilib-lint-common';
 import ResourceRule from './ResourceRule.js';
 import Locale from 'ilib-locale';
-import LocaleInfo from 'ilib-localeinfo';
 import ResourceFixer from '../plugins/resource/ResourceFixer.js';
-import { isPunct, isSpace } from 'ilib-ctype';
-
-/** @ignore @typedef {import("ilib-tools-common").Resource} Resource */
-/** @ignore @typedef {import("ilib-lint-common").Fix} Fix */
+import { isSpace } from 'ilib-ctype';
 
 /** @ignore
+ * @typedef {import("ilib-tools-common").Resource} Resource */
+/** @ignore
+ * @typedef {import("ilib-lint-common").Fix} Fix */
+/** @ignore
+ * @typedef {import("../plugins/resource/ResourceFix.js").default} ResourceFix */
+
+/**
  * Default punctuation for each punctuation type
+ * @ignore
  */
 const defaults = {
     'period': '.',
@@ -52,8 +62,9 @@ const defaults = {
     'colon': ':'
 };
 
-/** @ignore
+/**
  * Punctuation map for each language, with default punctuation for each punctuation type
+ * @ignore
  */
 const punctuationMap = {
     'ja': { 'period': '。', 'question': '？', 'exclamation': '！', 'ellipsis': '…', 'colon': '：' },
@@ -73,40 +84,129 @@ const punctuationMap = {
 };
 
 /**
+ * @ignore
+ * @typedef {{period: string, question: string, exclamation: string, ellipsis: string, colon: string, exceptions?: string[]}} LocaleOptions
+ * @property {string} period - Custom period punctuation for this locale
+ * @property {string} question - Custom question mark punctuation for this locale
+ * @property {string} exclamation - Custom exclamation mark punctuation for this locale
+ * @property {string} ellipsis - Custom ellipsis punctuation for this locale
+ * @property {string} colon - Custom colon punctuation for this locale
+ * @property {string[]} [exceptions] - Array of source strings to skip checking for this locale.
+ *   Useful for handling special cases like abbreviations that should not be checked for sentence-ending punctuation.
+*/
+/**
+ * @ignore
+ * @typedef {{minimumLength: number}} ResourceSentenceEndingFixedOptions
+ * @property {number} [minimumLength=10] - Minimum length of source string before the rule is applied.
+ *   Strings shorter than this length will be skipped (useful for avoiding false positives on abbreviations).
+ */
+/**
+ * @ignore
+ * @typedef {ResourceSentenceEndingFixedOptions & Record<string, LocaleOptions>} ResourceSentenceEndingOptions
+ */
+
+/**
  * @class ResourceSentenceEnding
  * @extends ResourceRule
  */
 class ResourceSentenceEnding extends ResourceRule {
-    constructor(options) {
+    /**
+     * Constructs a new ResourceSentenceEnding rule instance.
+     *
+     * @param {ResourceSentenceEndingOptions} [options] - Configuration options for the rule
+     *
+     * @example
+     * // Basic usage with default settings
+     * const rule = new ResourceSentenceEnding();
+     *
+     * @example
+     * // Custom minimum length
+     * const rule = new ResourceSentenceEnding({
+     *   minimumLength: 15
+     * });
+     *
+     * @example
+     * // Custom punctuation mappings for Japanese
+     * const rule = new ResourceSentenceEnding({
+     *   'ja-JP': {
+     *     period: '。',
+     *     question: '？',
+     *     exclamation: '！',
+     *     ellipsis: '…',
+     *     colon: '：'
+     *   }
+     * });
+     *
+     * @example
+     * // Exception list for German
+     * const rule = new ResourceSentenceEnding({
+     *   'de-DE': {
+     *     exceptions: [
+     *       'See the Dr.',
+     *       'Visit the Prof.',
+     *       'Check with Mr.'
+     *     ]
+     *   }
+     * });
+     *
+     * @example
+     * // Combined configuration
+     * const rule = new ResourceSentenceEnding({
+     *   minimumLength: 8,
+     *   'ja-JP': {
+     *     period: '。',
+     *     exceptions: ['Loading...', 'Please wait...']
+     *   },
+     *   'de-DE': {
+     *     exceptions: ['See the Dr.', 'Visit the Prof.']
+     *   }
+     * });
+     */
+    constructor(options = {}) {
         super(options);
         this.name = "resource-sentence-ending";
         this.description = "Checks that sentence-ending punctuation is appropriate for the locale of the target string and matches the punctuation in the source string";
         this.link = "https://github.com/iLib-js/ilib-lint/blob/main/docs/resource-sentence-ending.md";
 
+        // Initialize minimum length configuration
+        this.minimumLength = options?.minimumLength ?? 10;
+
         // Initialize custom punctuation mappings from configuration
         this.customPunctuationMap = {};
-        if (options && typeof options === 'object' && !Array.isArray(options)) {
-                    // options is an object with locale codes as keys and punctuation mappings as values
-        // Merge the default punctuation with the custom punctuation so that the custom
-        // punctuation overrides the default and we don't have to specify all punctuation types.
-        // Custom maps are stored by language, not locale, so that they apply to all locales of
-        // that language.
-        for (const locale in options) {
-            const localeObj = new Locale(locale);
+        // Initialize exception lists from configuration
+        this.exceptionsMap = {};
 
-            // only process config for valid locales
-            if (localeObj.isValid()) {
-                const language = localeObj.getLanguage();
-                // locale must have a language code
-                if (!language) continue;
-                // Apply locale-specific defaults for any locale that usesthis language
-                const localeDefaults = this.getLocaleDefaults(language);
-                this.customPunctuationMap[language] = {
-                    ...localeDefaults,
-                    ...options[locale]
-                };
+        if (options && typeof options === 'object' && !Array.isArray(options)) {
+            // options is an object with locale codes as keys and punctuation mappings as values
+            // Merge the default punctuation with the custom punctuation so that the custom
+            // punctuation overrides the default and we don't have to specify all punctuation types.
+            // Custom maps are stored by language, not locale, so that they apply to all locales of
+            // that language.
+            for (const locale in options) {
+                const localeObj = new Locale(locale);
+
+                // only process config for valid locales
+                if (localeObj.isValid()) {
+                    const language = localeObj.getLanguage();
+                    // locale must have a language code
+                    if (!language) continue;
+
+                    // Separate punctuation mappings from exceptions
+                    const { exceptions, ...punctuationMappings } = options[locale];
+
+                    // Apply locale-specific defaults for any locale that usesthis language
+                    const localeDefaults = this.getLocaleDefaults(language);
+                    this.customPunctuationMap[language] = {
+                        ...localeDefaults,
+                        ...punctuationMappings
+                    };
+
+                    // Store exceptions separately
+                    if (exceptions && Array.isArray(exceptions)) {
+                        this.exceptionsMap[language] = exceptions;
+                    }
+                }
             }
-        }
         }
 
         // Build the set of sentence-ending punctuation characters dynamically
@@ -490,7 +590,7 @@ class ResourceSentenceEnding extends ResourceRule {
      * @param {string} target - The target string
      * @param {string} incorrectPunctuation - The incorrect punctuation
      * @param {string} correctPunctuation - The correct punctuation
-     * @returns {Fix|undefined} - The fix object or undefined if no fix can be created
+     * @returns {ResourceFix|undefined} - The fix object or undefined if no fix can be created
      */
     createPunctuationFix(resource, target, incorrectPunctuation, correctPunctuation, index, category, targetLocaleObj) {
         // Get the last sentence to find the position
@@ -547,7 +647,7 @@ class ResourceSentenceEnding extends ResourceRule {
      * @param {string} character - The character to insert
      * @param {number} [index] - Index for array/plural resources
      * @param {string} [category] - Category for plural resources
-     * @returns {Fix|undefined} - The fix object or undefined if no fix can be created
+     * @returns {ResourceFix|undefined} - The fix object or undefined if no fix can be created
      */
     createInsertCharacterFix(resource, target, position, character, index, category) {
         return ResourceFixer.createFix({
@@ -576,7 +676,7 @@ class ResourceSentenceEnding extends ResourceRule {
      * @param {number} [index] - Index for array/plural resources
      * @param {string} [category] - Category for plural resources
      * @param {Locale} [targetLocaleObj] - The target locale object (unused, kept for compatibility)
-     * @returns {Fix|undefined} - The fix object or undefined if no fix can be created
+     * @returns {ResourceFix|undefined} - The fix object or undefined if no fix can be created
      */
     createFixForSpanishInvertedPunctuation(resource, target, lastSentence, correctPunctuation, index, category, targetLocaleObj) {
         const lastSentenceStart = target.lastIndexOf(lastSentence);
@@ -592,7 +692,7 @@ class ResourceSentenceEnding extends ResourceRule {
      * @param {string} nonBreakingSpace - The non-breaking space character to insert
      * @param {number} [index] - Index for array/plural resources
      * @param {string} [category] - Category for plural resources
-     * @returns {Fix|undefined} - The fix object or undefined if no fix can be created
+     * @returns {ResourceFix|undefined} - The fix object or undefined if no fix can be created
      */
     createFixForFrenchNonBreakingSpace(resource, target, position, nonBreakingSpace, index, category) {
         return ResourceFixer.createFix({
@@ -618,7 +718,7 @@ class ResourceSentenceEnding extends ResourceRule {
      * @param {string} currentSpace - The current space character (or empty string if none)
      * @param {number} [index] - Index for array/plural resources
      * @param {string} [category] - Category for plural resources
-     * @returns {Fix|undefined} - The fix object or undefined if no fix is needed
+     * @returns {ResourceFix|undefined} - The fix object or undefined if no fix is needed
      */
     createFrenchSpacingFix(resource, target, spacePosition, needsNonBreakingSpace, currentSpace, index, category) {
         const regularSpace = ' ';
@@ -732,6 +832,24 @@ class ResourceSentenceEnding extends ResourceRule {
         const sourceLocaleObj = new Locale(sourceLocale);
         const sourceLanguage = sourceLocaleObj.getLanguage();
         if (!sourceLanguage) return undefined;
+
+        // Exception 1: Check minimum length
+        if (source.length < this.minimumLength) {
+            return undefined;
+        }
+
+        // Exception 2: Check if source has no spaces AND doesn't end with sentence-ending punctuation (not a sentence)
+        if (!source.includes(' ')) {
+            return undefined;
+        }
+
+        // Exception 3: Check if source is in exception list
+        const exceptions = this.exceptionsMap[targetLanguage];
+        if (exceptions) {
+            if (exceptions.some(exception => exception.toLowerCase().trim() === source.toLowerCase().trim())) {
+                return undefined;
+            }
+        }
 
         const optionalPunctuationLanguages = ['th', 'lo', 'my', 'km', 'vi', 'id', 'ms', 'tl', 'jv', 'su'];
         const isOptionalPunctuationLanguage = optionalPunctuationLanguages.includes(targetLanguage);

--- a/packages/ilib-lint/test/rules/ResourceSentenceEnding.test.js
+++ b/packages/ilib-lint/test/rules/ResourceSentenceEnding.test.js
@@ -3523,6 +3523,110 @@ describe("ResourceSentenceEnding rule", function() {
                 // This should not trigger because string is longer than the long minimumLength
                 expect(actual).toBeTruthy();
             });
+
+            test("should handle negative minimumLength (treat as 0) - short string with spaces", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    minimumLength: -5
+                });
+
+                const resource = new ResourceString({
+                    key: "test.negative1",
+                    source: "a b.",
+                    target: "a b",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // Should trigger because negative minimumLength is treated as 0
+                expect(actual).toBeTruthy();
+            });
+
+            test("should handle negative minimumLength (treat as 0) - longer string with spaces", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    minimumLength: -5
+                });
+
+                const resource = new ResourceString({
+                    key: "test.negative2",
+                    source: "Hello world.",
+                    target: "Hallo Welt",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // Should trigger because negative minimumLength is treated as 0
+                expect(actual).toBeTruthy();
+            });
+
+            test("should handle floating point minimumLength - short string with spaces", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    minimumLength: 5.2
+                });
+
+                const resource = new ResourceString({
+                    key: "test.float1",
+                    source: "a b.",
+                    target: "a b",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // Should not trigger because "a b." (4 chars) < 5.2
+                expect(actual).toBeUndefined();
+            });
+
+            test("should handle floating point minimumLength - longer string with spaces", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    minimumLength: 5.2
+                });
+
+                const resource = new ResourceString({
+                    key: "test.float2",
+                    source: "Hello world.",
+                    target: "Hallo Welt",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // Should trigger because "Hello world." (12 chars) >= 5.2
+                expect(actual).toBeTruthy();
+            });
         });
 
         describe("No space exception", () => {
@@ -3924,7 +4028,7 @@ describe("ResourceSentenceEnding rule", function() {
                     key: "test.key",
                     sourceLocale: "en-US",
                     targetLocale: "ja-JP",
-                    source: "Amazing!",
+                    source: "That's amazing!",
                     target: "すごい!   " // spaces after English exclamation mark instead of Japanese
                 });
 

--- a/packages/ilib-lint/test/rules/ResourceSentenceEnding.test.js
+++ b/packages/ilib-lint/test/rules/ResourceSentenceEnding.test.js
@@ -1691,9 +1691,9 @@ describe("ResourceSentenceEnding rule", function() {
         const resource = new ResourceString({
             key: "french.missing.nbsp.exclamation",
             sourceLocale: "en-US",
-            source: "Welcome!",
+            source: "Welcome to our site!",
             targetLocale: "fr-FR",
-            target: "Bienvenue!",
+            target: "Bienvenue sur notre site!",
             pathName: "a/b/c.xliff"
         });
 
@@ -1707,13 +1707,13 @@ describe("ResourceSentenceEnding rule", function() {
         expect(actual).toBeTruthy();
         expect(actual?.description).toContain('Sentence ending should be "\u202F!" (U+202F U+0021) for fr-FR locale instead of "!" (U+0021)');
         expect(actual?.id).toBe(resource.getKey());
-        expect(actual?.highlight).toBe("Bienvenue<e0/>!");
+        expect(actual?.highlight).toBe("Bienvenue sur notre site<e0/>!");
         expect(actual?.fix).toBeTruthy();
 
         // Check that the fix replaces the regular space with a non-breaking space
         const fix = actual?.fix;
         expect(fix?.commands).toHaveLength(1);
-        expect(fix?.commands[0].stringFix.position).toBe(9); // position of the space
+        expect(fix?.commands[0].stringFix.position).toBe(24); // position of the space
         expect(fix?.commands[0].stringFix.deleteCount).toBe(1); // delete 1 character (the regular space)
         expect(fix?.commands[0].stringFix.insertContent).toBe("\u202F"); // insert thin no-break space
     });
@@ -1727,9 +1727,9 @@ describe("ResourceSentenceEnding rule", function() {
         const resource = new ResourceString({
             key: "french.wrong.space.exclamation",
             sourceLocale: "en-US",
-            source: "Welcome!",
+            source: "Welcome to our site!",
             targetLocale: "fr-FR",
-            target: "Bienvenue !",
+            target: "Bienvenue sur notre site !",
             pathName: "a/b/c.xliff"
         });
 
@@ -1743,7 +1743,7 @@ describe("ResourceSentenceEnding rule", function() {
         expect(actual).toBeTruthy();
         expect(actual?.description).toContain('Sentence ending should be "\u202F!" (U+202F U+0021) for fr-FR locale instead of " !" (U+0020 U+0021)');
         expect(actual?.id).toBe(resource.getKey());
-        expect(actual?.highlight).toBe("Bienvenue<e0> (U+0020)</e0>!");
+        expect(actual?.highlight).toBe("Bienvenue sur notre site<e0> (U+0020)</e0>!");
         expect(actual?.fix).toBeTruthy();
     });
 
@@ -1842,9 +1842,9 @@ describe("ResourceSentenceEnding rule", function() {
         const resource = new ResourceString({
             key: "french.missing.nbsp.ellipsis",
             sourceLocale: "en-US",
-            source: "Loading...",
+            source: "Loading the file...",
             targetLocale: "fr-FR",
-            target: "Chargement...",
+            target: "Chargement du fichier...",
             pathName: "a/b/c.xliff"
         });
 
@@ -1856,12 +1856,12 @@ describe("ResourceSentenceEnding rule", function() {
         });
 
         expect(actual).toBeTruthy();
-        expect(actual?.highlight).toBe("Chargement<e0>... (U+002E U+002E U+002E)</e0>");
+        expect(actual?.highlight).toBe("Chargement du fichier<e0>... (U+002E U+002E U+002E)</e0>");
         expect(actual?.fix).toBeTruthy();
 
         const fix = actual?.fix;
         expect(fix?.commands).toHaveLength(1);
-        expect(fix?.commands[0].stringFix.position).toBe(10);
+        expect(fix?.commands[0].stringFix.position).toBe(21);
         expect(fix?.commands[0].stringFix.deleteCount).toBe(3);
         expect(fix?.commands[0].stringFix.insertContent).toBe("…");
     });
@@ -2031,9 +2031,9 @@ describe("ResourceSentenceEnding rule", function() {
         const resource = new ResourceString({
             key: "french.wrong.nbsp.type.exclamation",
             sourceLocale: "en-US",
-            source: "Welcome!",
+            source: "Welcome to our site!",
             targetLocale: "fr-FR",
-            target: "Bienvenue\u00A0!",
+            target: "Bienvenue sur notre site\u00A0!",
             pathName: "a/b/c.xliff"
         });
 
@@ -2048,13 +2048,13 @@ describe("ResourceSentenceEnding rule", function() {
         expect(actual).toBeTruthy();
         expect(actual?.description).toContain('Sentence ending should be "\u202F!" (U+202F U+0021) for fr-FR locale instead of " !" (U+00A0 U+0021)');
         expect(actual?.id).toBe(resource.getKey());
-        expect(actual?.highlight).toBe("Bienvenue<e0> (U+00A0)</e0>!");
+        expect(actual?.highlight).toBe("Bienvenue sur notre site<e0> (U+00A0)</e0>!");
         expect(actual?.fix).toBeTruthy();
 
         // Check that the fix replaces the wrong no-break space with the correct one
         const fix = actual?.fix;
         expect(fix?.commands).toHaveLength(1);
-        expect(fix?.commands[0].stringFix.position).toBe(9); // position of the wrong no-break space
+        expect(fix?.commands[0].stringFix.position).toBe(24); // position of the wrong no-break space
         expect(fix?.commands[0].stringFix.deleteCount).toBe(1); // delete 1 character (wrong no-break space)
         expect(fix?.commands[0].stringFix.insertContent).toBe("\u202F"); // insert thin no-break space
     });
@@ -3150,12 +3150,10 @@ describe("ResourceSentenceEnding rule", function() {
                 expect.assertions(3);
 
                 const rule = new ResourceSentenceEnding({
-                    punctuation: {
-                        "en-US": {
-                            period: ".",
-                            question: "?",
-                            exclamation: "!"
-                        }
+                    "en-US": {
+                        period: ".",
+                        question: "?",
+                        exclamation: "!"
                     }
                 });
                 const localeObj = new Locale("en-US");
@@ -3242,6 +3240,563 @@ describe("ResourceSentenceEnding rule", function() {
 
                 const result2 = rule.findIncorrectPunctuationPosition("Hello world…", "Hello world…", "…");
                 expect(result2).toEqual({ position: 11, length: 1 });
+            });
+        });
+    });
+
+    describe("Exception behaviors", () => {
+        describe("Short string exception", () => {
+            test("should not check sentence-ending punctuation for short string 'A.M.'", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding();
+                const resource = new ResourceString({
+                    key: "test.short1",
+                    source: "A.M.",
+                    target: "am",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeUndefined();
+            });
+
+            test("should not check sentence-ending punctuation for short string 'Tues.'", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding();
+                const resource = new ResourceString({
+                    key: "test.short2",
+                    source: "Tues.",
+                    target: "Dins",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeUndefined();
+            });
+
+            test("should not check sentence-ending punctuation for short string 'Dr.'", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding();
+                const resource = new ResourceString({
+                    key: "test.short3",
+                    source: "Dr.",
+                    target: "Herr Dr.",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeUndefined();
+            });
+
+            test("should still check sentence-ending punctuation for longer strings", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding();
+                const resource = new ResourceString({
+                    key: "test.long",
+                    source: "This is a sentence.",
+                    target: "Das ist ein Satz",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // This should trigger a warning because target is missing punctuation
+                expect(actual).toBeTruthy();
+            });
+        });
+
+        describe("Minimum length configuration", () => {
+            test("should not check strings shorter than configured minimumLength", () => {
+                expect.assertions(2);
+
+                const rule = new ResourceSentenceEnding({
+                    minimumLength: 15
+                });
+
+                const resource1 = new ResourceString({
+                    key: "test.short1",
+                    source: "Hello world.",
+                    target: "Hallo Welt",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual1 = rule.matchString({
+                    source: resource1.getSource(),
+                    target: resource1.getTarget(),
+                    resource: resource1,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual1).toBeUndefined();
+
+                const resource2 = new ResourceString({
+                    key: "test.short2",
+                    source: "Good morning.",
+                    target: "Guten Morgen",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual2 = rule.matchString({
+                    source: resource2.getSource(),
+                    target: resource2.getTarget(),
+                    resource: resource2,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual2).toBeUndefined();
+            });
+
+            test("should check strings longer than configured minimumLength", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    minimumLength: 15
+                });
+
+                const resource = new ResourceString({
+                    key: "test.long",
+                    source: "This is a longer sentence.",
+                    target: "Das ist ein längerer Satz",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // This should trigger a warning because target is missing punctuation
+                expect(actual).toBeTruthy();
+            });
+
+            test("should use default minimumLength when not configured", () => {
+                expect.assertions(2);
+
+                const rule = new ResourceSentenceEnding();
+
+                const resource1 = new ResourceString({
+                    key: "test.short",
+                    source: "Hi.",
+                    target: "Hallo",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual1 = rule.matchString({
+                    source: resource1.getSource(),
+                    target: resource1.getTarget(),
+                    resource: resource1,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual1).toBeUndefined();
+
+                const resource2 = new ResourceString({
+                    key: "test.long",
+                    source: "This is a sentence.",
+                    target: "Das ist ein Satz",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual2 = rule.matchString({
+                    source: resource2.getSource(),
+                    target: resource2.getTarget(),
+                    resource: resource2,
+                    file: "a/b/c.xliff"
+                });
+
+                // This should trigger a warning because target is missing punctuation
+                expect(actual2).toBeTruthy();
+            });
+
+            test("should handle minimumLength of 0 (check all strings)", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    minimumLength: 0
+                });
+
+                const resource = new ResourceString({
+                    key: "test.short",
+                    source: "Hey you.",
+                    target: "Hallo, du!",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // This should trigger a warning because target is missing punctuation and the minimum length is 0
+                expect(actual).toBeTruthy();
+            });
+
+            test("should handle very high minimumLength (check almost no strings)", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    minimumLength: 100
+                });
+
+                const resource = new ResourceString({
+                    key: "test.long",
+                    source: "This is a sentence.",
+                    target: "Das ist ein Satz",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // This should not trigger because string is shorter than minimumLength
+                expect(actual).toBeUndefined();
+            });
+
+            test("should handle very high minimumLength (check almost no strings) with a long string", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    minimumLength: 100
+                });
+
+                const resource = new ResourceString({
+                    key: "test.long",
+                    source: "This is a sentence. This is another sentence. This is a third sentence. This is a fourth sentence. This is a fifth sentence.",
+                    target: "Das ist ein Satz. Das ist ein anderer Satz. Das ist ein dritter Satz. Das ist ein vierter Satz. Das ist ein fünfter Satz",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // This should not trigger because string is longer than the long minimumLength
+                expect(actual).toBeTruthy();
+            });
+        });
+
+        describe("No space exception", () => {
+            test("should not check sentence-ending punctuation for string with no spaces in snake case", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding();
+                const resource = new ResourceString({
+                    key: "test.nospace1",
+                    source: "FONT_NAME_FRONTEND_ADMIN!",
+                    target: "FONT_NAME_FRONTEND_ADMIN!",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeUndefined();
+            });
+
+            test("should not check sentence-ending punctuation for string with no spaces in kebab case", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding();
+                const resource = new ResourceString({
+                    key: "test.nospace2",
+                    source: "sentence-ending-rule:",
+                    target: "sentence-ending-rule:",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeUndefined();
+            });
+
+            test("should still check sentence-ending punctuation for strings with spaces", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding();
+                const resource = new ResourceString({
+                    key: "test.withspace",
+                    source: "This is a sentence.",
+                    target: "Das ist ein Satz",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // This should trigger a warning because target is missing punctuation
+                expect(actual).toBeTruthy();
+            });
+
+            test("should check sentence-ending punctuation for string with spaces and has dashes or underscores", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding();
+                const resource = new ResourceString({
+                    key: "test.spaces.dashes",
+                    source: "The variable-value is font_name_frontend_admin",
+                    target: "Die Variable-Wert heißt font_name_frontend_admin.",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeTruthy();
+            });
+
+            test("should check sentence-ending punctuation for string with all caps", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding();
+                const resource = new ResourceString({
+                    key: "test.allcaps",
+                    source: "THIS IS A SENTENCE.",
+                    target: "DAS IST EIN SATZ",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // This should trigger a warning because target is missing punctuation
+                expect(actual).toBeTruthy();
+            });
+
+            test("should check sentence-ending punctuation for string with no spaces, caps, dashes, or underscores", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding();
+                const resource = new ResourceString({
+                    key: "test.nocaps",
+                    source: "supercalifragilisticexpialidocious",
+                    target: "Das ist ein verückter Wort! Wer hat es erfunden?",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // source is not a sentence because it has no spaces, so no warning should be generated
+                expect(actual).toBeUndefined();
+            });
+        });
+
+        describe("Explicit exception list", () => {
+            test("should not check sentence-ending punctuation for string in exception list even when target lacks punctuation", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    "de-DE": {
+                        exceptions: ["For your appointment, please see the Dr."]
+                    }
+                });
+
+                const resource = new ResourceString({
+                    key: "test.exception",
+                    source: "For your appointment, please see the Dr.",
+                    target: "für Ihren Termin, bitte sehen Sie den Herr Dr",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeUndefined();
+            });
+
+            test("should still check sentence-ending punctuation for strings not in exception list", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    "de-DE": {
+                        exceptions: ["Please see the Dr. for your appointment."]
+                    }
+                });
+
+                const resource = new ResourceString({
+                    key: "test.noexception",
+                    source: "This is a sentence.",
+                    target: "Das ist ein Satz",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                // This should trigger a warning because target is missing punctuation
+                expect(actual).toBeTruthy();
+            });
+
+            test("should handle multiple exceptions with missing target punctuation", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    "de-DE": {
+                        exceptions: ["Please see the Dr. for your appointment.", "Visit today with the Prof.", "Call the Rev. tomorrow."]
+                    }
+                });
+
+                const resource = new ResourceString({
+                    key: "test.exception1",
+                    source: "Visit today with the Prof.",
+                    target: "Besuchen Sie heute mit den Prof",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeUndefined();
+            });
+
+            test("should handle multiple exceptions with missing target punctuation", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    "de-DE": {
+                        exceptions: ["Please see the Dr. for your appointment.", "Visit the Prof. today.", "Tomorrow, call the Rev."]
+                    }
+                });
+
+                const resource = new ResourceString({
+                    key: "test.exception2",
+                    source: "Tomorrow, call the Rev.",
+                    target: "Rufen Sie den Rev morgen an",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeUndefined();
+            });
+
+            test("should handle multiple exceptions with missing target punctuation and case insensitivity", () => {
+                expect.assertions(1);
+
+                const rule = new ResourceSentenceEnding({
+                    "de-DE": {
+                        exceptions: ["Please see the Dr. for your appointment.", "Visit the Prof. today.", "Tomorrow, call the Rev.", "please see the doctor for your appointment."]
+                    }
+                });
+
+                const resource = new ResourceString({
+                    key: "test.exception2",
+                    source: "Please see the Doctor for your Appointment.",
+                    target: "Rufen Sie den Herr Dr morgen an",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeUndefined();
             });
         });
     });


### PR DESCRIPTION
- ResourceSentenceEnding rule enhancements to support various exception
  - Added minimumLength configuration option (default: 10) to skip checking short strings/abbreviations
  - Added automatic skipping of strings with no spaces
  - Added exceptions array per locale to skip specific source strings from checking
  - Enhanced punctuation detection for quoted content to handle punctuation after closing quotes
  - Updated rule documentation with new configuration options and examples