### PR TITLE
ilib-lint: Add global exception list support in resource-sentence-ending

### DIFF
--- a/.changeset/wise-crabs-cross.md
+++ b/.changeset/wise-crabs-cross.md
@@ -1,0 +1,5 @@
+---
+"ilib-lint": patch
+---
+
+`resource-sentence-ending`: Added global exception list support. Strings specified under top-level `exceptions` in the rule config are now skipped for all locales, making it easy to exclude strings that end with a period as part of the name rather than as sentence-ending punctuation. Exception storage was also refactored from `Array` to `Set` for deduplication and O(1) lookup performance.

--- a/packages/ilib-lint/docs/resource-sentence-ending.md
+++ b/packages/ilib-lint/docs/resource-sentence-ending.md
@@ -81,7 +81,26 @@ The rule automatically skips checking strings that:
 - Are shorter than the minimum length threshold
 
 #### Exception Lists
-You can specify exact source strings to skip checking for specific locales:
+
+**Global exceptions** — skip checking for ALL locales by specifying `exceptions` at the top level:
+
+```json
+{
+  "rulesets": {
+    "myset": {
+      "resource-sentence-ending": {
+        "exceptions": [
+          "Please see the Dr.",
+          "Visit the Prof.",
+          "Check with Mr."
+        ]
+      }
+    }
+  }
+}
+```
+
+**Locale-specific exceptions** — skip checking only for a particular locale:
 
 ```json
 {
@@ -100,6 +119,8 @@ You can specify exact source strings to skip checking for specific locales:
   }
 }
 ```
+
+Both can be combined. Global exceptions are checked first, then locale-specific ones.
 
 ### Custom Punctuation Configuration
 
