### PR TITLE
ilib-localematcher: Fix a bug where locale parsing information is passed incorrectly

### DIFF
--- a/.changeset/purple-garlics-fetch.md
+++ b/.changeset/purple-garlics-fetch.md
@@ -1,0 +1,6 @@
+---
+"ilib-localematcher": patch
+---
+
+Fix a bug where locale parsing information is passed incorrectly.
+Add the missing `ko-CN` locale to the LocaleMatcher.

--- a/packages/ilib-localematcher/src/LocaleMatcher.js
+++ b/packages/ilib-localematcher/src/LocaleMatcher.js
@@ -91,22 +91,22 @@ class LocaleMatcher {
 
         if (typeof(matchdata.likelyLocales[locale.getSpec()]) === 'undefined') {
             // try various partials before giving up
-            let partial = matchdata.likelyLocales[new Locale(locale.language, undefined, locale.region).getSpec()];
+            let partial = matchdata.likelyLocales[new Locale(locale.language, locale.region, undefined).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
-            partial = matchdata.likelyLocales[new Locale(locale.language, locale.script, undefined).getSpec()];
+            partial = matchdata.likelyLocales[new Locale(locale.language, undefined, undefined, locale.script).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
             partial = matchdata.likelyLocales[new Locale(locale.language, undefined, undefined).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
-            partial = matchdata.likelyLocales[new Locale(undefined, locale.script, locale.region).getSpec()];
+            partial = matchdata.likelyLocales[new Locale(undefined, locale.region, undefined, locale.script).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
-            partial = matchdata.likelyLocales[new Locale(undefined, undefined, locale.region).getSpec()];
+            partial = matchdata.likelyLocales[new Locale(undefined, locale.region, undefined).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
-            partial = matchdata.likelyLocales[new Locale(undefined, locale.script, undefined).getSpec()];
+            partial = matchdata.likelyLocales[new Locale(undefined, undefined, undefined, locale.script).getSpec()];
             if (typeof(partial) !== 'undefined') return new Locale(partial);
 
             return locale;
@@ -161,7 +161,7 @@ class LocaleMatcher {
         const fullLocale = this._getLikelyLocale(this.locale);
         const langLocale = this._getLikelyLocale(new Locale(fullLocale.language));
         return fullLocale.script === langLocale.script && !multiScriptLanguages[fullLocale.language] ?
-            new Locale(fullLocale.language, undefined, fullLocale.region) :
+            new Locale(fullLocale.language, fullLocale.region, undefined) :
             fullLocale;
     }
 

--- a/packages/ilib-localematcher/src/localematch.js
+++ b/packages/ilib-localematcher/src/localematch.js
@@ -2,7 +2,7 @@
 /*
  * localematch.js - Locale match mappings
  *
- * Copyright © 2022-2023, 2025 JEDLSoft
+ * Copyright © 2022-2023, 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -351,6 +351,7 @@ export const matchdata = {
         "Kits": "zkt-Kits-CN",
         "Knda": "kn-Knda-IN",
         "Kore": "ko-Kore-KR",
+        "Kore-CN": "ko-Kore-CN",
         "Kore-KP": "ko-Kore-KP",
         "Kore-KR": "ko-Kore-KR",
         "Kore-TW": "ko-Kore-TW",
@@ -9982,6 +9983,7 @@ export const matchdata = {
         "knz-BF": "knz-Latn-BF",
         "knz-Latn": "knz-Latn-BF",
         "ko": "ko-Kore-KR",
+        "ko-CN": "ko-Kore-CN",
         "ko-KP": "ko-Kore-KP",
         "ko-KR": "ko-Kore-KR",
         "ko-Kore": "ko-Kore-KR",

--- a/packages/ilib-localematcher/test/localematch.test.js
+++ b/packages/ilib-localematcher/test/localematch.test.js
@@ -1,7 +1,7 @@
 /*
  * localematch.test.js - test the locale matcher object
  *
- * Copyright © 2012-2015, 2017,2019 2022-2023, 2025 JEDLSoft
+ * Copyright © 2012-2015, 2017,2019 2022-2023, 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,6 +183,39 @@ describe("testLocaleMatch", () => {
         expect(locale.getSpec()).toBe("arc-Elym-IR");
     });
 
+    test("LocaleMatcherGetLikelyLocaleByUndLanguageAndScriptArab", () => {
+        expect.assertions(3);
+        var lm = new LocaleMatcher({
+            locale: "und-Arab"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("ar-Arab-EG");
+    });
+
+    test("LocaleMatcherGetLikelyLocaleByUndLanguageAndScriptHans", () => {
+        expect.assertions(3);
+        var lm = new LocaleMatcher({
+            locale: "und-Hans"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("zh-Hans-CN");
+    });
+
+    test("LocaleMatcherGetLikelyLocaleByUndLanguageAndScriptCyrl", () => {
+        expect.assertions(3);
+        var lm = new LocaleMatcher({
+            locale: "und-Cyrl"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("ru-Cyrl-RU");
+    });
+
     test("LocaleMatcherGetLikelyLocaleByLanguageAndScript1", () => {
         expect.assertions(3);
         var lm = new LocaleMatcher({
@@ -280,6 +313,28 @@ describe("testLocaleMatch", () => {
         var locale = lm.getLikelyLocale();
         expect(typeof(locale) !== "undefined").toBeTruthy();
         expect(locale.getSpec()).toBe("fr-Latn-MA");
+    });
+
+    test("LocaleMatcherGetLikelyLocaleByRegionAndScript2", () => {
+        expect.assertions(3);
+        var lm = new LocaleMatcher({
+            locale: "Arab-IN"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("ur-Arab-IN");
+    });
+
+    test("LocaleMatcherGetLikelyLocaleByRegionAndScript3", () => {
+        expect.assertions(3);
+        var lm = new LocaleMatcher({
+            locale: "Deva-PK"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("btv-Deva-PK");
     });
 
     test("LocaleMatcherGetLikelyLocaleAlreadySpecified", () => {
@@ -1368,6 +1423,16 @@ describe("testLocaleMatch", () => {
         var locale = lm.getLikelyLocale();
         expect(typeof(locale) !== "undefined").toBeTruthy();
         expect(locale.getSpec()).toBe("ko-Kore-TW");
+    });
+    test("LocaleMatcherGetLikelyLocaleByLocaleCode_ko_CN", () => {
+        expect.assertions(3);
+        var lm = new LocaleMatcher({
+            locale: "ko-CN"
+        });
+        expect(typeof(lm) !== "undefined").toBeTruthy();
+        var locale = lm.getLikelyLocale();
+        expect(typeof(locale) !== "undefined").toBeTruthy();
+        expect(locale.getSpec()).toBe("ko-Kore-CN");
     });
     test("LocaleMatcherMatchExactFullLocale", () => {
         expect.assertions(2);


### PR DESCRIPTION
* Fix a bug where locale parsing information is passed incorrectly.
* Add the missing `ko-CN` locale to the LocaleMatcher.