### PR TITLE
loctool: Normalize and deduplicate translationsDir paths

### DIFF
--- a/.changeset/thick-kings-impress.md
+++ b/.changeset/thick-kings-impress.md
@@ -1,0 +1,5 @@
+---
+"loctool": patch
+---
+
+Normalize and deduplicate translationsDir paths

--- a/packages/loctool/lib/LocalRepository.js
+++ b/packages/loctool/lib/LocalRepository.js
@@ -134,6 +134,17 @@ LocalRepository.prototype.init = function(cb) {
         var miniMatchExpressions = getIntermediateFileExtensions().map(function(ext) {
             return "**/*." + ext;
         });
+
+        // Normalize and deduplicate translationsDir
+        var normalizedPaths = [];
+        for (var i = 0; i < this.translationsDir.length; i++) {
+            var resolvedPath = path.resolve(this.translationsDir[i]);
+            if (normalizedPaths.indexOf(resolvedPath) === -1) {
+                normalizedPaths.push(resolvedPath);
+            }
+        }
+        this.translationsDir = normalizedPaths;
+
         this.translationsDir.forEach(function(dir) {
             if (!fs.existsSync(dir)) {
                logger.warn("Translation dir " + dir + " does not exist.");

--- a/packages/loctool/test/LocalRepository.test.js
+++ b/packages/loctool/test/LocalRepository.test.js
@@ -1152,6 +1152,53 @@ describe("localrepository", function() {
         });
     });
 
+    test("LocalRepositoryConstructorWithTranslationsDirArrayWithDuplicateElements", function() {
+        expect.assertions(17);
+
+        // should read all xliffs from both directories
+        var repo = new LocalRepository({
+            sourceLocale: "en-US",
+            translationsDir: ["./test/testfiles/xliff20/app3",
+                              "./test/testfiles/xliff20/app3",
+                              "./test/testfiles/../testfiles/xliff20/app3/"],
+        });
+
+        expect(repo).toBeTruthy();
+        expect(repo.translationsDir.length).toBe(3);
+
+        repo.init(function(){
+            repo.getBy({
+                reskey: "String 1a"
+            }, function(err, resources) {
+                expect(resources).toBeTruthy();
+                expect(resources.length).toBe(2);
+
+                resources.sort(function(left, right) {
+                    var leftLocale = left.getTargetLocale();
+                    var rightLocale = right.getTargetLocale();
+                    return leftLocale < rightLocale ? -1 : (leftLocale > rightLocale ? 1 : 0);
+                });
+
+                expect(resources[0].getKey()).toBe("String 1a");
+                expect(resources[0].getProject()).toBe("app3");
+                expect(resources[0].getSourceLocale()).toBe("en-KR");
+                expect(resources[0].getSource()).toBe("app3:String 1a");
+                expect(resources[0].getTargetLocale()).toBe("de-DE");
+                expect(resources[0].getTarget()).toBe("Das app3:String 1a");
+
+                expect(resources[1].getKey()).toBe("String 1a");
+                expect(resources[1].getProject()).toBe("app3");
+                expect(resources[1].getSourceLocale()).toBe("en-KR");
+                expect(resources[1].getSource()).toBe("app3:String 1a");
+                expect(resources[1].getTargetLocale()).toBe("en-US");
+                expect(resources[1].getTarget()).toBe("app3:String 1a");
+
+                repo.close(function() {
+                });
+            });
+        })
+        expect(repo.translationsDir.length).toBe(1);
+    });
     /*
         test("LocalRepositoryGetResource", function() {
         expect.assertions(9);


### PR DESCRIPTION
Changes
* Duplicate paths are removed to avoid redundant file system operations before reading translation files.
* This change ensures `translationsDir` contains only unique, absolute paths.

Cause
* The settings values for `loctool` can be provided either as arguments or defined in `project.json`.  
When passed as arguments, these `settings` are merged into `options.settings` by [ProjectFactory](https://github.com/iLib-js/ilib-mono/blob/main/packages/loctool/lib/ProjectFactory.js#L62).
Later, both `settings` and `options.settings` are merged again within the [Project](https://github.com/iLib-js/ilib-mono/blob/main/packages/loctool/lib/Project.js#L139).  
Since `JSUtils.merge` allows duplicate elements in arrays, this can result in `translationsDir` containing redundant paths.
