### PR TITLE
Add support for named loctool config files and for path templates in the javascript resources

### DIFF
--- a/.changeset/cute-sites-film.md
+++ b/.changeset/cute-sites-film.md
@@ -6,6 +6,9 @@
   callers to use a different base file name for loctool config files
   in case there is a conflict with some other packages
   that uses "project.json" as its config file as well.
+- By default, loctool now recognizes both loctool-config.json and
+  project.json as config files during the tree walk. loctool init
+  writes loctool-config.json unless --configFileBaseName is set.
 - Add support for recognizing config files as being loctool
   style config files or not. If not recognized, then they are
   not used to indicate a new subproject.

--- a/.changeset/cute-sites-film.md
+++ b/.changeset/cute-sites-film.md
@@ -1,0 +1,11 @@
+---
+"loctool": minor
+---
+
+- Add support for the --configFile parameter that allows
+  callers to use a different file name for the config files
+  in case there is a conflict with some other packages
+  that uses "project.json" as its config file as well.
+- Add support for recognizing config files as being loctool
+  style config files or not. If not recognized, then they are
+  not used to indicate a new subproject.

--- a/.changeset/cute-sites-film.md
+++ b/.changeset/cute-sites-film.md
@@ -2,8 +2,8 @@
 "loctool": minor
 ---
 
-- Add support for the --configFile parameter that allows
-  callers to use a different file name for the config files
+- Add support for the --configFileBaseName parameter that allows
+  callers to use a different base file name for loctool config files
   in case there is a conflict with some other packages
   that uses "project.json" as its config file as well.
 - Add support for recognizing config files as being loctool

--- a/.changeset/smart-pumas-change.md
+++ b/.changeset/smart-pumas-change.md
@@ -1,0 +1,10 @@
+---
+"ilib-loctool-javascript-resource": minor
+---
+
+- Add support for the settings.javascript.template setting
+  so that callers can use a regular loctool-style formatted
+  path template if they like
+- default behaviour is the same as it was before, which is
+  to get the resource file path from the this.pathName if
+  it exists or from the resourceDirs.js setting as before

