### PR TITLE
Disable the 'Force update npm' section from .github/release.yml.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
                   registry-url: "https://registry.npmjs.org/"
             # Ensure npm 11.5.1 or later is installed so we can publish to npm with OIDC
             # per https://docs.npmjs.com/trusted-publishers#github-actions-configuration
-            - name: Force update npm
-              run: npm install -g npm@11.6.0
+            #- name: Force update npm
+            #  run: npm install -g npm@11.6.0
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
             - name: Create Release Pull Request or Publish to npm


### PR DESCRIPTION
The npm publish succeeded previously with that section disabled. 
The current changes have not been included in a previous release, so I revert it to the state at the time when the publish succeeded.