### PR TITLE
ilib-lint: Fix a crash in `ResourceQuoteStyle` when checking CJK target strings that use wrong-style quotes

### DIFF
--- a/.changeset/tidy-birds-drop.md
+++ b/.changeset/tidy-birds-drop.md
@@ -1,0 +1,5 @@
+---
+"ilib-lint": patch
+---
+
+Fix a crash in `ResourceQuoteStyle` when checking CJK target strings that use wrong-style quotes.

--- a/packages/ilib-lint/src/rules/ResourceQuoteStyle.js
+++ b/packages/ilib-lint/src/rules/ResourceQuoteStyle.js
@@ -236,14 +236,17 @@ class ResourceQuoteStyle extends ResourceRule {
             }
             let match;
             let commands = [];
+            const startQuotePositions = new Set();
 
             while ((match = startQuote.exec(tar)) !== null) {
                 // now that we have found a start quote, find it in the matched string so
                 // that we can get the index into that string
                 const offset = match[0].indexOf(match[3]);
+                const pos = match.index + offset;
+                startQuotePositions.add(pos);
 
                 commands.push(ResourceFixer.createStringCommand(
-                    match.index + offset,
+                    pos,
                     1,
                     correctQuoteStart
                 ));
@@ -253,9 +256,13 @@ class ResourceQuoteStyle extends ResourceRule {
                 // now that we have found an end quote, find it in the matched string so
                 // that we can get the index into that string
                 const offset = match[0].indexOf(match[3]);
+                const pos = match.index + offset;
+                // skip positions already handled by startQuote to avoid overlapping commands
+                // (can occur when a quote char is surrounded by CJK letters on both sides)
+                if (startQuotePositions.has(pos)) continue;
 
                 commands.push(ResourceFixer.createStringCommand(
-                    match.index + offset,
+                    pos,
                     1,
                     correctQuoteEnd
                 ));

--- a/packages/ilib-lint/test/ResourceQuoteStyle.test.js
+++ b/packages/ilib-lint/test/ResourceQuoteStyle.test.js
@@ -2338,4 +2338,150 @@ describe("testResourceQuoteStyle", () => {
 
         expect(actual).toBeTruthy();
     });
+
+    test("ResourceQuoteStyleMatchAsciiQuotesChinese -- apply fix", () => {
+        expect.assertions(3);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-KR",
+            source: "To delete the list, press 'OK'.",
+            targetLocale: "zh-Hans-CN",
+            // target uses primary “” quotes instead of correct alt ‘’ quotes
+            target: '要删除此列表，请按“确定”。',
+            pathName: "a/b/zh-Hans-CN.xliff"
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/zh-Hans-CN.xliff"
+        });
+
+        expect(actual?.fix).toBeTruthy();
+
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [resource],
+            sourceFile
+        });
+
+        const fixer = new ResourceFixer();
+        fixer.applyFixes(ir, [actual?.fix]);
+
+        // fix should replace primary “” quotes with alt ‘’ quotes
+        expect(resource.getTarget()).toBe('要删除此列表，请按‘确定’。');
+    });
+
+    test("ResourceQuoteStyleNoViolationChineseCorrectAltQuotes", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: "To delete the list, press 'OK'.",
+            targetLocale: "zh-Hans-CN",
+            // target uses correct alt ‘’ quotes for zh-Hans-CN
+            target: '要删除此列表，请按‘确定’。',
+            pathName: "a/b/zh-Hans-CN.xliff"
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/zh-Hans-CN.xliff"
+        });
+
+        // correct native alt quotes should not trigger a violation
+        expect(actual).toBeFalsy();
+    });
+
+    test("ResourceQuoteStyleKoreanCorrectPrimaryQuotes", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'Click the "OK" button.',
+            targetLocale: "ko-KR",
+            // target uses correct primary “/” quotes for ko-KR
+            target: '“확인” 버튼을 클릭하세요.',
+            pathName: "a/b/ko-KR.xliff"
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/ko-KR.xliff"
+        });
+
+        // correct native primary quotes should not trigger a violation
+        expect(actual).toBeFalsy();
+    });
+    
+    test("ResourceQuoteStyleKoreanCorrectAltQuotes", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: "Press 'OK' to confirm.",
+            targetLocale: "ko-KR",
+            // target uses correct alt ‘/’ quotes for ko-KR
+            target: "‘확인‘을 눌러 확인하세요.",
+            pathName: "a/b/ko-KR.xliff"
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/ko-KR.xliff"
+        });
+
+        // correct native alt quotes should not trigger a violation
+        expect(actual).toBeFalsy();
+    });
+
+    test("ResourceQuoteStyleJapaneseCorrectCornerBrackets", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'Click "OK" to continue.',
+            targetLocale: "ja-JP",
+            // target uses correct 「/」 corner bracket quotes for ja-JP
+            target: "「確認」をクリックして続行します。",
+            pathName: "a/b/ja-JP.xliff"
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/ja-JP.xliff"
+        });
+
+        // correct native corner bracket quotes should not trigger a violation
+        expect(actual).toBeFalsy();
+    });
 });

