### PR TITLE
ilib-loctool-yaml: Avoid schema warning for non yaml files

### DIFF
--- a/.changeset/six-parrots-hunt.md
+++ b/.changeset/six-parrots-hunt.md
@@ -1,0 +1,10 @@
+---
+"ilib-loctool-yaml": patch
+---
+
+Avoid schema warning for non yaml files
+
+- if we are localizing something other than a yaml file, such as
+  a markdown file that has some yaml-style frontmatter in it, then
+  don't try (and fail) to load a yaml schema file and then print
+  a warning on the screen

--- a/packages/ilib-loctool-yaml/YamlFile.js
+++ b/packages/ilib-loctool-yaml/YamlFile.js
@@ -416,12 +416,15 @@ YamlFile.prototype.getPath = function() {
 
 /**
  * Get the path name of schema file for the given resource file.
+ * Schema files are only used for .yml/.yaml files. When YamlFile is used for
+ * other formats (e.g. MDX frontmatter via ilib-loctool-mdx), return undefined
+ * to avoid spurious "No schema file found" warnings.
  *
- * @returns {String} the path name to this file
+ * @returns {String|undefined} the path name to the schema file, or undefined if not applicable
  */
 YamlFile.prototype.getSchemaPath = function() {
-    if (this.pathName) {
-        return this.pathName.replace(".yml", "-schema.json");
+    if (this.pathName && (this.pathName.endsWith(".yml") || this.pathName.endsWith(".yaml"))) {
+        return this.pathName.replace(/\.ya?ml$/, "-schema.json");
     }
 };
 

--- a/packages/ilib-loctool-yaml/test/YamlFile.test.js
+++ b/packages/ilib-loctool-yaml/test/YamlFile.test.js
@@ -1621,6 +1621,18 @@ describe("yamlfile testsWithLegacySchema", function() {
         expect(y).toBeTruthy();
         expect(y.getSchemaPath()).toBeUndefined();
     });
+    test("YamlGetSchemaPathReturnsUndefinedForMdxFiles", function() {
+        expect.assertions(2);
+        // When ilib-loctool-mdx uses YamlFile for frontmatter parsing, pathName is an .mdx file.
+        // Schema lookup is only for .yml/.yaml - must not try to load schema at MDX path.
+        var y = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "sign/webhooks/index.mdx"
+        });
+        expect(y).toBeTruthy();
+        expect(y.getSchemaPath()).toBeUndefined();
+    });
     test("YamlExtractSchemaFile", function() {
         expect.assertions(2);
         var y = new YamlFile({


### PR DESCRIPTION
- if we are localizing something other than a yaml file, such as a markdown file that has some yaml-style frontmatter in it, then don't try (and fail) to load a yaml schema file and then print the warning on the screen