@@ -219,6 +240,10 @@ Here's a comprehensive example showing all configuration options together:
     "myset": {
       "resource-sentence-ending": {
         "minimumLength": 8,
+        "exceptions": [
+          "Please see the Dr.",
+          "Visit the Prof."
+        ],
         "ja-JP": {
           "period": "。",
           "question": "？",
@@ -231,7 +256,6 @@ Here's a comprehensive example showing all configuration options together:
         "de-DE": {
           "exceptions": [
             "See the Dr.",
-            "Visit the Prof.",
             "Check with Mr."
           ]
         },
@@ -251,8 +275,9 @@ Here's a comprehensive example showing all configuration options together:
 
 This configuration:
 - Sets minimum length to 8 characters
-- Configures Japanese punctuation and exceptions (note: exclamation marks are disabled by default for Japanese, but this example explicitly enables them with `"exclamation": "！"`)
-- Adds German exceptions for common abbreviations
+- Skips `"Please see the Dr."` and `"Visit the Prof."` for **all locales** (global exceptions)
+- Configures Japanese punctuation and adds Japanese-specific exceptions
+- Adds German-specific exceptions for common abbreviations
 - Overrides French ellipsis behavior
 
 ### Supported Punctuation Types
@@ -274,7 +299,7 @@ The following punctuation types can be customized:
 - **Merging**: Custom configurations merge with the default locale-specific rules, so you only need to specify the punctuation types you want to override.
 - **Fallback**: If a punctuation type is not specified in the custom configuration, the rule uses the default punctuation for that language.
 - **Null Values**: Setting a punctuation type to `null` disables checking for that type. For Japanese, exclamation marks are disabled by default (`exclamation: null`).
-- **Exception Processing**: Exception lists are processed before punctuation checking, so strings in the exception list will never trigger warnings regardless of punctuation mismatches.
+- **Exception Processing**: Exception lists are processed before punctuation checking. Global exceptions (top-level `exceptions`) apply to all locales; locale-specific exceptions apply only to that locale. Global exceptions are checked first.
 - **Automatic Skipping**: The rule automatically skips strings that are shorter than `minimumLength` or have no spaces (unless they end with sentence-ending punctuation).
 
 ## Exception Behaviors
@@ -305,9 +330,16 @@ Strings with no spaces are automatically skipped:
 - `"Loading..."` (no spaces but ends with ellipsis)
 
 ### Exception Lists
-Strings in locale-specific exception lists are always skipped:
+Strings in exception lists are always skipped. Exceptions can be global (all locales) or locale-specific:
 
-**Example:**
+**Global exceptions** (top-level `exceptions` — apply to all locales):
+```json
+{
+  "exceptions": ["See the Dr.", "Visit the Prof."]
+}
+```
+
+**Locale-specific exceptions** (inside a locale key — apply only to that locale):
 ```json
 {
   "de-DE": {
@@ -316,7 +348,7 @@ Strings in locale-specific exception lists are always skipped:
 }
 ```
 
-Even if the target lacks punctuation, these source strings will never trigger warnings.
+Global exceptions are checked first. Even if the target lacks punctuation, these source strings will never trigger warnings for any locale.
 
 ## Common Scenarios
 

--- a/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
+++ b/packages/ilib-lint/src/rules/ResourceSentenceEnding.js
@@ -102,9 +102,11 @@ const punctuationMap = {
 
 /**
  * @ignore
- * @typedef {{minimumLength?: number}} ResourceSentenceEndingFixedOptions
+ * @typedef {{minimumLength?: number, exceptions?: string[]}} ResourceSentenceEndingFixedOptions
  * @property {number} [minimumLength=10] - Minimum length of source string before the rule is applied.
  *   Strings shorter than this length will be skipped (useful for avoiding false positives on abbreviations).
+ * @property {string[]} [exceptions] - Array of source strings to skip checking for ALL locales.
+ *   Useful for handling special cases that should be globally excluded from sentence-ending punctuation checks.
  */
 
 /**
@@ -120,7 +122,7 @@ class ResourceSentenceEnding extends ResourceRule {
     /**
      * Constructs a new ResourceSentenceEnding rule instance.
      *
-     * @param {ResourceSentenceEndingOptions} [options] - Configuration options for the rule
+     * @param {{ param?: ResourceSentenceEndingOptions, sourceLocale?: string, getLogger?: Function }} [options] - Configuration options for the rule
      *
      * @example
      * // Basic usage with default settings
@@ -181,9 +183,16 @@ class ResourceSentenceEnding extends ResourceRule {
         // Initialize minimum length configuration
         this.minimumLength = Math.max(0, param?.minimumLength ?? 10);
 
+        // Initialize global exceptions (apply to all locales), deduplicated via Set
+        this.globalExceptions = new Set(
+            Array.isArray(param?.exceptions)
+                ? param.exceptions.map((/** @type {string} */ e) => e.toLowerCase().trim())
+                : []
+        );
+
         // Initialize custom punctuation mappings from configuration
         this.customPunctuationMap = {};
-        // Initialize exception lists from configuration
+        // Initialize locale-specific exception lists from configuration
         this.exceptionsMap = {};
 
         if (param && typeof param === 'object' && !Array.isArray(param)) {
@@ -211,9 +220,11 @@ class ResourceSentenceEnding extends ResourceRule {
                         ...punctuationMappings
                     };
 
-                    // Store exceptions separately
+                    // Store exceptions as a Set to deduplicate
                     if (exceptions && Array.isArray(exceptions)) {
-                        this.exceptionsMap[language] = exceptions;
+                        this.exceptionsMap[language] = new Set(
+                            exceptions.map((/** @type {string} */ e) => e.toLowerCase().trim())
+                        );
                     }
                 }
             }
@@ -982,12 +993,17 @@ class ResourceSentenceEnding extends ResourceRule {
             }
         }
 
-        // Exception 3: Check if source is in exception list
+        const normalizedSource = source.toLowerCase().trim();
+
+        // Exception 3: Check if source is in global exception list (all locales)
+        if (this.globalExceptions.has(normalizedSource)) {
+            return undefined;
+        }
+
+        // Exception 4: Check if source is in locale-specific exception list
         const exceptions = this.exceptionsMap[targetLanguage];
