### PR TITLE
Commit last changes from ilib-localematcher independent package

### DIFF
--- a/packages/ilib-localematcher/README.md
+++ b/packages/ilib-localematcher/README.md
@@ -48,7 +48,7 @@ for specifics.
 
 ## License
 
-Copyright © 2021-2022, 2025 JEDLSoft
+Copyright © 2021-2022, 2025-2026 JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -65,46 +65,4 @@ limitations under the License.
 
 ## Release Notes
 
-### v1.3.2
-* Add the missing `ko-TW` and `ko-US` locales to the LocaleMatcher.
-
-### v1.3.1
-
-* Convert all unit tests from nodeunit to jest
-    * tests are now able to be run on headless browsers via karma
-* Fixed a bug where the territory containment reverse was generated
-  incorrectly
-
-### v1.3.0
-
-* Update to CLDR v44.0.0
-
-### v1.2.2
-
-* This module is now a hybrid ESM/CommonJS package that works under node
-  or webpack
-
-### v1.2.1
-
-* Updated dependencies
-
-### v1.2.0
-
-- Update to CLDR 41 data
-- Add additional likely locale data for a number of locales not listed in CLDR
-- Updated dependencies
-
-### v1.1.0
-
-- ship the locale dir too or else this whole package won't work!
-- update to CLDR 40
-
-### v1.0.1
-
-- updated dependencies
-- added docs in markdown format as well
-
-### v1.0.0
-
-- initial version
-- copied from ilib 14.9.0
+See [CHANGELOG.md](./CHANGELOG.md) for details.

--- a/packages/ilib-localematcher/scripts/genlikelyloc.js
+++ b/packages/ilib-localematcher/scripts/genlikelyloc.js
@@ -324,7 +324,7 @@ var preamble = `
 /*
  * localematch.js - Locale match mappings
  *
- * Copyright © 2022-2023, 2025 JEDLSoft
+ * Copyright © 2022-2023, 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ilib-localematcher/scripts/likelyLocalesAdditional.json
+++ b/packages/ilib-localematcher/scripts/likelyLocalesAdditional.json
@@ -335,6 +335,7 @@
     "it-CH": "it-Latn-CH",
     "ka-IR": "ka-Geor-IR",
     "kk-KZ": "kk-Cyrl-KZ",
+    "ko-CN": "ko-Kore-CN",
     "ko-TW": "ko-Kore-TW",
     "ko-US": "ko-Kore-US",
     "ku-IQ": "ku-Arab-IQ",

--- a/packages/ilib-localematcher/src/LocaleMatcher.js
+++ b/packages/ilib-localematcher/src/LocaleMatcher.js
@@ -1,7 +1,7 @@
 /*
  * LocaleMatcher.js - Locale matcher definition
  *
- * Copyright © 2013-2015, 2018-2019, 2021-2022 JEDLSoft
+ * Copyright © 2013-2015, 2018-2019, 2021-2022, 2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- these changes didn't make it over in the migration before
- https://github.com/iLib-js/ilib-mono/pull/288/changes#diff-e2b848aa53b37a44f599b055969021c44d22350d0190864a2cddcd46c194dccbR338 this does not need a changeset, because it only changes the behaviour of the build script for this package. The outcome of this change has already been included within https://github.com/iLib-js/ilib-mono/pull/286/changes#diff-bf8a6855ef06e10397bbfdcfa7d406414eee9282f3fb74fde98e850b2088d5b6R9986