--- a/packages/ilib-loctool-javascript-resource/JavaScriptResourceFile.js
+++ b/packages/ilib-loctool-javascript-resource/JavaScriptResourceFile.js
@@ -147,6 +147,30 @@ function clean(str) {
 
 /**
  * @private
+ * JsonFile passes its source .json path as pathName for cache disambiguation; that is
+ * not the resource output path unless a javascript.template computes the target.
+ * @param {String} pathName
+ * @returns {boolean}
+ */
+function isDelegatingSourcePath(pathName) {
+    return !!(pathName && path.extname(pathName).toLowerCase() === ".json");
+}
+
+/**
+ * @private
+ * @param {Object|undefined} jsSettings project settings.javascript
+ * @returns {String} extension including leading dot
+ */
+function getOutputExtension(jsSettings) {
+    if (jsSettings && jsSettings.extension) {
+        var ext = jsSettings.extension;
+        return ext.charAt(0) === "." ? ext : "." + ext;
+    }
+    return ".js";
+}
+
+/**
+ * @private
  */
 JavaScriptResourceFile.prototype.getDefaultSpec = function() {
     if (!this.defaultSpec) {
@@ -221,21 +245,14 @@ JavaScriptResourceFile.prototype.getContent = function() {
  * given project, context, and locale.
  */
 JavaScriptResourceFile.prototype.getResourceFilePath = function(locale, flavor) {
-    // Only treat pathName as the output path when it is a JS file. Callers
-    // (e.g. JsonFile delegating localize) may pass a source path like
-    // "dir/strings.json" for cache disambiguation; output still uses the
-    // project javascript template under resourceDirs.
-    if (this.pathName && /\.js$/i.test(this.pathName)) return this.pathName;
-
     var localeDir, dir, newPath, spec;
     locale = locale || this.locale;
 
-    // For delegated sources (eg. json plugin passing "dir/strings.json"), honor
-    // javascript.template when configured. This allows callers to preserve source
-    // directory structure or use other placeholders in output paths.
     var jsSettings = this.project && this.project.settings && this.project.settings.javascript;
     var template = jsSettings && jsSettings.template;
-    if (template && this.pathName && !/\.js$/i.test(this.pathName)) {
+
+    // javascript.template maps a source path (often .json from JsonFile) to the output path.
+    if (template && this.pathName) {
         var localeSpec = (typeof locale === "string") ? locale :
             ((locale && typeof locale.getSpec === "function") ? locale.getSpec() : this.locale.getSpec());
         var relativePath = this.API.utils.formatPath(template, {
@@ -248,13 +265,18 @@ JavaScriptResourceFile.prototype.getResourceFilePath = function(locale, flavor) 
         return path.normalize(newPath);
     }
 
+    // Use pathName as the output path when the caller set one (any extension).
+    if (this.pathName && !isDelegatingSourcePath(this.pathName)) {
+        return this.pathName;
+    }
+
     var localeDefaults = this.project.settings && this.project.settings.localeDefaults;
     var defaultSpec = localeDefaults ?
         this.API.utils.getLocaleDefault(locale, flavor, localeDefaults) :
         ((typeof locale === "string") ? locale :
             ((locale && typeof locale.getSpec === "function") ? locale.getSpec() : this.locale.getSpec()));
 
-    var filename = defaultSpec + ".js";
+    var filename = defaultSpec + getOutputExtension(jsSettings);
 
     dir = path.join(this.project.target, this.project.getResourceDirs("js")[0] ||this.project.getResourceDirs("javascript")[0] || ".");
     newPath = path.join(dir, filename);
@@ -275,11 +297,13 @@ JavaScriptResourceFile.prototype.write = function() {
 
             // must be a new file, so create the name
             this.pathName = this.getResourceFilePath();
-        } else if (!/\.js$/i.test(this.pathName)) {
-            this.logger.trace("Non-JS pathName is a delegating source path; computing JS output path");
-            this.pathName = this.getResourceFilePath();
-            this.defaultSpec = this.locale.getSpec();
         } else {
+            var jsSettings = this.project && this.project.settings && this.project.settings.javascript;
+            var template = jsSettings && jsSettings.template;
+            if ((template && this.pathName) || isDelegatingSourcePath(this.pathName)) {
+                this.logger.trace("Computing resource output path from template or resourceDirs");
+                this.pathName = this.getResourceFilePath();
+            }
             this.defaultSpec = this.locale.getSpec();
         }
 

--- a/packages/ilib-loctool-javascript-resource/JavaScriptResourceFile.js
+++ b/packages/ilib-loctool-javascript-resource/JavaScriptResourceFile.js
@@ -230,7 +230,29 @@ JavaScriptResourceFile.prototype.getResourceFilePath = function(locale, flavor) 
     var localeDir, dir, newPath, spec;
     locale = locale || this.locale;
 
-    var defaultSpec = this.getDefaultSpec();
+    // For delegated sources (eg. json plugin passing "dir/strings.json"), honor
+    // javascript.template when configured. This allows callers to preserve source
+    // directory structure or use other placeholders in output paths.
+    var jsSettings = this.project && this.project.settings && this.project.settings.javascript;
+    var template = jsSettings && jsSettings.template;
+    if (template && this.pathName && !/\.js$/i.test(this.pathName)) {
+        var localeSpec = (typeof locale === "string") ? locale :
+            ((locale && typeof locale.getSpec === "function") ? locale.getSpec() : this.locale.getSpec());
+        var relativePath = this.API.utils.formatPath(template, {
+            sourcepath: this.pathName,
+            locale: localeSpec
+        });
+        newPath = path.join(this.project.target, relativePath);
+
+        this.logger.trace("Getting resource file path from javascript.template for locale " + localeSpec + ": " + newPath);
+        return path.normalize(newPath);
+    }
+
+    var localeDefaults = this.project.settings && this.project.settings.localeDefaults;
+    var defaultSpec = localeDefaults ?
+        this.API.utils.getLocaleDefault(locale, flavor, localeDefaults) :
+        ((typeof locale === "string") ? locale :
+            ((locale && typeof locale.getSpec === "function") ? locale.getSpec() : this.locale.getSpec()));
 
     var filename = defaultSpec + ".js";
 

--- a/packages/ilib-loctool-javascript-resource/test/JavaScriptResourceFile.test.js
+++ b/packages/ilib-loctool-javascript-resource/test/JavaScriptResourceFile.test.js
@@ -653,6 +653,45 @@ describe("javascriptresourcefile", function() {
         expect(jsrf.getResourceFilePath()).toBe("path/to/foo.js");
     });
 
+    test("JavaScriptResourceFileGetResourceFilePathAlreadyHasCustomExtensionPath", function() {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p2,
+            locale: "de-DE",
+            pathName: "path/to/strings.mjs"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath()).toBe("path/to/strings.mjs");
+    });
+
+    test("JavaScriptResourceFileGetResourceFilePathLegacyUsesJavascriptExtensionSetting", function() {
+        expect.assertions(2);
+
+        var pExt = new CustomProject({
+            id: "webapp",
+            sourceLocale: "en-US",
+            resourceDirs: {
+                "js": "localized_js"
+            }
+        }, "./testfiles", {
+            locales: ["de-DE"],
+            javascript: {
+                extension: "tsx"
+            },
+            identify: true
+        });
+
+        var jsrf = new JavaScriptResourceFile({
+            project: pExt,
+            locale: "de-DE"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath()).toBe("testfiles/localized_js/de-DE.tsx");
+    });
+
     test("JavaScriptResourceFileGetResourceFilePathJsonDelegatingSourceUsesTemplate", function() {
         expect.assertions(2);
 

--- a/packages/ilib-loctool-javascript-resource/test/JavaScriptResourceFile.test.js
+++ b/packages/ilib-loctool-javascript-resource/test/JavaScriptResourceFile.test.js
@@ -20,6 +20,7 @@
 if (!JavaScriptResourceFile) {
     var JavaScriptResourceFile = require("../JavaScriptResourceFile.js");
     var CustomProject = require("loctool/lib/CustomProject.js");
+    var Locale = require("ilib-locale");
 }
 
 function diff(a, b) {
@@ -158,6 +159,69 @@ var p6 = new CustomProject({
         header: "// This is a generated file. DO NOT MODIFY BY HAND\nexport default ",
         footer: ";\n"
     },
+    identify: true
+});
+
+// Project with javascript.template for output path generation
+var p7 = new CustomProject({
+    id: "webapp",
+    sourceLocale: "en-US",
+    resourceDirs: {
+        "js": "localized_js"
+    }
+}, "./testfiles", {
+    locales:["en-GB", "de-DE", "de-AT"],
+    javascript: {
+        template: "[dir]/[locale].js"
+    },
+    identify: true
+});
+
+// Project with javascript.template and localeDefaults (template uses full locale spec)
+var p9 = new CustomProject({
+    id: "webapp",
+    sourceLocale: "en-US",
+    resourceDirs: {
+        "js": "localized_js"
+    }
+}, "./testfiles", {
+    locales:["en-GB", "de-DE", "de-AT"],
+    localeDefaults: {
+        "de": {
+            def: "de-DE",
+            spec: "de"
+        }
+    },
+    javascript: {
+        template: "[dir]/[locale].js"
+    },
+    identify: true
+});
+
+// Project with javascript.template using [localeDir]
+var p10 = new CustomProject({
+    id: "webapp",
+    sourceLocale: "en-US",
+    resourceDirs: {
+        "js": "localized_js"
+    }
+}, "./testfiles", {
+    locales:["en-GB", "de-DE", "ja-JP", "zh-Hans-CN"],
+    javascript: {
+        template: "[dir]/[localeDir]/messages.js"
+    },
+    identify: true
+});
+
+// Project with no javascript.template: should keep legacy resourceDirs behavior
+var p8 = new CustomProject({
+    id: "webapp",
+    sourceLocale: "en-US",
+    resourceDirs: {
+        "js": "localized_js"
+    }
+}, "./testfiles", {
+    locales:["en-GB", "de-DE", "de-AT"],
     identify: true
 });
 
@@ -601,6 +665,206 @@ describe("javascriptresourcefile", function() {
         expect(jsrf).toBeTruthy();
 
         expect(jsrf.getResourceFilePath()).toBe("testfiles/localized_js/de.js");
+    });
+
+    test("JavaScriptResourceFileGetResourceFilePathJsonDelegatingSourceUsesJavascriptTemplateWhenConfigured", function() {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p7,
+            locale: "de-DE",
+            pathName: "json/strings.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+
+        // With a configured javascript.template, output path should be based on source path + locale.
+        expect(jsrf.getResourceFilePath()).toBe("testfiles/json/de-DE.js");
+    });
+
+    test("JavaScriptResourceFileGetResourceFilePathJsonDelegatingSourceFallsBackWithoutJavascriptTemplate", function() {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p8,
+            locale: "de-DE",
+            pathName: "json/strings.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+
+        // Without javascript.template, keep legacy behavior (resourceDirs + locale.js).
+        expect(jsrf.getResourceFilePath()).toBe("testfiles/localized_js/de-DE.js");
+    });
+
+    test.each([
+        ["de-DE", "testfiles/json/de-DE.js"],
+        ["fr-FR", "testfiles/json/fr-FR.js"],
+        ["ja-JP", "testfiles/json/ja-JP.js"],
+        ["zh-Hans-CN", "testfiles/json/zh-Hans-CN.js"],
+        ["en-GB", "testfiles/json/en-GB.js"]
+    ])("JavaScriptResourceFileGetResourceFilePathWithJavascriptTemplate locale %s", function(locale, expectedPath) {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p7,
+            locale: locale,
+            pathName: "json/strings.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath()).toBe(expectedPath);
+    });
+
+    test.each([
+        ["de-DE", "testfiles/watermark-editor/i18n/de-DE.js"],
+        ["fr-FR", "testfiles/watermark-editor/i18n/fr-FR.js"],
+        ["ja-JP", "testfiles/watermark-editor/i18n/ja-JP.js"]
+    ])("JavaScriptResourceFileGetResourceFilePathWithJavascriptTemplateNestedSource locale %s", function(locale, expectedPath) {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p7,
+            locale: locale,
+            pathName: "watermark-editor/i18n/en-US.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath()).toBe(expectedPath);
+    });
+
+    test("JavaScriptResourceFileGetResourceFilePathWithJavascriptTemplateUsesFullLocaleNotDefaultSpec", function() {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p9,
+            locale: "de-AT",
+            pathName: "json/strings.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+        // Template uses the file's locale spec, not localeDefaults.spec ("de").
+        expect(jsrf.getResourceFilePath()).toBe("testfiles/json/de-AT.js");
+    });
+
+    test.each([
+        ["de-DE", "testfiles/json/de/DE/messages.js"],
+        ["ja-JP", "testfiles/json/ja/JP/messages.js"],
+        ["zh-Hans-CN", "testfiles/json/zh/Hans/CN/messages.js"]
+    ])("JavaScriptResourceFileGetResourceFilePathWithJavascriptTemplateLocaleDir locale %s", function(locale, expectedPath) {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p10,
+            locale: locale,
+            pathName: "json/strings.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath()).toBe(expectedPath);
+    });
+
+    test.each([
+        ["de-DE", "testfiles/json/de-DE.js"],
+        ["fr-FR", "testfiles/json/fr-FR.js"],
+        ["ja-JP", "testfiles/json/ja-JP.js"],
+        ["zh-Hans-CN", "testfiles/json/zh-Hans-CN.js"]
+    ])("JavaScriptResourceFileGetResourceFilePathWithJavascriptTemplateLocaleParam %s", function(pathLocale, expectedPath) {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p7,
+            locale: "en-US",
+            pathName: "json/strings.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath(pathLocale)).toBe(expectedPath);
+    });
+
+    test("JavaScriptResourceFileGetResourceFilePathWithJavascriptTemplateLocaleObjectParam", function() {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p7,
+            locale: "en-US",
+            pathName: "json/strings.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath(new Locale("de-DE"))).toBe("testfiles/json/de-DE.js");
+    });
+
+    test.each([
+        ["de-DE", "testfiles/watermark-editor/i18n/de-DE.js"],
+        ["fr-FR", "testfiles/watermark-editor/i18n/fr-FR.js"]
+    ])("JavaScriptResourceFileGetResourceFilePathWithJavascriptTemplateLocaleParamNested %s", function(pathLocale, expectedPath) {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p7,
+            locale: "en-US",
+            pathName: "watermark-editor/i18n/en-US.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath(pathLocale)).toBe(expectedPath);
+    });
+
+    test.each([
+        ["de-DE", "testfiles/json/de/DE/messages.js"],
+        ["ja-JP", "testfiles/json/ja/JP/messages.js"]
+    ])("JavaScriptResourceFileGetResourceFilePathWithJavascriptTemplateLocaleDirLocaleParam %s", function(pathLocale, expectedPath) {
+        expect.assertions(2);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p10,
+            locale: "en-US",
+            pathName: "json/strings.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath(pathLocale)).toBe(expectedPath);
+    });
+
+    test("JavaScriptResourceFileGetResourceFilePathLocaleParamOverridesInstanceLocale", function() {
+        expect.assertions(3);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p7,
+            locale: "de-DE",
+            pathName: "json/strings.json"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath()).toBe("testfiles/json/de-DE.js");
+        expect(jsrf.getResourceFilePath("fr-FR")).toBe("testfiles/json/fr-FR.js");
+    });
+
+    test("JavaScriptResourceFileGetResourceFilePathLocaleParamLegacyWithLocaleDefaults", function() {
+        expect.assertions(3);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p2,
+            locale: "de-DE"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath()).toBe("testfiles/localized_js/de.js");
+        expect(jsrf.getResourceFilePath("de-AT")).toBe("testfiles/localized_js/de-AT.js");
+    });
+
+    test("JavaScriptResourceFileGetResourceFilePathLocaleParamLegacyWithoutLocaleDefaults", function() {
+        expect.assertions(3);
+
+        var jsrf = new JavaScriptResourceFile({
+            project: p,
+            locale: "de-DE"
+        });
+
+        expect(jsrf).toBeTruthy();
+        expect(jsrf.getResourceFilePath()).toBe("testfiles/localized_js/de-DE.js");
+        expect(jsrf.getResourceFilePath("fr-FR")).toBe("testfiles/localized_js/fr-FR.js");
     });
 
     test("JavaScriptResourceFileGetContentDefaultLocale", function() {

--- a/packages/loctool/README.md
+++ b/packages/loctool/README.md
@@ -38,7 +38,7 @@ Running the Tool
 
 ### Basic Operation
 
-1. Create a project.json configuration file for your project
+1. Create a loctool project configuration file for your project
 1. Run the loctool to produce a set of xliff files with new strings to translate in them
 1. Send the xliff files to your translators for translation and, some time
 later, receive the translations back
@@ -49,14 +49,26 @@ since the last time that the loctool was run.
 
 ### Configuration
 
-To run the tool, you will need to create a project.json configuration file for
-each project and place it in the root of that project. The presence of a project.json
+To run the tool, you will need to create a loctool project configuration file for
+each project and place it in the root of that project. By default, loctool looks for
+a file named `loctool-config.json` or `project.json` in each directory. If both are
+present, `loctool-config.json` is preferred. The presence of a valid loctool config
 file indicates to the loctool that it has found the root of a project.
 
-The easiest way to create a new project.json file for a particular directory is
+Loctool validates config files before using them. A file must contain the required
+loctool properties (`id`, `name`, and `projectType`) to be treated as a loctool
+project. This means that other `project.json` files in your tree, such as those
+used by Nx, are ignored.
+
+The easiest way to create a new config file for a particular directory is
 to use the `loctool init` command. This will ask you a few questions and generate
-a new project.json file in the current directory. You can use this as a starting
-point for your project, and then edit it to customize any settings.
+a new `loctool-config.json` file in the current directory by default. You can use
+this as a starting point for your project, and then edit it to customize any
+settings.
+
+Use `--configFileBaseName` to search for or create a config file with a different
+name. For example, `loctool init --configFileBaseName project.json` writes
+`project.json` instead of `loctool-config.json`.
 
 ```
 > node node_modules/.bin/loctool.js init
@@ -68,24 +80,23 @@ Project Initialize
 Full name of this project: myproject
 Type of this project (web, swift, iosobjc, android, custom) [custom]:
 Source locale [en-US]:
-22:52:57 INFO loctool.loctool: Wrote file project.json
+22:52:57 INFO loctool.loctool: Wrote file loctool-config.json
 22:52:57 INFO loctool.loctool: Done
-> cat project.json
+> cat loctool-config.json
 {
+    "$schema": "https://github.com/iLib-js/ilib-mono/packages/loctool/loctool-project-v1.schema.json",
     "name": "myproject",
     "id": "myproject",
     "sourceLocale": "en-US",
     "pseudoLocale": "zxx-XX",
-    "resourceDirs": {
-        "javascript": "target",
-        "md": "target"
-    },
     "includes": [],
     "excludes": [
         ".git",
         ".github",
         "test",
-        "node_modules"
+        "node_modules",
+        "package.json",
+        "loctool-config.json"
     ],
     "settings": {
         "locales": [
@@ -110,7 +121,7 @@ Source locale [en-US]:
 >
 ```
 
-The project.json file minimally contains the name, id, and projectType
+The config file minimally contains the name, id, and projectType
 properties.
 
 All paths are relative to the root of the project.
@@ -800,8 +811,9 @@ These are the actions which are available:
 
 - localize - localize any projects found in the current directory tree.
   This is the default action.
-- init - create a new project.json file based on the answers to a few
-  questions. This makes it easy to set up a new project for localization.
+- init - create a new loctool-config.json file (or another name with
+  `--configFileBaseName`) based on the answers to a few questions. This makes
+  it easy to set up a new project for localization.
 - merge - merge multiple xliff files together into one. There may be some
   restrictions to this, as xliff v2.0 format files cannot contain translations
   to multiple languages.

--- a/packages/loctool/lib/Project.js
+++ b/packages/loctool/lib/Project.js
@@ -917,7 +917,7 @@ Project.prototype.getConfig = function(settings) {
             "test",
             "node_modules",
             "package.json",
-            settings.configFileBaseName || "project.json"
+            projectConfig.getConfigFileBaseName(settings)
         ],
         settings: {
             locales: ["en-GB", "de-DE", "fr-FR", "it-IT", "es-ES", "pt-BR", "ja-JP", "zh-Hans-CN", "ko-KR"]

--- a/packages/loctool/lib/Project.js
+++ b/packages/loctool/lib/Project.js
@@ -915,7 +915,7 @@ Project.prototype.getConfig = function(settings) {
             "test",
             "node_modules",
             "package.json",
-            "project.json"
+            settings.configFile || "project.json"
         ],
         settings: {
             locales: ["en-GB", "de-DE", "fr-FR", "it-IT", "es-ES", "pt-BR", "ja-JP", "zh-Hans-CN", "ko-KR"]

--- a/packages/loctool/lib/Project.js
+++ b/packages/loctool/lib/Project.js
@@ -35,6 +35,7 @@ var conversions = require("./ResourceConvert.js");
 var pluralCategories = require("../db/pluralCategories.json");
 var log4js = require("log4js");
 var iff = require("./IntermediateFileFactory.js");
+var projectConfig = require("./projectConfig.js");
 
 var getIntermediateFile = iff.getIntermediateFile;
 var getIntermediateFileExtension = iff.getIntermediateFileExtension;
@@ -903,6 +904,7 @@ Project.prototype.getConfig = function(settings) {
     logger.trace("Project get config");
 
     return {
+        "$schema": projectConfig.LOCTOOL_SCHEMA,
         name: this.options.name,
         id: this.options.id || this.options.name,
         sourceLocale: this.sourceLocale,

--- a/packages/loctool/lib/Project.js
+++ b/packages/loctool/lib/Project.js
@@ -917,7 +917,7 @@ Project.prototype.getConfig = function(settings) {
             "test",
             "node_modules",
             "package.json",
-            settings.configFile || "project.json"
+            settings.configFileBaseName || "project.json"
         ],
         settings: {
             locales: ["en-GB", "de-DE", "fr-FR", "it-IT", "es-ES", "pt-BR", "ja-JP", "zh-Hans-CN", "ko-KR"]

--- a/packages/loctool/lib/ProjectFactory.js
+++ b/packages/loctool/lib/ProjectFactory.js
@@ -54,56 +54,54 @@ var projectCache = {};
  * of a project.
  */
 var ProjectFactory = function ProjectFactory(dir, settings) {
-    var configFileBaseName = ProjectFactory.getConfigFileBaseName(settings);
-    var pathName = path.join(dir, configFileBaseName);
-    logger.debug("checking for the existence of " + pathName);
-    if (fs.existsSync(pathName)) {
-        var data = fs.readFileSync(pathName, 'utf8');
-        if (data.length > 0) {
-            var projectProps;
-            try {
-                projectProps = JSON.parse(data);
-            } catch (e) {
-                logger.warn("Found " + configFileBaseName + " in " + dir + " but it is not valid JSON; ignoring.");
-                return undefined;
-            }
-
-            var validation = ProjectFactory.validateLoctoolConfig(projectProps);
-            if (!validation.valid) {
-                logger.warn("Found " + configFileBaseName + " in " + dir + " but it is not a valid loctool project config (" + validation.reason + "); ignoring.");
-                return undefined;
-            }
-
-            if (validation.unknownProperties && validation.unknownProperties.length > 0) {
-                validation.unknownProperties.forEach(function(prop) {
-                    logger.warn("Unknown property \"" + prop + "\" in " + pathName);
-                });
-            }
-
-            projectProps.settings = _mergeSettings(projectProps.settings, settings);
-            settings = settings || {locales:[""]};
-            var project, projectType = projectTypes[projectProps.projectType];
-            if (!projectProps.projectType || !projectType) {
-                project = new CustomProject(projectProps, dir, settings);
-            } else {
-                project = new projectType(projectProps, dir, settings);
-            }
-            projectCache[project.getProjectId()] = project;
-            return project;
+    var configFileBaseNames = ProjectFactory.getConfigFileBaseNames(settings);
+    for (var i = 0; i < configFileBaseNames.length; i++) {
+        var configFileBaseName = configFileBaseNames[i];
+        var pathName = path.join(dir, configFileBaseName);
+        logger.debug("checking for the existence of " + pathName);
+        if (!fs.existsSync(pathName)) {
+            logger.debug("not there");
+            continue;
         }
-    } else {
-        logger.debug("not there");
+
+        var data = fs.readFileSync(pathName, 'utf8');
+        if (data.length === 0) {
+            continue;
+        }
+
+        var projectProps;
+        try {
+            projectProps = JSON.parse(data);
+        } catch (e) {
+            logger.warn("Found " + configFileBaseName + " in " + dir + " but it is not valid JSON; ignoring.");
+            continue;
+        }
+
+        var validation = ProjectFactory.validateLoctoolConfig(projectProps);
+        if (!validation.valid) {
+            logger.warn("Found " + configFileBaseName + " in " + dir + " but it is not a valid loctool project config (" + validation.reason + "); ignoring.");
+            continue;
+        }
+
+        if (validation.unknownProperties && validation.unknownProperties.length > 0) {
+            validation.unknownProperties.forEach(function(prop) {
+                logger.warn("Unknown property \"" + prop + "\" in " + pathName);
+            });
+        }
+
+        projectProps.settings = _mergeSettings(projectProps.settings, settings);
+        settings = settings || {locales:[""]};
+        var project, projectType = projectTypes[projectProps.projectType];
+        if (!projectProps.projectType || !projectType) {
+            project = new CustomProject(projectProps, dir, settings);
+        } else {
+            project = new projectType(projectProps, dir, settings);
+        }
+        projectCache[project.getProjectId()] = project;
+        return project;
     }
     return undefined;
 };
-
-ProjectFactory.defaultConfigFile = projectConfig.DEFAULT_CONFIG_FILE;
-ProjectFactory.LOCTOOL_SCHEMA = projectConfig.LOCTOOL_SCHEMA;
-ProjectFactory.KNOWN_PROJECT_TYPES = projectConfig.KNOWN_PROJECT_TYPES;
-ProjectFactory.ALLOWED_PROPERTIES = projectConfig.ALLOWED_PROPERTIES;
-ProjectFactory.validateLoctoolConfig = projectConfig.validateLoctoolConfig;
-ProjectFactory.getConfigFileBaseName = projectConfig.getConfigFileBaseName;
-ProjectFactory.getInitOutputPath = projectConfig.getInitOutputPath;
 
 /**
  * Return the project with the given name, or undefined if

--- a/packages/loctool/lib/ProjectFactory.js
+++ b/packages/loctool/lib/ProjectFactory.js
@@ -54,8 +54,8 @@ var projectCache = {};
  * of a project.
  */
 var ProjectFactory = function ProjectFactory(dir, settings) {
-    var configFile = ProjectFactory.getConfigFileName(settings);
-    var pathName = path.join(dir, configFile);
+    var configFileBaseName = ProjectFactory.getConfigFileBaseName(settings);
+    var pathName = path.join(dir, configFileBaseName);
     logger.debug("checking for the existence of " + pathName);
     if (fs.existsSync(pathName)) {
         var data = fs.readFileSync(pathName, 'utf8');
@@ -64,13 +64,13 @@ var ProjectFactory = function ProjectFactory(dir, settings) {
             try {
                 projectProps = JSON.parse(data);
             } catch (e) {
-                logger.warn("Found " + configFile + " in " + dir + " but it is not valid JSON; ignoring.");
+                logger.warn("Found " + configFileBaseName + " in " + dir + " but it is not valid JSON; ignoring.");
                 return undefined;
             }
 
             var validation = ProjectFactory.validateLoctoolConfig(projectProps);
             if (!validation.valid) {
-                logger.warn("Found " + configFile + " in " + dir + " but it is not a valid loctool project config (" + validation.reason + "); ignoring.");
+                logger.warn("Found " + configFileBaseName + " in " + dir + " but it is not a valid loctool project config (" + validation.reason + "); ignoring.");
                 return undefined;
             }
 
@@ -102,7 +102,7 @@ ProjectFactory.LOCTOOL_SCHEMA = projectConfig.LOCTOOL_SCHEMA;
 ProjectFactory.KNOWN_PROJECT_TYPES = projectConfig.KNOWN_PROJECT_TYPES;
 ProjectFactory.ALLOWED_PROPERTIES = projectConfig.ALLOWED_PROPERTIES;
 ProjectFactory.validateLoctoolConfig = projectConfig.validateLoctoolConfig;
-ProjectFactory.getConfigFileName = projectConfig.getConfigFileName;
+ProjectFactory.getConfigFileBaseName = projectConfig.getConfigFileBaseName;
 
 /**
  * Return the project with the given name, or undefined if

--- a/packages/loctool/lib/ProjectFactory.js
+++ b/packages/loctool/lib/ProjectFactory.js
@@ -38,11 +38,12 @@ var projectTypes = {
 };
 
 var projectCache = {};
+var defaultConfigFile = "project.json";
 
 /**
  * Create a new project of the correct type based on
- * the given dir. If the dir contains a project.json
- * file, this factory will return a project of the
+ * the given dir. If the dir contains the configured
+ * project config file, this factory will return a project of the
  * correct type. If not, it will return undefined.
  *
  * @param {String} path to the directory containing the root of the project
@@ -53,7 +54,8 @@ var projectCache = {};
  * of a project.
  */
 var ProjectFactory = function ProjectFactory(dir, settings) {
-    var pathName = path.join(dir, "project.json");
+    var configFile = ProjectFactory.getConfigFileName(settings);
+    var pathName = path.join(dir, configFile);
     logger.debug("checking for the existence of " + pathName);
     if (fs.existsSync(pathName)) {
         var data = fs.readFileSync(pathName, 'utf8');
@@ -74,6 +76,18 @@ var ProjectFactory = function ProjectFactory(dir, settings) {
         logger.debug("not there");
     }
     return undefined;
+};
+
+ProjectFactory.defaultConfigFile = defaultConfigFile;
+
+/**
+ * Return the name of the project config file to use.
+ *
+ * @param {Object} settings an object containing the current settings
+ * @returns {String} the config file name
+ */
+ProjectFactory.getConfigFileName = function(settings) {
+    return (settings && settings.configFile) || defaultConfigFile;
 };
 
 /**

--- a/packages/loctool/lib/ProjectFactory.js
+++ b/packages/loctool/lib/ProjectFactory.js
@@ -103,6 +103,7 @@ ProjectFactory.KNOWN_PROJECT_TYPES = projectConfig.KNOWN_PROJECT_TYPES;
 ProjectFactory.ALLOWED_PROPERTIES = projectConfig.ALLOWED_PROPERTIES;
 ProjectFactory.validateLoctoolConfig = projectConfig.validateLoctoolConfig;
 ProjectFactory.getConfigFileBaseName = projectConfig.getConfigFileBaseName;
+ProjectFactory.getInitOutputPath = projectConfig.getInitOutputPath;
 
 /**
  * Return the project with the given name, or undefined if

--- a/packages/loctool/lib/ProjectFactory.js
+++ b/packages/loctool/lib/ProjectFactory.js
@@ -1,7 +1,7 @@
 /*
  * ProjectFactory.js - factory object that creates project instances
  *
- * Copyright © 2016-2017, HealthTap, Inc.
+ * Copyright © 2016-2017, 2026, HealthTap, Inc. and JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ var ObjectiveCProject = require("./ObjectiveCProject.js");
 var SwiftProject = require("./SwiftProject.js");
 
 var CustomProject = require("./CustomProject.js");
+var projectConfig = require("./projectConfig.js");
 
 var logger = log4js.getLogger("loctool.lib.ProjectFactory");
 
@@ -38,7 +39,6 @@ var projectTypes = {
 };
 
 var projectCache = {};
-var defaultConfigFile = "project.json";
 
 /**
  * Create a new project of the correct type based on
@@ -60,7 +60,26 @@ var ProjectFactory = function ProjectFactory(dir, settings) {
     if (fs.existsSync(pathName)) {
         var data = fs.readFileSync(pathName, 'utf8');
         if (data.length > 0) {
-            var projectProps = JSON.parse(data);
+            var projectProps;
+            try {
+                projectProps = JSON.parse(data);
+            } catch (e) {
+                logger.warn("Found " + configFile + " in " + dir + " but it is not valid JSON; ignoring.");
+                return undefined;
+            }
+
+            var validation = ProjectFactory.validateLoctoolConfig(projectProps);
+            if (!validation.valid) {
+                logger.warn("Found " + configFile + " in " + dir + " but it is not a valid loctool project config (" + validation.reason + "); ignoring.");
+                return undefined;
+            }
+
+            if (validation.unknownProperties && validation.unknownProperties.length > 0) {
+                validation.unknownProperties.forEach(function(prop) {
+                    logger.warn("Unknown property \"" + prop + "\" in " + pathName);
+                });
+            }
+
             projectProps.settings = _mergeSettings(projectProps.settings, settings);
             settings = settings || {locales:[""]};
             var project, projectType = projectTypes[projectProps.projectType];
@@ -78,17 +97,12 @@ var ProjectFactory = function ProjectFactory(dir, settings) {
     return undefined;
 };
 
-ProjectFactory.defaultConfigFile = defaultConfigFile;
-
-/**
- * Return the name of the project config file to use.
- *
- * @param {Object} settings an object containing the current settings
- * @returns {String} the config file name
- */
-ProjectFactory.getConfigFileName = function(settings) {
-    return (settings && settings.configFile) || defaultConfigFile;
-};
+ProjectFactory.defaultConfigFile = projectConfig.DEFAULT_CONFIG_FILE;
+ProjectFactory.LOCTOOL_SCHEMA = projectConfig.LOCTOOL_SCHEMA;
+ProjectFactory.KNOWN_PROJECT_TYPES = projectConfig.KNOWN_PROJECT_TYPES;
+ProjectFactory.ALLOWED_PROPERTIES = projectConfig.ALLOWED_PROPERTIES;
+ProjectFactory.validateLoctoolConfig = projectConfig.validateLoctoolConfig;
+ProjectFactory.getConfigFileName = projectConfig.getConfigFileName;
 
 /**
  * Return the project with the given name, or undefined if

--- a/packages/loctool/lib/ProjectFactory.js
+++ b/packages/loctool/lib/ProjectFactory.js
@@ -54,7 +54,7 @@ var projectCache = {};
  * of a project.
  */
 var ProjectFactory = function ProjectFactory(dir, settings) {
-    var configFileBaseNames = ProjectFactory.getConfigFileBaseNames(settings);
+    var configFileBaseNames = projectConfig.getConfigFileBaseNames(settings);
     for (var i = 0; i < configFileBaseNames.length; i++) {
         var configFileBaseName = configFileBaseNames[i];
         var pathName = path.join(dir, configFileBaseName);
@@ -77,7 +77,7 @@ var ProjectFactory = function ProjectFactory(dir, settings) {
             continue;
         }
 
-        var validation = ProjectFactory.validateLoctoolConfig(projectProps);
+        var validation = projectConfig.validateLoctoolConfig(projectProps);
         if (!validation.valid) {
             logger.warn("Found " + configFileBaseName + " in " + dir + " but it is not a valid loctool project config (" + validation.reason + "); ignoring.");
             continue;

--- a/packages/loctool/lib/projectConfig.js
+++ b/packages/loctool/lib/projectConfig.js
@@ -1,0 +1,164 @@
+/*
+ * projectConfig.js - constants and validation for loctool project config files
+ *
+ * Copyright © 2026, HealthTap, Inc. and JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @type {string} JSON Schema URI written by loctool init and required when $schema is present */
+var LOCTOOL_SCHEMA = "https://github.com/iLib-js/ilib-mono/packages/loctool/loctool-project-v1.schema.json";
+
+var DEFAULT_CONFIG_FILE = "project.json";
+
+/** @type {string[]} loctool projectType values */
+var KNOWN_PROJECT_TYPES = ["android", "iosobjc", "swift", "web", "custom"];
+
+/** @type {string[]} top-level properties recognized by loctool project configs */
+var ALLOWED_PROPERTIES = [
+    "$schema",
+    "name",
+    "id",
+    "projectType",
+    "sourceLocale",
+    "pseudoLocale",
+    "resourceDirs",
+    "resourceFileTypes",
+    "excludes",
+    "includes",
+    "plugins",
+    "settings",
+    "schema",
+    "fileTypes"
+];
+
+/**
+ * Return true if value is a non-empty string.
+ *
+ * @private
+ * @param {*} value
+ * @returns {boolean}
+ */
+function isNonEmptyString(value) {
+    return typeof(value) === "string" && value.length > 0;
+}
+
+/**
+ * Return the name of the project config file to use.
+ *
+ * @param {Object} settings an object containing the current settings
+ * @returns {String} the config file name
+ */
+function getConfigFileName(settings) {
+    return (settings && settings.configFile) || DEFAULT_CONFIG_FILE;
+}
+
+/**
+ * Validate whether parsed JSON is a loctool project configuration.
+ *
+ * @param {Object} props parsed config file contents
+ * @returns {{valid: boolean, reason?: string, unknownProperties?: string[]}}
+ */
+function validateLoctoolConfig(props) {
+    if (!props || typeof(props) !== "object" || Array.isArray(props)) {
+        return {valid: false, reason: "config is not a JSON object"};
+    }
+
+    if (props.$schema !== undefined) {
+        if (props.$schema !== LOCTOOL_SCHEMA) {
+            return {
+                valid: false,
+                reason: "$schema must be \"" + LOCTOOL_SCHEMA + "\" when present"
+            };
+        }
+    }
+
+    var missing = [];
+    if (!isNonEmptyString(props.id)) {
+        missing.push("id");
+    }
+    if (!isNonEmptyString(props.name)) {
+        missing.push("name");
+    }
+    if (!isNonEmptyString(props.projectType)) {
+        missing.push("projectType");
+    }
+
+    if (missing.length > 0) {
+        return {
+            valid: false,
+            reason: missing.length === 1 ?
+                "missing or invalid required property: " + missing.join(", ") :
+                "missing or invalid required properties: " + missing.join(", ")
+        };
+    }
+
+    if (KNOWN_PROJECT_TYPES.indexOf(props.projectType) === -1) {
+        return {
+            valid: false,
+            reason: "projectType must be one of: " + KNOWN_PROJECT_TYPES.join(", ")
+        };
+    }
+
+    if (props.projectType === "custom") {
+        if (!Array.isArray(props.plugins) || props.plugins.length === 0) {
+            return {
+                valid: false,
+                reason: "custom projects require a non-empty plugins array"
+            };
+        }
+    }
+
+    var requiredKeys = ["id", "name", "projectType"];
+    if (props.projectType === "custom") {
+        requiredKeys.push("plugins");
+    }
+
+    var extraKeys = Object.keys(props).filter(function(key) {
+        return requiredKeys.indexOf(key) === -1;
+    });
+
+    if (extraKeys.length === 0) {
+        return {valid: true};
+    }
+
+    var allowedExtras = extraKeys.filter(function(key) {
+        return ALLOWED_PROPERTIES.indexOf(key) !== -1;
+    });
+    var unknownExtras = extraKeys.filter(function(key) {
+        return ALLOWED_PROPERTIES.indexOf(key) === -1;
+    });
+
+    if (allowedExtras.length === 0 && unknownExtras.length > 0) {
+        return {
+            valid: false,
+            reason: "config contains only unrecognized properties: " + unknownExtras.join(", ")
+        };
+    }
+
+    var result = {valid: true};
+    if (unknownExtras.length > 0) {
+        result.unknownProperties = unknownExtras;
+    }
+    return result;
+}
+
+module.exports = {
+    LOCTOOL_SCHEMA: LOCTOOL_SCHEMA,
+    DEFAULT_CONFIG_FILE: DEFAULT_CONFIG_FILE,
+    KNOWN_PROJECT_TYPES: KNOWN_PROJECT_TYPES,
+    ALLOWED_PROPERTIES: ALLOWED_PROPERTIES,
+    getConfigFileName: getConfigFileName,
+    validateLoctoolConfig: validateLoctoolConfig
+};

--- a/packages/loctool/lib/projectConfig.js
+++ b/packages/loctool/lib/projectConfig.js
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+var path = require("path");
+
 /** @type {string} JSON Schema URI written by loctool init and required when $schema is present */
 var LOCTOOL_SCHEMA = "https://github.com/iLib-js/ilib-mono/packages/loctool/loctool-project-v1.schema.json";
 
@@ -62,6 +64,17 @@ function isNonEmptyString(value) {
  */
 function getConfigFileBaseName(settings) {
     return (settings && settings.configFileBaseName) || DEFAULT_CONFIG_FILE;
+}
+
+/**
+ * Return the path where loctool init should write the project config file.
+ *
+ * @param {Object} settings CLI settings (rootDir, configFileBaseName)
+ * @returns {String} output file path
+ */
+function getInitOutputPath(settings) {
+    var rootDir = (settings && settings.rootDir) || ".";
+    return path.join(rootDir, getConfigFileBaseName(settings));
 }
 
 /**
@@ -148,5 +161,6 @@ module.exports = {
     KNOWN_PROJECT_TYPES: KNOWN_PROJECT_TYPES,
     ALLOWED_PROPERTIES: ALLOWED_PROPERTIES,
     getConfigFileBaseName: getConfigFileBaseName,
+    getInitOutputPath: getInitOutputPath,
     validateLoctoolConfig: validateLoctoolConfig
 };

--- a/packages/loctool/lib/projectConfig.js
+++ b/packages/loctool/lib/projectConfig.js
@@ -22,7 +22,17 @@ var path = require("path");
 /** @type {string} JSON Schema URI written by loctool init and required when $schema is present */
 var LOCTOOL_SCHEMA = "https://github.com/iLib-js/ilib-mono/packages/loctool/loctool-project-v1.schema.json";
 
-var DEFAULT_CONFIG_FILE = "project.json";
+/** @type {string} legacy config file name still recognized during the tree walk */
+var LEGACY_CONFIG_FILE = "project.json";
+
+/** @type {string} default config file name written by loctool init */
+var INIT_DEFAULT_CONFIG_FILE = "loctool-config.json";
+
+/** @type {string[]} config file base names searched during the tree walk when --configFileBaseName is not set */
+var DEFAULT_CONFIG_FILES = [INIT_DEFAULT_CONFIG_FILE, LEGACY_CONFIG_FILE];
+
+/** @deprecated use INIT_DEFAULT_CONFIG_FILE or LEGACY_CONFIG_FILE */
+var DEFAULT_CONFIG_FILE = LEGACY_CONFIG_FILE;
 
 /** @type {string[]} loctool projectType values */
 var KNOWN_PROJECT_TYPES = ["android", "iosobjc", "swift", "web", "custom"];
@@ -57,13 +67,41 @@ function isNonEmptyString(value) {
 }
 
 /**
- * Return the base name of the project config file to search for during the tree walk.
+ * Return true when the caller set an explicit config file base name.
+ *
+ * @private
+ * @param {Object} settings
+ * @returns {boolean}
+ */
+function hasExplicitConfigFileBaseName(settings) {
+    return !!(settings && settings.configFileBaseName);
+}
+
+/**
+ * Return the base names of project config files to search for during the tree walk.
+ * When --configFileBaseName is not set, both loctool-config.json and project.json
+ * are tried (in that order).
+ *
+ * @param {Object} settings an object containing the current settings
+ * @returns {String[]} config file base names (not paths)
+ */
+function getConfigFileBaseNames(settings) {
+    if (hasExplicitConfigFileBaseName(settings)) {
+        return [settings.configFileBaseName];
+    }
+    return DEFAULT_CONFIG_FILES.slice();
+}
+
+/**
+ * Return the base name of the project config file for loctool init output and
+ * generated excludes. Defaults to loctool-config.json unless --configFileBaseName
+ * is set.
  *
  * @param {Object} settings an object containing the current settings
  * @returns {String} the config file base name (not a path)
  */
 function getConfigFileBaseName(settings) {
-    return (settings && settings.configFileBaseName) || DEFAULT_CONFIG_FILE;
+    return (settings && settings.configFileBaseName) || INIT_DEFAULT_CONFIG_FILE;
 }
 
 /**
@@ -157,9 +195,13 @@ function validateLoctoolConfig(props) {
 
 module.exports = {
     LOCTOOL_SCHEMA: LOCTOOL_SCHEMA,
+    LEGACY_CONFIG_FILE: LEGACY_CONFIG_FILE,
+    INIT_DEFAULT_CONFIG_FILE: INIT_DEFAULT_CONFIG_FILE,
+    DEFAULT_CONFIG_FILES: DEFAULT_CONFIG_FILES,
     DEFAULT_CONFIG_FILE: DEFAULT_CONFIG_FILE,
     KNOWN_PROJECT_TYPES: KNOWN_PROJECT_TYPES,
     ALLOWED_PROPERTIES: ALLOWED_PROPERTIES,
+    getConfigFileBaseNames: getConfigFileBaseNames,
     getConfigFileBaseName: getConfigFileBaseName,
     getInitOutputPath: getInitOutputPath,
     validateLoctoolConfig: validateLoctoolConfig

--- a/packages/loctool/lib/projectConfig.js
+++ b/packages/loctool/lib/projectConfig.js
@@ -111,19 +111,7 @@ function validateLoctoolConfig(props) {
         };
     }
 
-    if (props.projectType === "custom") {
-        if (!Array.isArray(props.plugins) || props.plugins.length === 0) {
-            return {
-                valid: false,
-                reason: "custom projects require a non-empty plugins array"
-            };
-        }
-    }
-
     var requiredKeys = ["id", "name", "projectType"];
-    if (props.projectType === "custom") {
-        requiredKeys.push("plugins");
-    }
 
     var extraKeys = Object.keys(props).filter(function(key) {
         return requiredKeys.indexOf(key) === -1;

--- a/packages/loctool/lib/projectConfig.js
+++ b/packages/loctool/lib/projectConfig.js
@@ -55,13 +55,13 @@ function isNonEmptyString(value) {
 }
 
 /**
- * Return the name of the project config file to use.
+ * Return the base name of the project config file to search for during the tree walk.
  *
  * @param {Object} settings an object containing the current settings
- * @returns {String} the config file name
+ * @returns {String} the config file base name (not a path)
  */
-function getConfigFileName(settings) {
-    return (settings && settings.configFile) || DEFAULT_CONFIG_FILE;
+function getConfigFileBaseName(settings) {
+    return (settings && settings.configFileBaseName) || DEFAULT_CONFIG_FILE;
 }
 
 /**
@@ -147,6 +147,6 @@ module.exports = {
     DEFAULT_CONFIG_FILE: DEFAULT_CONFIG_FILE,
     KNOWN_PROJECT_TYPES: KNOWN_PROJECT_TYPES,
     ALLOWED_PROPERTIES: ALLOWED_PROPERTIES,
-    getConfigFileName: getConfigFileName,
+    getConfigFileBaseName: getConfigFileBaseName,
     validateLoctoolConfig: validateLoctoolConfig
 };

--- a/packages/loctool/loctool.js
+++ b/packages/loctool/loctool.js
@@ -51,7 +51,7 @@ function getVersion() {
 var commandOptionHelp = {
     init:
         "init  [project-name]\n" +
-        "  Initialize the current directory as a loctool project and write out a project.json file.\n\n" +
+        "  Initialize the current directory as a loctool project and write out a project config file.\n\n" +
         "project-name (optional)\n" +
         "  the name of the project to initialize",
     localize:
@@ -65,7 +65,7 @@ var commandOptionHelp = {
         "  during localization. This is intended for use with translation management systems that cannot\n" + 
         "  handle plurals properly.\n" +
         "--exclude\n" +
-        "  exclude a comma-separated list of directories while searching for project.json config files \n" +
+        "  exclude a comma-separated list of directories while searching for project config files \n" +
         "-f or --filetype\n" +
         "  Restrict operation to only the given list of file types. This allows you to\n" +
         "  run only the parts of the loctool that are needed at the moment.\n" +
@@ -228,6 +228,9 @@ function usage() {
 //        "  Do a git pull first to update to the latest. (Assumes clean dirs.)\n" +
         "--projectId\n" +
         "  Specify the default name of the project if not specified otherwise.\n" +
+        "--configFile\n" +
+        "  Specify the base name of the project config file to search for in any directory\n" +
+        "  during the tree walk. This is a file name only, not a path. (Default is 'project.json')\n" +
         "--projectType\n" +
         "  The type of project, which affects how source files are read and resource files are written. Default: web \n" +
         "--plugins\n" +
@@ -308,7 +311,8 @@ var settings = {
     localeMap: {},
     localeInherit: {},
     onlyTranslated: false,
-    convertPlurals: false
+    convertPlurals: false,
+    configFile: "project.json"
 };
 
 var options = [];
@@ -377,6 +381,13 @@ for (var i = 0; i < argv.length; i++) {
         }
     } else if (val === "--projectId") {
         settings.id = argv[++i];
+    } else if (val === "--configFile") {
+        if (i + 1 < argv.length && argv[i + 1] && argv[i + 1][0] !== "-") {
+            settings.configFile = argv[++i];
+        } else {
+            console.error("Error: --configFile option requires a file name argument to follow it.");
+            usage();
+        }
     } else if (val === "--projectType") {
         settings.projectType = argv[++i];
     } else if (val === "--plugins") {
@@ -499,6 +510,9 @@ for (var i = 0; i < argv.length; i++) {
     }
 }
 
+if (settings.configFile && settings.exclude.indexOf(settings.configFile) === -1) {
+    settings.exclude.push(settings.configFile);
+}
 
 if (settings.help) {
     if (options.length > 2 && options[2] && commandOptionHelp[options[2]]) {
@@ -777,8 +791,8 @@ try {
     case "init":
         var info = collectInfo();
         var project = ProjectFactory.newProject(info);
-        var config = project.getConfig(info);
-        var outputFile = path.join(settings.rootDir, "project.json");
+        var config = project.getConfig(settings);
+        var outputFile = path.join(settings.rootDir, settings.configFile);
         fs.writeFileSync(outputFile, JSON.stringify(config, undefined, 4) + '\n', "utf-8");
         logger.info("Wrote file " + outputFile);
         break;

--- a/packages/loctool/loctool.js
+++ b/packages/loctool/loctool.js
@@ -28,6 +28,7 @@ var Queue = require("js-stl").Queue;
 var mm = require("micromatch");
 
 var ProjectFactory = require("./lib/ProjectFactory.js");
+var projectConfig = require("./lib/projectConfig.js");
 var GenerateModeProcess = require("./lib/GenerateModeProcess.js");
 var XliffFactory = require("./lib/XliffFactory.js");
 var XliffMerge = require("./lib/XliffMerge.js");
@@ -55,7 +56,7 @@ var commandOptionHelp = {
         "root-dir-name (optional)\n" +
         "  the directory where the config file should be written. Default is '.'\n" +
         "--configFileBaseName name\n" +
-        "  base name of the config file to write (default: project.json)\n",
+        "  base name of the config file to write (default: loctool-config.json)\n",
     localize:
         "localize [root-dir-name]\n" +
         "  Extract strings and generate localized resource files. This is the default command.\n\n" + 
@@ -232,7 +233,9 @@ function usage() {
         "  Specify the default name of the project if not specified otherwise.\n" +
         "--configFileBaseName\n" +
         "  Specify the base name of the project config file to search for in any directory\n" +
-        "  during the tree walk. This is a file name only, not a path. (Default is 'project.json')\n" +
+        "  during the tree walk. This is a file name only, not a path.\n" +
+        "  When not set, loctool searches for loctool-config.json or project.json.\n" +
+        "  (loctool init writes loctool-config.json by default.)\n" +
         "--projectType\n" +
         "  The type of project, which affects how source files are read and resource files are written. Default: web \n" +
         "--plugins\n" +
@@ -297,6 +300,7 @@ var settings = {
         "package.json",
         "package-lock.json",
         "project.json",
+        "loctool-config.json",
         "log4js.json",
         "yarn.lock",
         ".gitignore",
@@ -313,8 +317,7 @@ var settings = {
     localeMap: {},
     localeInherit: {},
     onlyTranslated: false,
-    convertPlurals: false,
-    configFileBaseName: "project.json"
+    convertPlurals: false
 };
 
 var options = [];
@@ -519,9 +522,11 @@ for (var i = 0; i < argv.length; i++) {
     }
 }
 
-if (settings.configFileBaseName && settings.exclude.indexOf(settings.configFileBaseName) === -1) {
-    settings.exclude.push(settings.configFileBaseName);
-}
+projectConfig.getConfigFileBaseNames(settings).forEach(function(configFileBaseName) {
+    if (settings.exclude.indexOf(configFileBaseName) === -1) {
+        settings.exclude.push(configFileBaseName);
+    }
+});
 
 if (settings.help) {
     if (options.length > 2 && options[2] && commandOptionHelp[options[2]]) {

--- a/packages/loctool/loctool.js
+++ b/packages/loctool/loctool.js
@@ -813,7 +813,7 @@ try {
         info.rootDir = settings.rootDir;
         var project = ProjectFactory.newProject(info, settings);
         var config = project.getConfig(settings);
-        var outputFile = ProjectFactory.getInitOutputPath(settings);
+        var outputFile = projectConfig.getInitOutputPath(settings);
         fs.writeFileSync(outputFile, JSON.stringify(config, undefined, 4) + '\n', "utf-8");
         logger.info("Wrote file " + outputFile);
         break;

--- a/packages/loctool/loctool.js
+++ b/packages/loctool/loctool.js
@@ -50,10 +50,12 @@ function getVersion() {
 
 var commandOptionHelp = {
     init:
-        "init  [project-name]\n" +
-        "  Initialize the current directory as a loctool project and write out a project config file.\n\n" +
-        "project-name (optional)\n" +
-        "  the name of the project to initialize",
+        "init  [root-dir-name]\n" +
+        "  Initialize a directory as a loctool project and write out a project config file.\n\n" +
+        "root-dir-name (optional)\n" +
+        "  the directory where the config file should be written. Default is '.'\n" +
+        "--configFileBaseName name\n" +
+        "  base name of the config file to write (default: project.json)\n",
     localize:
         "localize [root-dir-name]\n" +
         "  Extract strings and generate localized resource files. This is the default command.\n\n" + 
@@ -381,6 +383,13 @@ for (var i = 0; i < argv.length; i++) {
         }
     } else if (val === "--projectId") {
         settings.id = argv[++i];
+    } else if (val === "--root") {
+        if (i + 1 < argv.length && argv[i + 1] && argv[i + 1][0] !== "-") {
+            settings.rootDir = argv[++i];
+        } else {
+            console.error("Error: --root option requires a directory name argument to follow it.");
+            usage();
+        }
     } else if (val === "--configFileBaseName") {
         if (i + 1 < argv.length && argv[i + 1] && argv[i + 1][0] !== "-") {
             settings.configFileBaseName = argv[++i];
@@ -527,6 +536,12 @@ settings.mode = command;
 switch (command) {
 default:
 case "localize":
+    if (options.length > 3) {
+        settings.rootDir = options[3];
+    }
+    break;
+
+case "init":
     if (options.length > 3) {
         settings.rootDir = options[3];
     }
@@ -790,9 +805,10 @@ try {
     switch (command) {
     case "init":
         var info = collectInfo();
-        var project = ProjectFactory.newProject(info);
+        info.rootDir = settings.rootDir;
+        var project = ProjectFactory.newProject(info, settings);
         var config = project.getConfig(settings);
-        var outputFile = path.join(settings.rootDir, settings.configFileBaseName);
+        var outputFile = ProjectFactory.getInitOutputPath(settings);
         fs.writeFileSync(outputFile, JSON.stringify(config, undefined, 4) + '\n', "utf-8");
         logger.info("Wrote file " + outputFile);
         break;

--- a/packages/loctool/loctool.js
+++ b/packages/loctool/loctool.js
@@ -228,7 +228,7 @@ function usage() {
 //        "  Do a git pull first to update to the latest. (Assumes clean dirs.)\n" +
         "--projectId\n" +
         "  Specify the default name of the project if not specified otherwise.\n" +
-        "--configFile\n" +
+        "--configFileBaseName\n" +
         "  Specify the base name of the project config file to search for in any directory\n" +
         "  during the tree walk. This is a file name only, not a path. (Default is 'project.json')\n" +
         "--projectType\n" +
@@ -312,7 +312,7 @@ var settings = {
     localeInherit: {},
     onlyTranslated: false,
     convertPlurals: false,
-    configFile: "project.json"
+    configFileBaseName: "project.json"
 };
 
 var options = [];
@@ -381,11 +381,11 @@ for (var i = 0; i < argv.length; i++) {
         }
     } else if (val === "--projectId") {
         settings.id = argv[++i];
-    } else if (val === "--configFile") {
+    } else if (val === "--configFileBaseName") {
         if (i + 1 < argv.length && argv[i + 1] && argv[i + 1][0] !== "-") {
-            settings.configFile = argv[++i];
+            settings.configFileBaseName = argv[++i];
         } else {
-            console.error("Error: --configFile option requires a file name argument to follow it.");
+            console.error("Error: --configFileBaseName option requires a file name argument to follow it.");
             usage();
         }
     } else if (val === "--projectType") {
@@ -510,8 +510,8 @@ for (var i = 0; i < argv.length; i++) {
     }
 }
 
-if (settings.configFile && settings.exclude.indexOf(settings.configFile) === -1) {
-    settings.exclude.push(settings.configFile);
+if (settings.configFileBaseName && settings.exclude.indexOf(settings.configFileBaseName) === -1) {
+    settings.exclude.push(settings.configFileBaseName);
 }
 
 if (settings.help) {
@@ -792,7 +792,7 @@ try {
         var info = collectInfo();
         var project = ProjectFactory.newProject(info);
         var config = project.getConfig(settings);
-        var outputFile = path.join(settings.rootDir, settings.configFile);
+        var outputFile = path.join(settings.rootDir, settings.configFileBaseName);
         fs.writeFileSync(outputFile, JSON.stringify(config, undefined, 4) + '\n', "utf-8");
         logger.info("Wrote file " + outputFile);
         break;

--- a/packages/loctool/test/ProjectFactory.test.js
+++ b/packages/loctool/test/ProjectFactory.test.js
@@ -1,12 +1,27 @@
 /*
  * ProjectFactory.test.js - test class used to load Projects
  *
- * Copyright © 2017, 2020, 2023, 2025 Healthtap, Inc. All Rights Reserved.
+ * Copyright © 2017, 2020, 2023, 2025-2026, HealthTap, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 if (!ProjectFactory) {
     var ProjectFactory= require("../lib/ProjectFactory.js");
 }
+var fs = require("fs");
+var path = require("path");
 
 describe("projectfactory", function() {
     test("ProjectFactoryCreationAllEmpty", function() {
@@ -174,3 +189,206 @@ describe("projectfactory", function() {
     });
 
 });
+
+describe("ProjectFactory.validateLoctoolConfig", function() {
+    test("accepts config with valid $schema", function() {
+        var result = ProjectFactory.validateLoctoolConfig({
+            "$schema": ProjectFactory.LOCTOOL_SCHEMA,
+            "name": "Test",
+            "id": "test",
+            "projectType": "web"
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test("rejects config with wrong $schema", function() {
+        var result = ProjectFactory.validateLoctoolConfig({
+            "$schema": "https://nx.dev/schemas/project-schema.json",
+            "name": "Test",
+            "id": "test",
+            "projectType": "web"
+        });
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain("$schema");
+    });
+
+    test("rejects config missing required id", function() {
+        var result = ProjectFactory.validateLoctoolConfig({
+            "name": "Test",
+            "projectType": "web"
+        });
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain("id");
+    });
+
+    test("rejects config with invalid projectType", function() {
+        var result = ProjectFactory.validateLoctoolConfig({
+            "name": "Test",
+            "id": "test",
+            "projectType": "library"
+        });
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain("projectType");
+    });
+
+    test("rejects custom config without plugins", function() {
+        var result = ProjectFactory.validateLoctoolConfig({
+            "name": "Test",
+            "id": "test",
+            "projectType": "custom"
+        });
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain("plugins");
+    });
+
+    test("rejects config when all extra properties are foreign", function() {
+        var result = ProjectFactory.validateLoctoolConfig({
+            "name": "Test",
+            "id": "test",
+            "projectType": "custom",
+            "plugins": ["javascript"],
+            "targets": {},
+            "sourceRoot": "src"
+        });
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain("unrecognized properties");
+    });
+
+    test("accepts legacy config without $schema when properties are valid", function() {
+        var result = ProjectFactory.validateLoctoolConfig({
+            "name": "Loctool Test",
+            "id": "loctest",
+            "projectType": "web",
+            "resourceDirs": {"js": "public"},
+            "settings": {"locales": ["de-DE"]}
+        });
+        expect(result.valid).toBe(true);
+        expect(result.unknownProperties).toBeUndefined();
+    });
+
+    test("accepts config with unknown properties when at least one extra is allowed", function() {
+        var result = ProjectFactory.validateLoctoolConfig({
+            "name": "Test",
+            "id": "test",
+            "projectType": "web",
+            "settings": {"locales": ["de-DE"]},
+            "unknownProperty": true
+        });
+        expect(result.valid).toBe(true);
+        expect(result.unknownProperties).toStrictEqual(["unknownProperty"]);
+    });
+
+    test("accepts minimal config with only required properties", function() {
+        var result = ProjectFactory.validateLoctoolConfig({
+            "name": "Test",
+            "id": "test",
+            "projectType": "web"
+        });
+        expect(result.valid).toBe(true);
+    });
+});
+
+describe("ProjectFactory config file validation", function() {
+    function loadConfigFixture(subdir) {
+        var file = path.join(__dirname, "testfiles", "config-validation", subdir, "project.json");
+        return JSON.parse(fs.readFileSync(file, "utf8"));
+    }
+
+    test("loads valid config with $schema from disk", function() {
+        var props = loadConfigFixture("valid-with-schema");
+        expect(ProjectFactory.validateLoctoolConfig(props).valid).toBe(true);
+
+        var project = ProjectFactory('./test/testfiles/config-validation/valid-with-schema', {});
+        expect(project).toBeTruthy();
+        expect(project.getProjectId()).toBe('valid-with-schema');
+    });
+
+    test("ignores config with wrong $schema from disk", function() {
+        var props = loadConfigFixture("invalid-wrong-schema");
+        var validation = ProjectFactory.validateLoctoolConfig(props);
+        expect(validation.valid).toBe(false);
+        expect(validation.reason).toContain("$schema");
+
+        var project = ProjectFactory('./test/testfiles/config-validation/invalid-wrong-schema', {});
+        expect(project).toBeUndefined();
+    });
+
+    test("ignores config missing required properties from disk", function() {
+        var props = loadConfigFixture("invalid-missing-id");
+        var validation = ProjectFactory.validateLoctoolConfig(props);
+        expect(validation.valid).toBe(false);
+        expect(validation.reason).toContain("id");
+
+        var project = ProjectFactory('./test/testfiles/config-validation/invalid-missing-id', {});
+        expect(project).toBeUndefined();
+    });
+
+    test("ignores config with invalid projectType from disk", function() {
+        var props = loadConfigFixture("invalid-project-type");
+        var validation = ProjectFactory.validateLoctoolConfig(props);
+        expect(validation.valid).toBe(false);
+        expect(validation.reason).toContain("projectType");
+
+        var project = ProjectFactory('./test/testfiles/config-validation/invalid-project-type', {});
+        expect(project).toBeUndefined();
+    });
+
+    test("ignores custom config without plugins from disk", function() {
+        var props = loadConfigFixture("invalid-custom-no-plugins");
+        var validation = ProjectFactory.validateLoctoolConfig(props);
+        expect(validation.valid).toBe(false);
+        expect(validation.reason).toContain("plugins");
+
+        var project = ProjectFactory('./test/testfiles/config-validation/invalid-custom-no-plugins', {});
+        expect(project).toBeUndefined();
+    });
+
+    test("ignores config with only foreign extra properties from disk", function() {
+        var props = loadConfigFixture("invalid-all-foreign");
+        var validation = ProjectFactory.validateLoctoolConfig(props);
+        expect(validation.valid).toBe(false);
+        expect(validation.reason).toContain("unrecognized properties");
+
+        var project = ProjectFactory('./test/testfiles/config-validation/invalid-all-foreign', {});
+        expect(project).toBeUndefined();
+    });
+
+    test("loads valid minimal config without $schema from disk", function() {
+        var props = loadConfigFixture("valid-minimal");
+        expect(ProjectFactory.validateLoctoolConfig(props).valid).toBe(true);
+
+        var project = ProjectFactory('./test/testfiles/config-validation/valid-minimal', {});
+        expect(project).toBeTruthy();
+        expect(project.getProjectId()).toBe('valid-minimal');
+    });
+
+    test("loads config with unknown properties and reports them for warnings from disk", function() {
+        var props = loadConfigFixture("valid-with-warnings");
+        var validation = ProjectFactory.validateLoctoolConfig(props);
+        expect(validation.valid).toBe(true);
+        expect(validation.unknownProperties).toStrictEqual(["unknownProperty"]);
+
+        var project = ProjectFactory('./test/testfiles/config-validation/valid-with-warnings', {});
+        expect(project).toBeTruthy();
+        expect(project.getProjectId()).toBe('valid-with-warnings');
+    });
+
+    test("existing testfiles project.json still loads without $schema", function() {
+        var project = ProjectFactory('./test/testfiles', {});
+        expect(project).toBeTruthy();
+        expect(project.getProjectId()).toBe('loctest');
+    });
+
+    test("init getConfig includes loctool $schema", function() {
+        var project = ProjectFactory.newProject({
+            name: "Init Test",
+            id: "init-test",
+            projectType: "web",
+            rootDir: "."
+        }, {});
+        var config = project.getConfig({configFile: "project.json"});
+        expect(config.$schema).toBe(ProjectFactory.LOCTOOL_SCHEMA);
+        expect(config.projectType).toBe("web");
+    });
+});
+

--- a/packages/loctool/test/ProjectFactory.test.js
+++ b/packages/loctool/test/ProjectFactory.test.js
@@ -152,9 +152,11 @@ describe("projectfactory", function() {
     });
 
     test("ProjectFactoryDefaultConfigFileBaseName", function() {
-        expect.assertions(2);
-        expect(ProjectFactory.getConfigFileBaseName({})).toBe("project.json");
-        expect(ProjectFactory.getConfigFileBaseName(undefined)).toBe("project.json");
+        expect.assertions(4);
+        expect(ProjectFactory.getConfigFileBaseName({})).toBe("loctool-config.json");
+        expect(ProjectFactory.getConfigFileBaseName(undefined)).toBe("loctool-config.json");
+        expect(ProjectFactory.getConfigFileBaseNames({})).toEqual(["loctool-config.json", "project.json"]);
+        expect(ProjectFactory.getConfigFileBaseNames({configFileBaseName: "loctool.json"})).toEqual(["loctool.json"]);
     });
 
     test("ProjectFactoryDefaultConfigFileBaseNameLoadsProjectJson", function() {
@@ -163,6 +165,27 @@ describe("projectfactory", function() {
         expect(project).not.toBeUndefined();
         // make sure it loaded the default project.json file instead of the loctool.json file
         expect(project.getProjectId()).toBe('loctest');
+    });
+
+    test("ProjectFactoryDefaultConfigFileBaseNameLoadsLoctoolConfigJson", function() {
+        expect.assertions(2);
+        var project = ProjectFactory('./test/testfiles/loctool-config-only', {});
+        expect(project).not.toBeUndefined();
+        expect(project.getProjectId()).toBe('loctest-loctool-config-only');
+    });
+
+    test("ProjectFactoryPrefersLoctoolConfigJsonOverProjectJson", function() {
+        expect.assertions(2);
+        var project = ProjectFactory('./test/testfiles/dual-config', {});
+        expect(project).not.toBeUndefined();
+        expect(project.getProjectId()).toBe('loctest-loctool-config');
+    });
+
+    test("ProjectFactoryIgnoresInvalidProjectJsonWhenLoctoolConfigIsValid", function() {
+        expect.assertions(2);
+        var project = ProjectFactory('./test/testfiles/nx-and-loctool', {});
+        expect(project).not.toBeUndefined();
+        expect(project.getProjectId()).toBe('loctest-nx-and-loctool');
     });
 
     test("ProjectFactoryCustomConfigFileBaseName", function() {
@@ -398,7 +421,18 @@ describe("ProjectFactory config file validation", function() {
         }, {});
         var config = project.getConfig({configFileBaseName: "loctool.json"});
         expect(config.excludes).toContain("loctool.json");
-        expect(config.excludes).not.toContain("project.json");
+        expect(config.excludes).not.toContain("loctool-config.json");
+    });
+
+    test("init getConfig excludes uses default loctool-config.json", function() {
+        var project = ProjectFactory.newProject({
+            name: "Init Test",
+            id: "init-test",
+            projectType: "web",
+            rootDir: "."
+        }, {});
+        var config = project.getConfig({});
+        expect(config.excludes).toContain("loctool-config.json");
     });
 
     test("init output path uses configFileBaseName and rootDir from settings", function() {
@@ -410,7 +444,7 @@ describe("ProjectFactory config file validation", function() {
             rootDir: ".",
             configFileBaseName: "project.json"
         })).toBe("project.json");
-        expect(ProjectFactory.getInitOutputPath({})).toBe("project.json");
+        expect(ProjectFactory.getInitOutputPath({})).toBe("loctool-config.json");
     });
 });
 

--- a/packages/loctool/test/ProjectFactory.test.js
+++ b/packages/loctool/test/ProjectFactory.test.js
@@ -20,6 +20,7 @@
 if (!ProjectFactory) {
     var ProjectFactory= require("../lib/ProjectFactory.js");
 }
+var projectConfig = require("../lib/projectConfig.js");
 var fs = require("fs");
 var path = require("path");
 
@@ -153,10 +154,10 @@ describe("projectfactory", function() {
 
     test("ProjectFactoryDefaultConfigFileBaseName", function() {
         expect.assertions(4);
-        expect(ProjectFactory.getConfigFileBaseName({})).toBe("loctool-config.json");
-        expect(ProjectFactory.getConfigFileBaseName(undefined)).toBe("loctool-config.json");
-        expect(ProjectFactory.getConfigFileBaseNames({})).toEqual(["loctool-config.json", "project.json"]);
-        expect(ProjectFactory.getConfigFileBaseNames({configFileBaseName: "loctool.json"})).toEqual(["loctool.json"]);
+        expect(projectConfig.getConfigFileBaseName({})).toBe("loctool-config.json");
+        expect(projectConfig.getConfigFileBaseName(undefined)).toBe("loctool-config.json");
+        expect(projectConfig.getConfigFileBaseNames({})).toEqual(["loctool-config.json", "project.json"]);
+        expect(projectConfig.getConfigFileBaseNames({configFileBaseName: "loctool.json"})).toEqual(["loctool.json"]);
     });
 
     test("ProjectFactoryDefaultConfigFileBaseNameLoadsProjectJson", function() {
@@ -190,7 +191,7 @@ describe("projectfactory", function() {
 
     test("ProjectFactoryCustomConfigFileBaseName", function() {
         expect.assertions(3);
-        expect(ProjectFactory.getConfigFileBaseName({configFileBaseName: "loctool.json"})).toBe("loctool.json");
+        expect(projectConfig.getConfigFileBaseName({configFileBaseName: "loctool.json"})).toBe("loctool.json");
 
         var project = ProjectFactory('./test/testfiles', {configFileBaseName: "loctool.json"});
         expect(project).not.toBeUndefined();
@@ -213,10 +214,10 @@ describe("projectfactory", function() {
 
 });
 
-describe("ProjectFactory.validateLoctoolConfig", function() {
+describe("projectConfig.validateLoctoolConfig", function() {
     test("accepts config with valid $schema", function() {
-        var result = ProjectFactory.validateLoctoolConfig({
-            "$schema": ProjectFactory.LOCTOOL_SCHEMA,
+        var result = projectConfig.validateLoctoolConfig({
+            "$schema": projectConfig.LOCTOOL_SCHEMA,
             "name": "Test",
             "id": "test",
             "projectType": "web"
@@ -225,7 +226,7 @@ describe("ProjectFactory.validateLoctoolConfig", function() {
     });
 
     test("rejects config with wrong $schema", function() {
-        var result = ProjectFactory.validateLoctoolConfig({
+        var result = projectConfig.validateLoctoolConfig({
             "$schema": "https://nx.dev/schemas/project-schema.json",
             "name": "Test",
             "id": "test",
@@ -236,7 +237,7 @@ describe("ProjectFactory.validateLoctoolConfig", function() {
     });
 
     test("rejects config missing required id", function() {
-        var result = ProjectFactory.validateLoctoolConfig({
+        var result = projectConfig.validateLoctoolConfig({
             "name": "Test",
             "projectType": "web"
         });
@@ -245,7 +246,7 @@ describe("ProjectFactory.validateLoctoolConfig", function() {
     });
 
     test("rejects config with invalid projectType", function() {
-        var result = ProjectFactory.validateLoctoolConfig({
+        var result = projectConfig.validateLoctoolConfig({
             "name": "Test",
             "id": "test",
             "projectType": "library"
@@ -255,7 +256,7 @@ describe("ProjectFactory.validateLoctoolConfig", function() {
     });
 
     test("accepts custom config without plugins", function() {
-        var result = ProjectFactory.validateLoctoolConfig({
+        var result = projectConfig.validateLoctoolConfig({
             "name": "Test",
             "id": "test",
             "projectType": "custom"
@@ -264,7 +265,7 @@ describe("ProjectFactory.validateLoctoolConfig", function() {
     });
 
     test("rejects config when all extra properties are foreign", function() {
-        var result = ProjectFactory.validateLoctoolConfig({
+        var result = projectConfig.validateLoctoolConfig({
             "name": "Test",
             "id": "test",
             "projectType": "custom",
@@ -276,7 +277,7 @@ describe("ProjectFactory.validateLoctoolConfig", function() {
     });
 
     test("accepts legacy config without $schema when properties are valid", function() {
-        var result = ProjectFactory.validateLoctoolConfig({
+        var result = projectConfig.validateLoctoolConfig({
             "name": "Loctool Test",
             "id": "loctest",
             "projectType": "web",
@@ -288,7 +289,7 @@ describe("ProjectFactory.validateLoctoolConfig", function() {
     });
 
     test("accepts config with unknown properties when at least one extra is allowed", function() {
-        var result = ProjectFactory.validateLoctoolConfig({
+        var result = projectConfig.validateLoctoolConfig({
             "name": "Test",
             "id": "test",
             "projectType": "web",
@@ -300,7 +301,7 @@ describe("ProjectFactory.validateLoctoolConfig", function() {
     });
 
     test("accepts minimal config with only required properties", function() {
-        var result = ProjectFactory.validateLoctoolConfig({
+        var result = projectConfig.validateLoctoolConfig({
             "name": "Test",
             "id": "test",
             "projectType": "web"
@@ -317,7 +318,7 @@ describe("ProjectFactory config file validation", function() {
 
     test("loads valid config with $schema from disk", function() {
         var props = loadConfigFixture("valid-with-schema");
-        expect(ProjectFactory.validateLoctoolConfig(props).valid).toBe(true);
+        expect(projectConfig.validateLoctoolConfig(props).valid).toBe(true);
 
         var project = ProjectFactory('./test/testfiles/config-validation/valid-with-schema', {});
         expect(project).toBeTruthy();
@@ -326,7 +327,7 @@ describe("ProjectFactory config file validation", function() {
 
     test("ignores config with wrong $schema from disk", function() {
         var props = loadConfigFixture("invalid-wrong-schema");
-        var validation = ProjectFactory.validateLoctoolConfig(props);
+        var validation = projectConfig.validateLoctoolConfig(props);
         expect(validation.valid).toBe(false);
         expect(validation.reason).toContain("$schema");
 
@@ -336,7 +337,7 @@ describe("ProjectFactory config file validation", function() {
 
     test("ignores config missing required properties from disk", function() {
         var props = loadConfigFixture("invalid-missing-id");
-        var validation = ProjectFactory.validateLoctoolConfig(props);
+        var validation = projectConfig.validateLoctoolConfig(props);
         expect(validation.valid).toBe(false);
         expect(validation.reason).toContain("id");
 
@@ -346,7 +347,7 @@ describe("ProjectFactory config file validation", function() {
 
     test("ignores config with invalid projectType from disk", function() {
         var props = loadConfigFixture("invalid-project-type");
-        var validation = ProjectFactory.validateLoctoolConfig(props);
+        var validation = projectConfig.validateLoctoolConfig(props);
         expect(validation.valid).toBe(false);
         expect(validation.reason).toContain("projectType");
 
@@ -356,7 +357,7 @@ describe("ProjectFactory config file validation", function() {
 
     test("loads custom config without plugins from disk", function() {
         var props = loadConfigFixture("valid-custom-no-plugins");
-        var validation = ProjectFactory.validateLoctoolConfig(props);
+        var validation = projectConfig.validateLoctoolConfig(props);
         expect(validation.valid).toBe(true);
 
         var project = ProjectFactory('./test/testfiles/config-validation/valid-custom-no-plugins', {});
@@ -366,7 +367,7 @@ describe("ProjectFactory config file validation", function() {
 
     test("ignores config with only foreign extra properties from disk", function() {
         var props = loadConfigFixture("invalid-all-foreign");
-        var validation = ProjectFactory.validateLoctoolConfig(props);
+        var validation = projectConfig.validateLoctoolConfig(props);
         expect(validation.valid).toBe(false);
         expect(validation.reason).toContain("unrecognized properties");
 
@@ -376,7 +377,7 @@ describe("ProjectFactory config file validation", function() {
 
     test("loads valid minimal config without $schema from disk", function() {
         var props = loadConfigFixture("valid-minimal");
-        expect(ProjectFactory.validateLoctoolConfig(props).valid).toBe(true);
+        expect(projectConfig.validateLoctoolConfig(props).valid).toBe(true);
 
         var project = ProjectFactory('./test/testfiles/config-validation/valid-minimal', {});
         expect(project).toBeTruthy();
@@ -385,7 +386,7 @@ describe("ProjectFactory config file validation", function() {
 
     test("loads config with unknown properties and reports them for warnings from disk", function() {
         var props = loadConfigFixture("valid-with-warnings");
-        var validation = ProjectFactory.validateLoctoolConfig(props);
+        var validation = projectConfig.validateLoctoolConfig(props);
         expect(validation.valid).toBe(true);
         expect(validation.unknownProperties).toStrictEqual(["unknownProperty"]);
 
@@ -408,7 +409,7 @@ describe("ProjectFactory config file validation", function() {
             rootDir: "."
         }, {});
         var config = project.getConfig({configFileBaseName: "project.json"});
-        expect(config.$schema).toBe(ProjectFactory.LOCTOOL_SCHEMA);
+        expect(config.$schema).toBe(projectConfig.LOCTOOL_SCHEMA);
         expect(config.projectType).toBe("web");
     });
 
@@ -436,15 +437,15 @@ describe("ProjectFactory config file validation", function() {
     });
 
     test("init output path uses configFileBaseName and rootDir from settings", function() {
-        expect(ProjectFactory.getInitOutputPath({
+        expect(projectConfig.getInitOutputPath({
             rootDir: "./test/testfiles",
             configFileBaseName: "loctool.json"
         })).toBe("test/testfiles/loctool.json");
-        expect(ProjectFactory.getInitOutputPath({
+        expect(projectConfig.getInitOutputPath({
             rootDir: ".",
             configFileBaseName: "project.json"
         })).toBe("project.json");
-        expect(ProjectFactory.getInitOutputPath({})).toBe("loctool-config.json");
+        expect(projectConfig.getInitOutputPath({})).toBe("loctool-config.json");
     });
 });
 

--- a/packages/loctool/test/ProjectFactory.test.js
+++ b/packages/loctool/test/ProjectFactory.test.js
@@ -388,5 +388,29 @@ describe("ProjectFactory config file validation", function() {
         expect(config.$schema).toBe(ProjectFactory.LOCTOOL_SCHEMA);
         expect(config.projectType).toBe("web");
     });
+
+    test("init getConfig excludes uses configFileBaseName from settings", function() {
+        var project = ProjectFactory.newProject({
+            name: "Init Test",
+            id: "init-test",
+            projectType: "web",
+            rootDir: "."
+        }, {});
+        var config = project.getConfig({configFileBaseName: "loctool.json"});
+        expect(config.excludes).toContain("loctool.json");
+        expect(config.excludes).not.toContain("project.json");
+    });
+
+    test("init output path uses configFileBaseName and rootDir from settings", function() {
+        expect(ProjectFactory.getInitOutputPath({
+            rootDir: "./test/testfiles",
+            configFileBaseName: "loctool.json"
+        })).toBe("test/testfiles/loctool.json");
+        expect(ProjectFactory.getInitOutputPath({
+            rootDir: ".",
+            configFileBaseName: "project.json"
+        })).toBe("project.json");
+        expect(ProjectFactory.getInitOutputPath({})).toBe("project.json");
+    });
 });
 

--- a/packages/loctool/test/ProjectFactory.test.js
+++ b/packages/loctool/test/ProjectFactory.test.js
@@ -151,13 +151,13 @@ describe("projectfactory", function() {
         expect(project.xliffsOut).toBe('/foo/asdf');
     });
 
-    test("ProjectFactoryDefaultConfigFileName", function() {
+    test("ProjectFactoryDefaultConfigFileBaseName", function() {
         expect.assertions(2);
-        expect(ProjectFactory.getConfigFileName({})).toBe("project.json");
-        expect(ProjectFactory.getConfigFileName(undefined)).toBe("project.json");
+        expect(ProjectFactory.getConfigFileBaseName({})).toBe("project.json");
+        expect(ProjectFactory.getConfigFileBaseName(undefined)).toBe("project.json");
     });
 
-    test("ProjectFactoryDefaultConfigFileLoadsProjectJson", function() {
+    test("ProjectFactoryDefaultConfigFileBaseNameLoadsProjectJson", function() {
         expect.assertions(2);
         var project = ProjectFactory('./test/testfiles', {});
         expect(project).not.toBeUndefined();
@@ -165,24 +165,24 @@ describe("projectfactory", function() {
         expect(project.getProjectId()).toBe('loctest');
     });
 
-    test("ProjectFactoryCustomConfigFileName", function() {
+    test("ProjectFactoryCustomConfigFileBaseName", function() {
         expect.assertions(3);
-        expect(ProjectFactory.getConfigFileName({configFile: "loctool.json"})).toBe("loctool.json");
+        expect(ProjectFactory.getConfigFileBaseName({configFileBaseName: "loctool.json"})).toBe("loctool.json");
 
-        var project = ProjectFactory('./test/testfiles', {configFile: "loctool.json"});
+        var project = ProjectFactory('./test/testfiles', {configFileBaseName: "loctool.json"});
         expect(project).not.toBeUndefined();
         expect(project.options.id).toBe("loctest-alt");
     });
 
-    test("ProjectFactoryCustomConfigFileNameDoesNotLoadDefault", function() {
+    test("ProjectFactoryCustomConfigFileBaseNameDoesNotLoadDefault", function() {
         expect.assertions(1);
-        var project = ProjectFactory('./test/testfiles', {configFile: "missing-config.json"});
+        var project = ProjectFactory('./test/testfiles', {configFileBaseName: "missing-config.json"});
         expect(project).toBeUndefined();
     });
 
-    test("ProjectFactoryCustomConfigFileNameInSubdirectory", function() {
+    test("ProjectFactoryCustomConfigFileBaseNameInSubdirectory", function() {
         expect.assertions(3);
-        var project = ProjectFactory('./test/testfiles/x/y/z', {configFile: "loctool.json"});
+        var project = ProjectFactory('./test/testfiles/x/y/z', {configFileBaseName: "loctool.json"});
         expect(project).not.toBeUndefined();
         expect(project.getProjectId()).toBe('loctest-nested');
         expect(project.root).toBe('./test/testfiles/x/y/z');
@@ -384,7 +384,7 @@ describe("ProjectFactory config file validation", function() {
             projectType: "web",
             rootDir: "."
         }, {});
-        var config = project.getConfig({configFile: "project.json"});
+        var config = project.getConfig({configFileBaseName: "project.json"});
         expect(config.$schema).toBe(ProjectFactory.LOCTOOL_SCHEMA);
         expect(config.projectType).toBe("web");
     });

--- a/packages/loctool/test/ProjectFactory.test.js
+++ b/packages/loctool/test/ProjectFactory.test.js
@@ -231,14 +231,13 @@ describe("ProjectFactory.validateLoctoolConfig", function() {
         expect(result.reason).toContain("projectType");
     });
 
-    test("rejects custom config without plugins", function() {
+    test("accepts custom config without plugins", function() {
         var result = ProjectFactory.validateLoctoolConfig({
             "name": "Test",
             "id": "test",
             "projectType": "custom"
         });
-        expect(result.valid).toBe(false);
-        expect(result.reason).toContain("plugins");
+        expect(result.valid).toBe(true);
     });
 
     test("rejects config when all extra properties are foreign", function() {
@@ -246,7 +245,6 @@ describe("ProjectFactory.validateLoctoolConfig", function() {
             "name": "Test",
             "id": "test",
             "projectType": "custom",
-            "plugins": ["javascript"],
             "targets": {},
             "sourceRoot": "src"
         });
@@ -333,14 +331,14 @@ describe("ProjectFactory config file validation", function() {
         expect(project).toBeUndefined();
     });
 
-    test("ignores custom config without plugins from disk", function() {
-        var props = loadConfigFixture("invalid-custom-no-plugins");
+    test("loads custom config without plugins from disk", function() {
+        var props = loadConfigFixture("valid-custom-no-plugins");
         var validation = ProjectFactory.validateLoctoolConfig(props);
-        expect(validation.valid).toBe(false);
-        expect(validation.reason).toContain("plugins");
+        expect(validation.valid).toBe(true);
 
-        var project = ProjectFactory('./test/testfiles/config-validation/invalid-custom-no-plugins', {});
-        expect(project).toBeUndefined();
+        var project = ProjectFactory('./test/testfiles/config-validation/valid-custom-no-plugins', {});
+        expect(project).toBeTruthy();
+        expect(project.getProjectId()).toBe('valid-custom-no-plugins');
     });
 
     test("ignores config with only foreign extra properties from disk", function() {

--- a/packages/loctool/test/ProjectFactory.test.js
+++ b/packages/loctool/test/ProjectFactory.test.js
@@ -136,4 +136,41 @@ describe("projectfactory", function() {
         expect(project.xliffsOut).toBe('/foo/asdf');
     });
 
+    test("ProjectFactoryDefaultConfigFileName", function() {
+        expect.assertions(2);
+        expect(ProjectFactory.getConfigFileName({})).toBe("project.json");
+        expect(ProjectFactory.getConfigFileName(undefined)).toBe("project.json");
+    });
+
+    test("ProjectFactoryDefaultConfigFileLoadsProjectJson", function() {
+        expect.assertions(2);
+        var project = ProjectFactory('./test/testfiles', {});
+        expect(project).not.toBeUndefined();
+        // make sure it loaded the default project.json file instead of the loctool.json file
+        expect(project.getProjectId()).toBe('loctest');
+    });
+
+    test("ProjectFactoryCustomConfigFileName", function() {
+        expect.assertions(3);
+        expect(ProjectFactory.getConfigFileName({configFile: "loctool.json"})).toBe("loctool.json");
+
+        var project = ProjectFactory('./test/testfiles', {configFile: "loctool.json"});
+        expect(project).not.toBeUndefined();
+        expect(project.options.id).toBe("loctest-alt");
+    });
+
+    test("ProjectFactoryCustomConfigFileNameDoesNotLoadDefault", function() {
+        expect.assertions(1);
+        var project = ProjectFactory('./test/testfiles', {configFile: "missing-config.json"});
+        expect(project).toBeUndefined();
+    });
+
+    test("ProjectFactoryCustomConfigFileNameInSubdirectory", function() {
+        expect.assertions(3);
+        var project = ProjectFactory('./test/testfiles/x/y/z', {configFile: "loctool.json"});
+        expect(project).not.toBeUndefined();
+        expect(project.getProjectId()).toBe('loctest-nested');
+        expect(project.root).toBe('./test/testfiles/x/y/z');
+    });
+
 });

--- a/packages/loctool/test/testfiles/config-validation/invalid-all-foreign/project.json
+++ b/packages/loctool/test/testfiles/config-validation/invalid-all-foreign/project.json
@@ -1,0 +1,8 @@
+{
+    "name": "All Foreign Extras",
+    "id": "invalid-all-foreign",
+    "projectType": "custom",
+    "plugins": ["javascript"],
+    "targets": {},
+    "sourceRoot": "src"
+}

--- a/packages/loctool/test/testfiles/config-validation/invalid-all-foreign/project.json
+++ b/packages/loctool/test/testfiles/config-validation/invalid-all-foreign/project.json
@@ -2,7 +2,6 @@
     "name": "All Foreign Extras",
     "id": "invalid-all-foreign",
     "projectType": "custom",
-    "plugins": ["javascript"],
     "targets": {},
     "sourceRoot": "src"
 }

--- a/packages/loctool/test/testfiles/config-validation/invalid-custom-no-plugins/project.json
+++ b/packages/loctool/test/testfiles/config-validation/invalid-custom-no-plugins/project.json
@@ -1,0 +1,5 @@
+{
+    "name": "Custom No Plugins",
+    "id": "invalid-custom-no-plugins",
+    "projectType": "custom"
+}

--- a/packages/loctool/test/testfiles/config-validation/invalid-custom-no-plugins/project.json
+++ b/packages/loctool/test/testfiles/config-validation/invalid-custom-no-plugins/project.json
@@ -1,5 +1,0 @@
-{
-    "name": "Custom No Plugins",
-    "id": "invalid-custom-no-plugins",
-    "projectType": "custom"
-}

--- a/packages/loctool/test/testfiles/config-validation/invalid-missing-id/project.json
+++ b/packages/loctool/test/testfiles/config-validation/invalid-missing-id/project.json
@@ -1,0 +1,4 @@
+{
+    "name": "Missing Id",
+    "projectType": "web"
+}

--- a/packages/loctool/test/testfiles/config-validation/invalid-project-type/project.json
+++ b/packages/loctool/test/testfiles/config-validation/invalid-project-type/project.json
@@ -1,0 +1,6 @@
+{
+    "name": "Nx Like",
+    "id": "invalid-project-type",
+    "projectType": "library",
+    "targets": {}
+}

--- a/packages/loctool/test/testfiles/config-validation/invalid-wrong-schema/project.json
+++ b/packages/loctool/test/testfiles/config-validation/invalid-wrong-schema/project.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://nx.dev/schemas/project-schema.json",
+    "name": "Wrong Schema",
+    "id": "invalid-wrong-schema",
+    "projectType": "web"
+}

--- a/packages/loctool/test/testfiles/config-validation/valid-custom-no-plugins/project.json
+++ b/packages/loctool/test/testfiles/config-validation/valid-custom-no-plugins/project.json
@@ -1,0 +1,5 @@
+{
+    "name": "Custom No Plugins",
+    "id": "valid-custom-no-plugins",
+    "projectType": "custom"
+}

--- a/packages/loctool/test/testfiles/config-validation/valid-minimal/project.json
+++ b/packages/loctool/test/testfiles/config-validation/valid-minimal/project.json
@@ -1,0 +1,5 @@
+{
+    "name": "Valid Minimal",
+    "id": "valid-minimal",
+    "projectType": "web"
+}

--- a/packages/loctool/test/testfiles/config-validation/valid-with-schema/project.json
+++ b/packages/loctool/test/testfiles/config-validation/valid-with-schema/project.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://github.com/iLib-js/ilib-mono/packages/loctool/loctool-project-v1.schema.json",
+    "name": "Valid With Schema",
+    "id": "valid-with-schema",
+    "projectType": "web"
+}

--- a/packages/loctool/test/testfiles/config-validation/valid-with-warnings/project.json
+++ b/packages/loctool/test/testfiles/config-validation/valid-with-warnings/project.json
@@ -1,0 +1,9 @@
+{
+    "name": "Valid With Warnings",
+    "id": "valid-with-warnings",
+    "projectType": "web",
+    "settings": {
+        "locales": ["de-DE"]
+    },
+    "unknownProperty": true
+}

--- a/packages/loctool/test/testfiles/dual-config/loctool-config.json
+++ b/packages/loctool/test/testfiles/dual-config/loctool-config.json
@@ -1,0 +1,5 @@
+{
+    "name": "Dual Config Loctool",
+    "id": "loctest-loctool-config",
+    "projectType": "web"
+}

--- a/packages/loctool/test/testfiles/dual-config/project.json
+++ b/packages/loctool/test/testfiles/dual-config/project.json
@@ -1,0 +1,5 @@
+{
+    "name": "Dual Config Legacy",
+    "id": "loctest-legacy-project-json",
+    "projectType": "web"
+}

--- a/packages/loctool/test/testfiles/loctool-config-only/loctool-config.json
+++ b/packages/loctool/test/testfiles/loctool-config-only/loctool-config.json
@@ -1,0 +1,5 @@
+{
+    "name": "Loctool Config Only",
+    "id": "loctest-loctool-config-only",
+    "projectType": "web"
+}

--- a/packages/loctool/test/testfiles/loctool.json
+++ b/packages/loctool/test/testfiles/loctool.json
@@ -1,0 +1,19 @@
+{
+    "name": "Loctool Test",
+    "id": "loctest-alt",
+    "projectType": "web",
+    "pseudoLocale": "de-DE",
+    "resourceDirs": {
+        "yml": "config/locales",
+        "js": "public/localized_js"
+    },
+    "schema": "./appinfo.schema.json",
+    "excludes": [
+    ],
+    "includes": [
+        "config/notifications.yml"
+    ],
+    "settings": {
+        "locales": ["en-GB", "es-US", "zh-Hans-CN"]
+    }
+}

--- a/packages/loctool/test/testfiles/nx-and-loctool/loctool-config.json
+++ b/packages/loctool/test/testfiles/nx-and-loctool/loctool-config.json
@@ -1,0 +1,5 @@
+{
+    "name": "Nx And Loctool",
+    "id": "loctest-nx-and-loctool",
+    "projectType": "web"
+}

--- a/packages/loctool/test/testfiles/nx-and-loctool/project.json
+++ b/packages/loctool/test/testfiles/nx-and-loctool/project.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://nx.dev/schemas/project-schema.json",
+    "name": "nx-app",
+    "sourceRoot": "src"
+}

--- a/packages/loctool/test/testfiles/x/y/z/loctool.json
+++ b/packages/loctool/test/testfiles/x/y/z/loctool.json
@@ -1,0 +1,12 @@
+{
+    "name": "Nested Loctool Test",
+    "id": "loctest-nested",
+    "projectType": "web",
+    "pseudoLocale": "de-DE",
+    "resourceDirs": {
+        "yml": "config/locales"
+    },
+    "settings": {
+        "locales": ["en-GB", "de-DE"]
+    }
+}


### PR DESCRIPTION
- Add support for the --configFile parameter that allows callers to use a different file name for the config files in case there is a conflict with some other packages that uses "project.json" as its config file as well.
- Add support for recognizing config files as being loctool style config files or not. If not recognized, then they are not used to indicate a new subproject.
- Add support for the settings.javascript.template setting so that callers can use a regular loctool-style formatted
  path template if they like
- default behaviour is the same as it was before, which is to get the resource file path from the this.pathName if it exists or from the resourceDirs.js setting as before