-        if (exceptions) {
-            if (exceptions.some(exception => exception.toLowerCase().trim() === source.toLowerCase().trim())) {
-                return undefined;
-            }
+        if (exceptions?.has(normalizedSource)) {
+            return undefined;
         }
 
         const optionalPunctuationLanguages = ['th', 'lo', 'my', 'km', 'vi', 'id', 'ms', 'tl', 'jv', 'su'];

--- a/packages/ilib-lint/test/rules/ResourceSentenceEnding.test.js
+++ b/packages/ilib-lint/test/rules/ResourceSentenceEnding.test.js
@@ -4407,6 +4407,160 @@ describe("ResourceSentenceEnding rule", function() {
 
                 expect(actual).toBeUndefined();
             });
+
+            test("should not check sentence-ending punctuation for zh-Hans-CN string in exception list", () => {
+                expect.assertions(1);
+
+                const zhHansCNConfig = {
+                    "zh-Hans-CN": {
+                        exceptions: ["This is a sentence."]
+                    }
+                };
+                const rule = new ResourceSentenceEnding({ param: zhHansCNConfig });
+
+                const resource = new ResourceString({
+                    key: "test.zhhanscn.exception",
+                    source: "This is a sentence.",
+                    target: "这是一个句子",
+                    sourceLocale: "en-US",
+                    targetLocale: "zh-Hans-CN"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeUndefined();
+            });
+        });
+
+        describe("Global exception list", () => {
+            test("should skip check for all locales when source is in global exception list", () => {
+                expect.assertions(4);
+
+                const globalConfig = {
+                    exceptions: ["Please see the Dr."]
+                };
+                const rule = new ResourceSentenceEnding({ param: globalConfig });
+                expect(rule).toBeTruthy();
+
+                for (const targetLocale of ["ja-JP", "zh-Hans-CN", "de-DE"]) {
+                    const resource = new ResourceString({
+                        key: `test.global.exception.${targetLocale}`,
+                        source: "Please see the Dr.",
+                        target: "translated without punctuation",
+                        sourceLocale: "en-US",
+                        targetLocale
+                    });
+
+                    const actual = rule.matchString({
+                        source: resource.getSource(),
+                        target: resource.getTarget(),
+                        resource,
+                        file: "a/b/c.xliff"
+                    });
+
+                    expect(actual).toBeUndefined();
+                }
+            });
+
+            test("should still check strings not in global exception list", () => {
+                expect.assertions(1);
+
+                const globalConfig = {
+                    exceptions: ["Please see the Dr."]
+                };
+                const rule = new ResourceSentenceEnding({ param: globalConfig });
+
+                const resource = new ResourceString({
+                    key: "test.global.noexception",
+                    source: "This is a sentence.",
+                    target: "これは文です",
+                    sourceLocale: "en-US",
+                    targetLocale: "ja-JP"
+                });
+
+                const actual = rule.matchString({
+                    source: resource.getSource(),
+                    target: resource.getTarget(),
+                    resource,
+                    file: "a/b/c.xliff"
+                });
+
+                expect(actual).toBeTruthy();
+            });
+
+            test("should skip check for company name with multiple periods like ABC.Corp.", () => {
+                expect.assertions(4);
+
+                const globalConfig = {
+                    exceptions: ["ABC.Corp."]
+                };
+                const rule = new ResourceSentenceEnding({ param: globalConfig });
+                expect(rule).toBeTruthy();
+
+                for (const targetLocale of ["ja-JP", "zh-Hans-CN", "de-DE"]) {
+                    const resource = new ResourceString({
+                        key: `test.global.company.${targetLocale}`,
+                        source: "ABC.Corp.",
+                        target: "translated without punctuation",
+                        sourceLocale: "en-US",
+                        targetLocale
+                    });
+
+                    const actual = rule.matchString({
+                        source: resource.getSource(),
+                        target: resource.getTarget(),
+                        resource,
+                        file: "a/b/c.xliff"
+                    });
+
+                    expect(actual).toBeUndefined();
+                }
+            });
+
+            test("should combine global and locale-specific exceptions", () => {
+                expect.assertions(2);
+
+                const combinedConfig = {
+                    exceptions: ["Global exception string."],
+                    "ja-JP": {
+                        exceptions: ["Japanese only exception."]
+                    }
+                };
+                const rule = new ResourceSentenceEnding({ param: combinedConfig });
+
+                const globalResource = new ResourceString({
+                    key: "test.combined.global",
+                    source: "Global exception string.",
+                    target: "translated without punctuation",
+                    sourceLocale: "en-US",
+                    targetLocale: "de-DE"
+                });
+                expect(rule.matchString({
+                    source: globalResource.getSource(),
+                    target: globalResource.getTarget(),
+                    resource: globalResource,
+                    file: "a/b/c.xliff"
+                })).toBeUndefined();
+
+                const localeResource = new ResourceString({
+                    key: "test.combined.locale",
+                    source: "Japanese only exception.",
+                    target: "translated without punctuation",
+                    sourceLocale: "en-US",
+                    targetLocale: "ja-JP"
+                });
+                expect(rule.matchString({
+                    source: localeResource.getSource(),
+                    target: localeResource.getTarget(),
+                    resource: localeResource,
+                    file: "a/b/c.xliff"
+                })).toBeUndefined();
+            });
         });
     });
 


