### PR TITLE
Remove unused locales from FileType

### DIFF
--- a/packages/ilib-lint/src/FileType.js
+++ b/packages/ilib-lint/src/FileType.js
@@ -52,13 +52,6 @@ class FileType {
     name;
 
     /**
-     * The list of locales to use with this file type
-     * @type {Array.<String>|undefined}
-     * @readonly
-     */
-    locales;
-
-    /**
      * The intermediate representation type of this file type.
      * @type {String}
      * @readonly
@@ -114,7 +107,6 @@ class FileType {
      * of this file type as documented above
      * @param {String} options.name the name or glob spec for this file type
      * @param {Project} options.project the Project that this file type is a part of
-     * @param {Array.<String>} [options.locales] list of locales to use with this file type
      * @param {String} [options.template] the path name template for this file type
      * which shows how to extract the locale from the path
      * name if the path includes it. Many file types
@@ -152,7 +144,6 @@ class FileType {
 
         this.name = options.name;
         this.project = options.project;
-        this.locales = options.locales;
         this.template = options.template;
 
         const parserNames = options.parsers;
@@ -241,10 +232,6 @@ class FileType {
 
     getProject() {
         return this.project;
-    }
-
-    getLocales() {
-        return this.locales || this.project.getLocales();
     }
 
     getTemplate() {

--- a/packages/ilib-lint/test/FileType.test.js
+++ b/packages/ilib-lint/test/FileType.test.js
@@ -340,20 +340,6 @@ describe("testFileType", () => {
         expect(ft.getProject()).toBe(project);
     });
 
-    test("FileTypeGetLocales", () => {
-        expect.assertions(2);
-
-        const locales = ["en-US", "de-DE"];
-        const ft = new FileType({
-            name: "test",
-            locales,
-            project,
-        });
-        expect(ft).toBeTruthy();
-
-        expect(ft.getLocales()).toBe(locales);
-    });
-
     test("FileType get the intermediate representation type", () => {
         expect.assertions(2);
         const ft = new FileType({
@@ -415,18 +401,6 @@ describe("testFileType", () => {
         const serializer = ft.getSerializer();
         expect(serializer).toBeTruthy();
         expect(serializer?.getName()).toBe("serializer-xyz");
-    });
-
-    test("FileTypeGetLocalesFromProject", () => {
-        expect.assertions(2);
-
-        const ft = new FileType({
-            name: "test",
-            project,
-        });
-        expect(ft).toBeTruthy();
-
-        expect(ft.getLocales()).toEqual(["fr-FR", "nl-NL"]);
     });
 
     test("FileTypeGetTemplate", () => {


### PR DESCRIPTION
Test PR to run CI to validate that locales property of the FileType class is not used anywhere except for tests