--- a/packages/ilib-lint/test/ResourceQuoteStyle.test.js
+++ b/packages/ilib-lint/test/ResourceQuoteStyle.test.js
@@ -2289,4 +2289,53 @@ describe("testResourceQuoteStyle", () => {
         // Proper quotes are used for "sauni"
         expect(actual).toBeFalsy();
     });
+
+    test("ResourceQuoteStyleMatchAsciiQuotesChines", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-KR",
+            source: "Prevent Input Delay (Input Lag) setting will return to Standard if 'Game Optimizer' is not used.",
+            targetLocale: "zh-Hans-CN",
+            target: '如果未使用“游戏优化器”，则“防止输入延迟（输入滞后）”设置将返回“标准”',
+            pathName: "a/b/zh-Hans-CN.xliff"
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/zh-Hans-CN.xliff"
+        });
+
+        expect(actual).toBeTruthy();
+    });
+    test("ResourceQuoteStyleMatchAsciiQuotesChines2", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-KR",
+            source: "To delete the list, press 'OK'.",
+            targetLocale: "zh-Hans-CN",
+            target: '要删除此列表，请按“确定”。',
+            pathName: "a/b/zh-Hans-CN.xliff"
+        });
+
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/zh-Hans-CN.xliff"
+        });
+
+        expect(actual).toBeTruthy();
+    });
 });


### PR DESCRIPTION
## Problem

When checking quote style in CJK (Chinese/Japanese/Korean) target strings,
`ResourceQuoteStyle` throws an unhandled error:

> Cannot create a fix because some of the commands overlap with each other

This causes any test or lint run that encounters a CJK target using wrong-style
quotes (e.g. Chinese `"…"` where single quotes `'…'` are expected) to crash
instead of reporting a `Result`.

### Root cause

JavaScript's `\W` shorthand matches `[^A-Za-z0-9_]`, which includes CJK
characters. Because of this, a quote that is **surrounded by CJK letters on
both sides** is matched by **both** `startQuote` and `endQuote` at the same
string position:

- `startQuote`: uses `\W` before the quote → CJK char satisfies `\W` ✓
- `endQuote`: uses `\p{Letter}` before the quote and `\W` after → CJK char
  satisfies both ✓

Both regexes therefore emit a `StringFixCommand` targeting the identical
character index, violating the non-overlap invariant enforced by `ResourceFix`.

**Example**
source: "Prevent Input Delay (Input Lag) setting will return to Standard if 'Game Optimizer' is not used.",
target: '如果未使用“游戏优化器”，则“防止输入延迟（输入滞后）”设置将返回“标准”',
targetLocale: zh-Hans-CN

 — source `'Game Optimizer'` (ASCII single-quote style),
target `"游戏优化器"` (Chinese double-quote style, which is wrong):

用 " 游      ← position 5
└─ \W (startQuote leading char)
└─ \p{Letter} (endQuote leading char)
└─ \W (endQuote trailing char — 游 is not ASCII-word)



Both `startQuote` and `endQuote` generate a command at position 5 → overlap
→ exception.

## Fix

Track the string positions claimed by `startQuote` in a `Set`. When the
`endQuote` loop encounters a position that is already in that set, it skips
it. This prevents duplicate commands without changing the regex patterns.

Changing the regexes themselves (e.g. replacing `\W` with `[^\p{Letter}]`
in `endQuote`) was considered but rejected: Japanese tests rely on `endQuote`
matching closing corner brackets (`』`) that are legitimately followed by
hiragana, which is `\p{Letter}`. The deduplication approach handles both
locales correctly because Japanese corner brackets are excluded from
`nonQuoteStartCharsAlt`, so `startQuote` never claims those positions in the
first place.