### PR DESCRIPTION
## Summary

Previously, `exceptions` could only be configured per locale. This PR adds support for a **global exception list** — strings specified at the top level under `exceptions` are skipped for **all locales**. Additionally, exception storage is refactored from `Array` to `Set` for deduplication and O(1) lookup performance.

On webOS, there are strings like `"LG Electronics."` where a company name ends with a period. Since these are not sentence-ending punctuation but part of the name itself, they need to be excluded from the punctuation check across all locales. The global exception list addresses this use case directly.

## Changes

### `src/rules/ResourceSentenceEnding.js`

**Feature**
- Added `exceptions?: string[]` to `ResourceSentenceEndingFixedOptions` typedef — when placed at the top level of the param config, exceptions apply to all locales
- Initialized `this.globalExceptions` as a `Set<string>` in the constructor (values are normalized with `toLowerCase().trim()` at storage time)
- Added Exception 3 in `matchString` to check global exceptions before locale-specific ones (existing locale-specific check renumbered to Exception 4)
- `normalizedSource` is computed once and reused across both exception checks

**Refactor**
- Changed `this.exceptionsMap[language]` from `string[]` to `Set<string>`, with normalization applied at storage time
- Replaced `Array.some()` (O(n)) with `Set.has()` (O(1)) for exception lookups

**Bug Fix**
- Corrected the constructor `@param` JSDoc type from `ResourceSentenceEndingOptions` to `{ param?: ResourceSentenceEndingOptions, sourceLocale?: string, getLogger?: Function }`, accurately reflecting that locale config lives under `options.param`, not `options` itself

### `test/rules/ResourceSentenceEnding.test.js`

- Added a `zh-Hans-CN` locale-specific exception test case in the `Explicit exception list` block
- Added a new `Global exception list` describe block with 4 test cases:
  - A string in the global exception list is skipped across ja-JP, zh-Hans-CN, and de-DE
  - A string not in the global exception list is still checked
  - A company name with multiple periods (e.g. `ABC.Corp.`) is correctly skipped when added to the global exception list
  - Global and locale-specific exceptions work correctly when combined

### `docs/resource-sentence-ending.md`

- Added global exceptions documentation and examples to the Exception Lists section
- Updated the Combined Configuration Example to include a top-level `exceptions` field
- Updated the Configuration Behavior note and Exception Behaviors section to distinguish between global and locale-specific exceptions

## Config Example

```json
{
  "rulesets": {
    "myset": {
      "resource-sentence-ending": {
        "exceptions": [
          "LG Electronics.",
          "ABC.Corp.",
          "Please see the Dr."
        ],
        "de-DE": {
          "exceptions": ["German-only exception."]
        }
      }
    }
  }
}