### PR TITLE
fix(ilib-loctool-mdx): only extract literal string JSX attributes

### DIFF
--- a/.changeset/loud-bottles-begin.md
+++ b/.changeset/loud-bottles-begin.md
@@ -1,0 +1,5 @@
+---
+"ilib-loctool-mdx": patch
+---
+
+- 3cc48da: only extract literal string JSX attributes

--- a/.changeset/loud-bottles-begin.md
+++ b/.changeset/loud-bottles-begin.md
@@ -2,4 +2,4 @@
 "ilib-loctool-mdx": patch
 ---
 
-- 3cc48da: only extract literal string JSX attributes
+Fixed <img> extraction so that "alt" and "title" attributes are extracted only when they are literal strings

--- a/packages/ilib-loctool-mdx/MdxFile.js
+++ b/packages/ilib-loctool-mdx/MdxFile.js
@@ -483,7 +483,7 @@ MdxFile.prototype._walk = function(node) {
         case 'link':
         case 'emphasis':
         case 'strong':
-            node.title && this._addTransUnit(node.title);
+            node.title && typeof node.title === 'string' && this._addTransUnit(node.title);
             if (this.localizeLinks && node.url) {
                 var value = node.url;
                 var parts = trim(this.API, value);
@@ -544,7 +544,7 @@ MdxFile.prototype._walk = function(node) {
                     this._addTransUnit(node.url);
                     node.localizable = true;
                 }
-                node.title && this._addTransUnit(node.title);
+                node.title && typeof node.title === 'string' && this._addTransUnit(node.title);
             }
             break;
 
@@ -993,7 +993,7 @@ MdxFile.prototype._localizeNode = function(node, message, locale, translations) 
         case 'link':
         case 'emphasis':
         case 'strong':
-            if (node.title) {
+            if (node.title && typeof node.title === 'string') {
                node.title = this._localizeString(node.title, locale, translations);
             }
             if (node.url && node.localizedLink) {
@@ -1068,7 +1068,7 @@ MdxFile.prototype._localizeNode = function(node, message, locale, translations) 
                     // don't pseudo-localize URLs
                     node.url = this._localizeString(node.url, locale, translations, true);
                 }
-                if (node.title) {
+                if (node.title && typeof node.title === 'string') {
                     node.title = this._localizeString(node.title, locale, translations);
                 }
             }

--- a/packages/ilib-loctool-mdx/MdxFile.js
+++ b/packages/ilib-loctool-mdx/MdxFile.js
@@ -359,14 +359,10 @@ MdxFile.prototype._findAttributes = function(node) {
             // Direct string value
             stringValue = value;
         } else if (typeof value === 'object') {
-            // Check if it's a literal value object
+            // Only extract literal string values; expressions ({variable}, {fn()}) are not localizable
             if (value.type === 'mdxJsxAttributeValueLiteral' && value.value !== undefined) {
                 stringValue = value.value;
-            } else if (value.value !== undefined && typeof value.value === 'string') {
-                // Fallback: try value.value if it exists and is a string
-                stringValue = value.value;
             } else {
-                // It's likely an expression (like {variable}), skip it - expressions are not localizable
                 continue;
             }
         } else {
@@ -416,12 +412,18 @@ MdxFile.prototype._localizeJsxAttributes = function(node, locale, translations) 
 
         // In MDX, string attribute values might be stored as:
         // - A string directly: "Click me"
-        // - A literal object with a value property: { type: 'mdxJsxAttributeValueLiteral', value: "Click me" }
-        var stringValue = value;
+        // - A literal object: { type: 'mdxJsxAttributeValueLiteral', value: "Click me" }
+        // Expression attributes ({ type: 'mdxJsxAttributeValueExpression' }) are not localizable.
+        var stringValue = null;
         var isLiteralObject = false;
-        if (value && typeof value === 'object' && value.value !== undefined) {
+        if (typeof value === 'string') {
+            stringValue = value;
+        } else if (value && typeof value === 'object' && value.type === 'mdxJsxAttributeValueLiteral' && value.value !== undefined) {
             stringValue = value.value;
             isLiteralObject = true;
+        } else {
+            // Expression or unknown type – skip
+            continue;
         }
 
         // For JSX components, only localize specific attributes: title, placeholder, label
@@ -510,8 +512,8 @@ MdxFile.prototype._walk = function(node) {
 
         case 'image':
         case 'imageReference':
-            node.title && this._addTransUnit(node.title);
-            node.alt && this._addTransUnit(node.alt);
+            node.title && typeof node.title === 'string' && this._addTransUnit(node.title);
+            node.alt && typeof node.alt === 'string' && this._addTransUnit(node.alt);
             // images are non-breaking, self-closing nodes
             // this.text += '<c' + this.componentIndex++ + '/>';
             if (this.message.getTextLength()) {
@@ -1009,10 +1011,10 @@ MdxFile.prototype._localizeNode = function(node, message, locale, translations) 
 
         case 'image':
         case 'imageReference':
-            if (node.title) {
+            if (node.title && typeof node.title === 'string') {
                 node.title = this._localizeString(node.title, locale, translations);
             }
-            if (node.alt) {
+            if (node.alt && typeof node.alt === 'string') {
                 node.alt = this._localizeString(node.alt, locale, translations);
             }
             // images are non-breaking, self-closing nodes

--- a/packages/ilib-loctool-mdx/MdxFile.js
+++ b/packages/ilib-loctool-mdx/MdxFile.js
@@ -484,7 +484,7 @@ MdxFile.prototype._walk = function(node) {
         case 'emphasis':
         case 'strong':
             node.title && typeof node.title === 'string' && this._addTransUnit(node.title);
-            if (this.localizeLinks && node.url) {
+            if (this.localizeLinks && node.url && typeof node.url === 'string') {
                 var value = node.url;
                 var parts = trim(this.API, value);
                 // only localizable if there already is some localizable text
@@ -535,7 +535,7 @@ MdxFile.prototype._walk = function(node) {
         case 'definition':
             // definitions are breaking nodes
             this._emitText();
-            if (node.url && this.localizeLinks) {
+            if (node.url && typeof node.url === 'string' && this.localizeLinks) {
                 var value = node.url;
                 var parts = trim(this.API, value);
                 // only localizable if there already is some localizable text
@@ -996,7 +996,7 @@ MdxFile.prototype._localizeNode = function(node, message, locale, translations) 
             if (node.title && typeof node.title === 'string') {
                node.title = this._localizeString(node.title, locale, translations);
             }
-            if (node.url && node.localizedLink) {
+            if (node.url && typeof node.url === 'string' && node.localizedLink) {
                 // don't pseudo-localize URLs
                 node.url = this._localizeString(node.url, locale, translations, true);
             }
@@ -1064,7 +1064,7 @@ MdxFile.prototype._localizeNode = function(node, message, locale, translations) 
                     message.pop();
                 }
 
-                if (node.url) {
+                if (node.url && typeof node.url === 'string') {
                     // don't pseudo-localize URLs
                     node.url = this._localizeString(node.url, locale, translations, true);
                 }

--- a/packages/ilib-loctool-mdx/test/MdxFile.test.js
+++ b/packages/ilib-loctool-mdx/test/MdxFile.test.js
@@ -1937,6 +1937,39 @@ Dictionary<string, object> metadata = await client.MetadataManager
         expect(set.size()).toBe(0);
     });
 
+    test("MdxFileParseMarkdownLinkStringUrlIsExtracted", function() {
+        expect.assertions(5);
+        var mf = new MdxFile({
+            project: p,
+            type: mdft
+        });
+        expect(mf).toBeTruthy();
+        mf.parse('{/* i18n-enable localize-links */}\n[link text](http://example.com)\n');
+        var set = mf.getTranslationSet();
+        expect(set).toBeTruthy();
+        // link text + URL are both extracted when localize-links is enabled
+        expect(set.size()).toBe(2);
+        var r = set.getBySource("http://example.com");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("http://example.com");
+    });
+
+    test("MdxFileParseMarkdownDefinitionStringUrlIsExtracted", function() {
+        expect.assertions(5);
+        var mf = new MdxFile({
+            project: p,
+            type: mdft
+        });
+        expect(mf).toBeTruthy();
+        mf.parse('{/* i18n-enable localize-links */}\n[ref]: http://example.com\n');
+        var set = mf.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(1);
+        var r = set.getBySource("http://example.com");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("http://example.com");
+    });
+
     test("MdxFileParseJsxAStringTitleIsExtracted", function() {
         expect.assertions(5);
         var mf = new MdxFile({

--- a/packages/ilib-loctool-mdx/test/MdxFile.test.js
+++ b/packages/ilib-loctool-mdx/test/MdxFile.test.js
@@ -1937,6 +1937,70 @@ Dictionary<string, object> metadata = await client.MetadataManager
         expect(set.size()).toBe(0);
     });
 
+    test("MdxFileParseJsxAStringTitleIsExtracted", function() {
+        expect.assertions(5);
+        var mf = new MdxFile({
+            project: p,
+            type: mdft
+        });
+        expect(mf).toBeTruthy();
+        mf.parse('<a href="http://example.com" title="My link title">link text</a>\n');
+        var set = mf.getTranslationSet();
+        expect(set).toBeTruthy();
+        // title attribute + text content are both extracted
+        expect(set.size()).toBe(2);
+        var r = set.getBySource("My link title");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("My link title");
+    });
+
+    test("MdxFileParseJsxAExpressionTitleIsNotExtracted", function() {
+        expect.assertions(4);
+        var mf = new MdxFile({
+            project: p,
+            type: mdft
+        });
+        expect(mf).toBeTruthy();
+        mf.parse('<a href="http://example.com" title={translate("abc")}>link text</a>\n');
+        var set = mf.getTranslationSet();
+        expect(set).toBeTruthy();
+        // only the text content is extracted; the expression title is not
+        expect(set.size()).toBe(1);
+        expect(set.getBySource("link text")).toBeTruthy();
+    });
+
+    test("MdxFileParseJsxStrongStringTitleIsExtracted", function() {
+        expect.assertions(5);
+        var mf = new MdxFile({
+            project: p,
+            type: mdft
+        });
+        expect(mf).toBeTruthy();
+        mf.parse('<strong title="My strong title">bold text</strong>\n');
+        var set = mf.getTranslationSet();
+        expect(set).toBeTruthy();
+        // title attribute + text content are both extracted
+        expect(set.size()).toBe(2);
+        var r = set.getBySource("My strong title");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("My strong title");
+    });
+
+    test("MdxFileParseJsxStrongExpressionTitleIsNotExtracted", function() {
+        expect.assertions(4);
+        var mf = new MdxFile({
+            project: p,
+            type: mdft
+        });
+        expect(mf).toBeTruthy();
+        mf.parse('<strong title={translate("abc")}>bold text</strong>\n');
+        var set = mf.getTranslationSet();
+        expect(set).toBeTruthy();
+        // only the text content is extracted; the expression title is not
+        expect(set.size()).toBe(1);
+        expect(set.getBySource("bold text")).toBeTruthy();
+    });
+
     test("MdxFileParseI18NComments", function() {
         expect.assertions(10);
         var mf = new MdxFile({

--- a/packages/ilib-loctool-mdx/test/MdxFile.test.js
+++ b/packages/ilib-loctool-mdx/test/MdxFile.test.js
@@ -1879,6 +1879,64 @@ Dictionary<string, object> metadata = await client.MetadataManager
         expect(r.getKey()).toBe("r160369622");
     });
 
+    test("MdxFileParseImgJsxStringAltIsExtracted", function() {
+        expect.assertions(5);
+        var mf = new MdxFile({
+            project: p,
+            type: mdft
+        });
+        expect(mf).toBeTruthy();
+        mf.parse('<img alt="Test string" src="foo.png" />\n');
+        var set = mf.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(1);
+        var r = set.getBySource("Test string");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Test string");
+    });
+
+    test("MdxFileParseImgJsxExpressionAltIsNotExtracted", function() {
+        expect.assertions(3);
+        var mf = new MdxFile({
+            project: p,
+            type: mdft
+        });
+        expect(mf).toBeTruthy();
+        mf.parse('<img alt={translate("abc")} src="foo.png" />\n');
+        var set = mf.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(0);
+    });
+
+    test("MdxFileParseImgJsxStringTitleIsExtracted", function() {
+        expect.assertions(5);
+        var mf = new MdxFile({
+            project: p,
+            type: mdft
+        });
+        expect(mf).toBeTruthy();
+        mf.parse('<img title="Test string" src="foo.png" />\n');
+        var set = mf.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(1);
+        var r = set.getBySource("Test string");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Test string");
+    });
+
+    test("MdxFileParseImgJsxExpressionTitleIsNotExtracted", function() {
+        expect.assertions(3);
+        var mf = new MdxFile({
+            project: p,
+            type: mdft
+        });
+        expect(mf).toBeTruthy();
+        mf.parse('<img title={translate("abc")} src="foo.png" />\n');
+        var set = mf.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(0);
+    });
+
     test("MdxFileParseI18NComments", function() {
         expect.assertions(10);
         var mf = new MdxFile({


### PR DESCRIPTION
## Summary
JSX attribute values in MDX come in two forms: string literals (`alt="Text"`) and expressions (`alt={translate("abc")}`). Previously, the fallback logic in `_findAttributes` and `_localizeJsxAttributes` treated **expression attributes as localizable** because both literal and expression objects share a `.value` property — for expressions, `.value` holds the expression's source code as a string (e.g. `translate("abc")`), which was being incorrectly extracted as a translation unit.
## Changes
- **`_findAttributes`**: Removed the loose fallback that accepted any object with a string `.value` property. Now only `mdxJsxAttributeValueLiteral` objects are treated as string values; expression attributes (`mdxJsxAttributeValueExpression`) hit an early `continue` and are skipped.
- **`_localizeJsxAttributes`**: Applied the same fix — expression attribute values are now skipped entirely during the localization phase instead of having their source code string localized and written back into the AST.
- **`_walk` / `_localizeNode`** (`image`/`imageReference` cases): Added defensive `typeof ... === 'string'` guards for `node.alt` and `node.title` to be consistent with the same intent.
- **Tests**: Added 4 tests covering all required scenarios for `<img>` JSX elements:
  - `alt="Text"` → trans unit created
  - `alt={translate("abc")}` → no trans unit
  - `title="Text"` → trans unit created
  - `title={translate("abc")}` → no trans unit