### PR TITLE
ilib-loader: avoid dragging in NodeLoader to the webpack bundles

### DIFF
--- a/.changeset/sharp-dots-approve.md
+++ b/.changeset/sharp-dots-approve.md
@@ -1,0 +1,15 @@
+---
+"ilib-loader": minor
+---
+
+- Added the ability to have browser-only loaders
+  - Browsers can specify to use the webpack loader
+    automatically by putting
+    `"ilib-loader": "ilib-loader/browser"` in the
+    webpack.resolve.alias in the karma configuration.
+  - This will avoid dragging in the NodeLoader to the
+    webpack bundle, and all of its dependencies making
+    for a clean webpack build
+  - Loaders now check if the mode is async but the caller
+    requests a sync call. In this case, it now throws
+    because sync calls are not supported.

--- a/.changeset/sharp-dots-approve.md
+++ b/.changeset/sharp-dots-approve.md
@@ -1,5 +1,6 @@
 ---
 "ilib-loader": minor
+"ilib-localedata": patch
 ---
 
 - Added the ability to have browser-only loaders
@@ -13,3 +14,6 @@
   - Loaders now check if the mode is async but the caller
     requests a sync call. In this case, it now throws
     because sync calls are not supported.
+- Updated ilib-localedata to set the shared loader mode for sync and async
+  calls, and to use already-loaded assembled locale data when sync loading is
+  requested from an async-only loader.

--- a/packages/ilib-loader/README.md
+++ b/packages/ilib-loader/README.md
@@ -233,7 +233,7 @@ only the locale data needed for the locales that are being used.
 
 ## License
 
-Copyright © 2022-2023, 2026, JEDLSoft
+Copyright © 2022-2023, 2025-2026 JEDLSoft
 
 This package is released under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). The full license text is available in the [LICENSE](https://github.com/iLib-js/ilib-mono/blob/main/packages/ilib-loader/LICENSE) file in the ilib-mono repository on GitHub.
 

--- a/packages/ilib-loader/jest.config.cjs
+++ b/packages/ilib-loader/jest.config.cjs
@@ -1,6 +1,5 @@
 /*
- * LoaderFactory.js - create new loader objects or return existing
- * ones
+ * jest.config.cjs - Jest configuration for ilib-loader
  *
  * Copyright © 2022, 2025 JEDLSoft
  *
@@ -17,20 +16,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const { jestConfig } = require("ilib-internal");
 
-import { getPlatform } from 'ilib-env';
-import { Loader, registerLoader, LoaderFactory } from './LoaderFactory.js';
-import NodeLoader from './NodeLoader.js';
-import WebpackLoader from './WebpackLoader.js';
+const config = {
+    ...jestConfig,
+    testPathIgnorePatterns: [
+        '.*/test/WebpackLoader\\.test\\.js$'
+    ],
+    displayName: {
+        name: "ilib-common",
+        color: "blackBright",
+    },
+};
 
-switch (getPlatform()) {
-    case 'nodejs':
-        registerLoader(NodeLoader);
-        break;
-    case 'browser':
-        registerLoader(WebpackLoader);
-        break;
-}
+module.exports = config;
 
-export { Loader, registerLoader };
-export default LoaderFactory;

--- a/packages/ilib-loader/karma.conf.js
+++ b/packages/ilib-loader/karma.conf.js
@@ -1,37 +1,33 @@
+/*
+ * karma.conf.js - configure the karma testing environment
+ *
+ * Copyright © 2023, 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 const { createKarmaConfig } = require("ilib-internal");
 
 module.exports = function (config) {
     config.set(
         createKarmaConfig({
+            // list of files to exclude
+            exclude: [
+                "./test/NodeLoader.test.js"
+            ],
+
             // Additional webpack configuration specific to this package
             webpack: {
-                module: {
-                    rules: [
-                        {
-                            test: /\.js$/,
-                            exclude: /\/node_modules\//,
-                            use: {
-                                loader: "babel-loader",
-                                options: {
-                                    minified: false,
-                                    compact: false,
-                                    presets: [
-                                        [
-                                            "@babel/preset-env",
-                                            {
-                                                targets: {
-                                                    node: process.versions.node,
-                                                    browsers: "cover 99.5%",
-                                                },
-                                            },
-                                        ],
-                                    ],
-                                    plugins: ["add-module-exports", "@babel/plugin-transform-regenerator"],
-                                },
-                            },
-                        },
-                    ],
-                },
                 resolve: {
                     fallback: {
                         buffer: require.resolve("buffer"),

--- a/packages/ilib-loader/package.json
+++ b/packages/ilib-loader/package.json
@@ -7,6 +7,14 @@
         ".": {
             "import": "./src/index.js",
             "require": "./lib/index.js"
+        },
+        "./node": {
+            "import": "./src/index-node.js",
+            "require": "./lib/index-node.js"
+        },
+        "./browser": {
+            "import": "./src/index-browser.js",
+            "require": "./lib/index-browser.js"
         }
     },
     "description": "Loader to load text files in a cross-platform manner",

--- a/packages/ilib-loader/src/Loader.js
+++ b/packages/ilib-loader/src/Loader.js
@@ -106,6 +106,14 @@ class Loader {
     }
 
     /**
+     * Return the current sync mode.
+     * @returns {boolean} true if the loader is in synchronous mode, false otherwise.
+     */
+    getSyncMode() {
+        return this.sync;
+    }
+
+    /**
      * Add an array of paths to search for files.
      * @param {Array.<string>} paths to search
      */
@@ -174,6 +182,9 @@ class Loader {
      */
     loadFiles(paths, options) {
         let { sync } = options || {};
+        if (typeof(sync) === "boolean" && sync && !this.sync) {
+            throw new Error("This loader does not support synchronous loading of data.");
+        }
         sync = typeof(sync) === "boolean" ? sync : this.sync;
         let values = [];
         if (paths) {

--- a/packages/ilib-loader/src/LoaderFactory.js
+++ b/packages/ilib-loader/src/LoaderFactory.js
@@ -1,0 +1,79 @@
+/*
+ * LoaderFactory.js - shared loader registration and factory logic
+ *
+ * Copyright © 2022, 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getPlatform, top } from 'ilib-env';
+import Loader from './Loader.js';
+
+/**
+ * Register a loader with the loader factory. The loader must return
+ * which platforms it is a loader for.
+ *
+ * @param {Class} loaderClass a loader class from which to make an instance
+ */
+export function registerLoader(loaderClass) {
+    if (!loaderClass) return;
+
+    const globalScope = top();
+
+    if (!globalScope.ilib) {
+        globalScope.ilib = {};
+    }
+    if (!globalScope.ilib.classCache) {
+        globalScope.ilib.classCache = {};
+    }
+
+    var loader = new loaderClass();
+    const platforms = loader.getPlatforms();
+    if (platforms) {
+        platforms.forEach((platform) => {
+            globalScope.ilib.classCache[platform] = loader;
+        });
+    }
+}
+
+/**
+ * Factory method that returns a loader instance that is appropriate
+ * for the current platform. The current platform is determined using
+ * the ilib-env package.
+ *
+ * @returns {Loader} a loader instance for this platform
+ */
+export function LoaderFactory() {
+    const globalScope = top();
+
+    if (!globalScope.ilib || !globalScope.ilib.classCache) {
+        return undefined;
+    }
+
+    // special case because Webpack is not a platform:
+    if (typeof(__webpack_require__) !== 'undefined' && globalScope.ilib.classCache.webpack) {
+        return globalScope.ilib.classCache.webpack;
+    } else {
+        const platform = getPlatform();
+        if (globalScope.ilib.classCache[platform]) {
+            return globalScope.ilib.classCache[platform];
+        }
+    }
+
+    // No loader -- this platform is required to have all of the ilib data
+    // built-in.
+    return undefined;
+}
+
+export { Loader };

--- a/packages/ilib-loader/src/NodeLoader.js
+++ b/packages/ilib-loader/src/NodeLoader.js
@@ -122,6 +122,9 @@ class NodeLoader extends Loader {
     loadFile(pathName, options) {
         if (!pathName) return undefined;
         let { sync } = options || {};
+        if (typeof(sync) === "boolean" && sync && !this.sync) {
+            throw new Error("This loader does not support synchronous loading of data.");
+        }
         sync = typeof(sync) === "boolean" ? sync : this.sync;
         const isJs = pathName.endsWith(".js") || pathName.endsWith(".mjs") || pathName.endsWith(".cjs");
         const fullPath = isJs && pathName[0] !== "/" ? path.join(process.cwd(), pathName) : pathName;
@@ -129,6 +132,9 @@ class NodeLoader extends Loader {
         if (sync) {
             try {
                 this.logger.trace(`loadFile: loading file ${pathName} synchronously.`);
+                if (!fs.existsSync(fullPath)) {
+                    return undefined;
+                }
                 if (isJs) {
                     if (pathName.endsWith(".mjs")) {
                         // cannot load ESM modules synchronously

--- a/packages/ilib-loader/src/WebpackLoader.js
+++ b/packages/ilib-loader/src/WebpackLoader.js
@@ -1,7 +1,7 @@
 /*
  * WebpackLoader.js - Loader implementation for webpack'ed ilib
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022, 2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ class WebpackLoader extends Loader {
     constructor(options) {
         super(options);
 
+        this.sync = false;
         this.logger = log4js.getLogger("ilib-loader");
     }
 
@@ -60,6 +61,79 @@ class WebpackLoader extends Loader {
      */
     getName() {
         return "Webpack Loader";
+    }
+
+    /**
+     * Extract the relative path from a full path that should be loaded via calling-module.
+     *
+     * This method handles the conversion from full paths (as used by the caching layers)
+     * to relative paths that can be loaded via the calling-module webpack alias.
+     *
+     * If __CALLING_MODULE_PATH__ is defined (via webpack's DefinePlugin), it will be
+     * used to strip the prefix from the path. Otherwise, the method uses a heuristic
+     * to find the relative path by looking for the directory component right before
+     * locale-like filenames.
+     *
+     * For example, if the incoming path is './test/testfiles/files3/en-US.js' and
+     * __CALLING_MODULE_PATH__ is 'test/testfiles', this method returns 'files3/en-US.js'.
+     *
+     * @private
+     * @param {string} pathName the full path to extract from
+     * @returns {string} the relative path to use with calling-module
+     */
+    _extractRelativePath(pathName) {
+        // Normalize the path separators
+        const normalizedPath = pathName.replace(/\\/g, '/').replace(/^\.\//, '');
+
+        // If __CALLING_MODULE_PATH__ is defined, use it to strip the prefix
+        if (typeof __CALLING_MODULE_PATH__ !== 'undefined' && __CALLING_MODULE_PATH__) {
+            const normalizedBase = __CALLING_MODULE_PATH__.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/$/, '');
+
+            if (normalizedPath.startsWith(normalizedBase + '/')) {
+                return normalizedPath.substring(normalizedBase.length + 1);
+            }
+            if (normalizedPath.startsWith(normalizedBase)) {
+                return normalizedPath.substring(normalizedBase.length).replace(/^\//, '');
+            }
+        }
+
+        // Heuristic fallback: find the last path component before the locale file
+        // that looks like a root directory name. Common patterns:
+        // - files, files2, files3, etc. (test directories)
+        // - locale (production)
+        // - data, resources (other common names)
+        const parts = normalizedPath.split('/');
+        const filename = parts[parts.length - 1];
+
+        // Check if the filename looks like a locale file
+        const localePattern = /^([a-z][a-z](-[A-Z][a-z][a-z][a-z])?(-[A-Z][A-Z])?|root)\.(js|cjs|mjs|json)$/;
+        if (localePattern.test(filename)) {
+            // For pre-assembled locale files (e.g., en-US.js), the relative path
+            // is just the filename if there's no subdirectory structure
+            // But we need to include any root directory (e.g., files3/en-US.js)
+
+            // Look for root directory markers
+            for (let i = parts.length - 2; i >= 0; i--) {
+                const part = parts[i];
+                // Check for common root directory patterns
+                if (/^(files\d*|locale|data|resources)$/.test(part)) {
+                    return parts.slice(i).join('/');
+                }
+            }
+        }
+
+        // For hierarchical paths (e.g., files/en/US/tester.json), look for directory
+        // names that look like language or region codes
+        for (let i = 0; i < parts.length - 1; i++) {
+            const part = parts[i];
+            // If we find a directory that looks like it could be a root name
+            if (/^(files\d*|locale|data|resources)$/.test(part)) {
+                return parts.slice(i).join('/');
+            }
+        }
+
+        // Ultimate fallback: just the basename
+        return Path.basename(pathName);
     }
 
     /**
@@ -102,19 +176,29 @@ class WebpackLoader extends Loader {
      */
     loadFile(pathName, options) {
         if (!pathName || typeof(pathName) !== 'string') return undefined;
-        if (options && options.sync) {
-            throw "The webpack loader does not support synchronous loading of data.";
+        const { sync } = options || {};
+        if (typeof(sync) === "boolean" && sync && !this.sync) {
+            throw new Error("This loader does not support synchronous loading of data.");
         }
         this.logger.trace(`Loading file ${pathName} from webpack asynchronously`);
 
-        const fileName = Path.basename(pathName);
+        const relativePath = this._extractRelativePath(pathName);
 
         return import(
-            /* webpackInclude: /([a-z][a-z](-[A-Z][a-z][a-z][a-z])?(-[A-Z][A-Z])?|root).js(on)?$/ */
+            /* webpackInclude: /([a-z][a-z](-[A-Z][a-z][a-z][a-z])?(-[A-Z][A-Z])?|root)\.(js|cjs|mjs|json)$/ */
             /* webpackChunkName: "ilib.[request]" */
             /* webpackMode: "lazy" */
-            `calling-module/${fileName}`
-        ).catch((e) => {
+            `calling-module/${relativePath}`
+        ).then((module) => {
+            // Webpack wraps imports in a module object with a 'default' property.
+            // For JSON files, webpack parses the JSON and puts the result in .default.
+            // For JS modules, the module object contains the exports.
+            // We unwrap .default to return the actual content.
+            if (module && typeof module === 'object' && 'default' in module) {
+                return module.default;
+            }
+            return module;
+        }).catch((e) => {
             this.logger.trace(e);
             return undefined;
         });

--- a/packages/ilib-loader/src/WebpackLoader.js
+++ b/packages/ilib-loader/src/WebpackLoader.js
@@ -1,7 +1,7 @@
 /*
  * WebpackLoader.js - Loader implementation for webpack'ed ilib
  *
- * Copyright © 2022, 2025 JEDLSoft
+ * Copyright © 2022, 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ilib-loader/src/index-browser.js
+++ b/packages/ilib-loader/src/index-browser.js
@@ -1,6 +1,5 @@
 /*
- * LoaderFactory.js - create new loader objects or return existing
- * ones
+ * index-browser.js - Browser specific entry point for ilib-loader
  *
  * Copyright © 2022, 2025 JEDLSoft
  *
@@ -18,19 +17,10 @@
  * limitations under the License.
  */
 
-import { getPlatform } from 'ilib-env';
 import { Loader, registerLoader, LoaderFactory } from './LoaderFactory.js';
-import NodeLoader from './NodeLoader.js';
 import WebpackLoader from './WebpackLoader.js';
 
-switch (getPlatform()) {
-    case 'nodejs':
-        registerLoader(NodeLoader);
-        break;
-    case 'browser':
-        registerLoader(WebpackLoader);
-        break;
-}
+registerLoader(WebpackLoader);
 
 export { Loader, registerLoader };
 export default LoaderFactory;

--- a/packages/ilib-loader/src/index-node.js
+++ b/packages/ilib-loader/src/index-node.js
@@ -1,6 +1,5 @@
 /*
- * LoaderFactory.js - create new loader objects or return existing
- * ones
+ * index-node.js - Node.js specific entry point for ilib-loader
  *
  * Copyright © 2022, 2025 JEDLSoft
  *
@@ -18,19 +17,10 @@
  * limitations under the License.
  */
 
-import { getPlatform } from 'ilib-env';
 import { Loader, registerLoader, LoaderFactory } from './LoaderFactory.js';
 import NodeLoader from './NodeLoader.js';
-import WebpackLoader from './WebpackLoader.js';
 
-switch (getPlatform()) {
-    case 'nodejs':
-        registerLoader(NodeLoader);
-        break;
-    case 'browser':
-        registerLoader(WebpackLoader);
-        break;
-}
+registerLoader(NodeLoader);
 
 export { Loader, registerLoader };
 export default LoaderFactory;

--- a/packages/ilib-loader/src/index.js
+++ b/packages/ilib-loader/src/index.js
@@ -1,8 +1,7 @@
 /*
- * LoaderFactory.js - create new loader objects or return existing
- * ones
+ * index.js - create new loader objects or return existing ones
  *
- * Copyright © 2022, 2025 JEDLSoft
+ * Copyright © 2022, 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ilib-loader/test/Loader.test.js
+++ b/packages/ilib-loader/test/Loader.test.js
@@ -50,6 +50,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setSyncMode();
         const content = loader.loadFile("foobar.json", {sync: true});
         expect(content).toBe("foobar.json");
     });
@@ -60,6 +61,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setSyncMode();
         const content = loader.loadFile(undefined, {sync: true});
         expect(!content).toBeTruthy();
     });
@@ -70,6 +72,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setSyncMode();
         const content = loader.loadFile("", {sync: true});
         expect(!content).toBeTruthy();
     });
@@ -80,6 +83,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setSyncMode();
         const content = loader.loadFile("unknown.json", {sync: true});
         expect(!content).toBeTruthy();
     });
@@ -90,6 +94,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setAsyncMode();
         const promise = loader.loadFile("foobar.json", {sync: false});
         return promise.then((content) => {
             expect(content).toBe("foobar.json");
@@ -102,7 +107,8 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
-        const promise = loader.loadFile("foobar.json");
+        loader.setAsyncMode();
+        const promise = loader.loadFile("foobar.json", );
         return promise.then((content) => {
             expect(content).toBe("foobar.json");
         });
@@ -114,6 +120,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setSyncMode();
         const content = loader.loadFiles([
             "foobar.json",
             "asdf.json",
@@ -132,6 +139,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setAsyncMode();
         const promise = loader.loadFiles([
             "foobar.json",
             "asdf.json",
@@ -152,6 +160,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setSyncMode();
         const content = loader.loadFiles([
             "foobar.json",
             undefined,
@@ -170,6 +179,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setSyncMode();
         const content = loader.loadFiles([
             "foobar.json",
             "",
@@ -188,6 +198,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setAsyncMode();
         const promise = loader.loadFiles([
             "foobar.json",
             undefined,
@@ -208,6 +219,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setAsyncMode();
         const promise = loader.loadFiles([
             "foobar.json",
             "",
@@ -228,6 +240,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setSyncMode();
         const content = loader.loadFiles([
             "foobar.json",
             "unknown.json",
@@ -246,6 +259,7 @@ describe("testLoader", () => {
         const loader = LoaderFactory();
         expect(loader.getName()).toBe("Mock Loader");
 
+        loader.setAsyncMode();
         const promise = loader.loadFiles([
             "foobar.json",
             "unknown.json",
@@ -267,6 +281,7 @@ describe("testLoader", () => {
         expect(loader.getName()).toBe("Mock Loader");
         loader.setSyncMode();
 
+        loader.setSyncMode();
         const content = loader.loadFiles([
             "foobar.json",
             "asdf.json",
@@ -286,6 +301,7 @@ describe("testLoader", () => {
         expect(loader.getName()).toBe("Mock Loader");
         loader.setAsyncMode();
 
+        loader.setAsyncMode();
         const promise = loader.loadFiles([
             "foobar.json",
             "asdf.json",

--- a/packages/ilib-loader/test/MockLoader.js
+++ b/packages/ilib-loader/test/MockLoader.js
@@ -55,6 +55,9 @@ export default class MockLoader extends Loader {
 
     loadFile(pathName, options) {
         let { sync } = options || {};
+        if (typeof(sync) === "boolean" && sync && !this.sync) {
+            throw new Error("This loader does not support synchronous loading of data.");
+        }
         sync = typeof(sync) === "boolean" ? sync : this.sync;
 
         let text = pathName && pathName.length ? pathName : undefined;

--- a/packages/ilib-loader/test/NodeLoader.test.js
+++ b/packages/ilib-loader/test/NodeLoader.test.js
@@ -1,7 +1,7 @@
 /*
  * Nodeloader.test.js - test the loader on nodejs
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2023, 2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,26 +22,84 @@ import LoaderFactory, { registerLoader } from '../src/index.js';
 
 describe("testNodeLoader", () => {
     clearCache();
-
-    if (getPlatform() === "nodejs") {
         test("LoaderGetName", () => {
             expect.assertions(1);
             var loader = LoaderFactory();
             expect(loader.getName()).toBe("Nodejs Loader");
         });
 
-        test("LoaderSupportsSync", () => {
-            expect.assertions(1);
-            var loader = LoaderFactory();
-            expect(loader.supportsSync()).toBeTruthy();
-        });
+    test("LoaderSupportsSync", () => {
+        expect.assertions(1);
+        var loader = LoaderFactory();
+        expect(loader.supportsSync()).toBeTruthy();
+    });
 
-        test("LoadFileSync", () => {
-            expect.assertions(1);
+    test("LoaderSetAsyncMode", () => {
+        expect.assertions(5);
+        var loader = LoaderFactory();
+        loader.setAsyncMode();
+        expect(loader.getSyncMode()).toBe(false);
+        expect(loader.supportsSync()).toBe(true);
 
-            var loader = LoaderFactory();
+        expect(() => {
+            return loader.loadFile("./test/files/test.json", {sync: true});
+        }).toThrow("This loader does not support synchronous loading of data.");
 
-            var content = loader.loadFile("./test/files/test.json", {sync: true});
+        // set it back to clean up
+        loader.setSyncMode();
+        expect(loader.getSyncMode()).toBe(true);
+        expect(loader.supportsSync()).toBe(true);
+    });
+
+    test("LoadFileSync", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+
+        var content = loader.loadFile("./test/files/test.json", {sync: true});
+        expect(content).toBe(`{
+    "test": "this is a test",
+    "test2": {
+        "test3": "this is only a test"
+    }
+}`
+        );
+    });
+
+    test("LoadFileSyncUndefinedFileName", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+
+        var content = loader.loadFile(undefined, {sync: true});
+        expect(!content).toBeTruthy();
+    });
+
+    test("LoadFileSyncEmptyFileName", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+
+        var content = loader.loadFile("", {sync: true});
+        expect(!content).toBeTruthy();
+    });
+
+    test("LoadFileSyncUnknownFileName", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+
+        var content = loader.loadFile("unknown.json", {sync: true});
+        expect(!content).toBeTruthy();
+    });
+
+    test("LoadFileAsync", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+
+        var promise = loader.loadFile("./test/files/test.json", {sync: false});
+        return promise.then((content) => {
             expect(content).toBe(`{
     "test": "this is a test",
     "test2": {
@@ -50,77 +108,62 @@ describe("testNodeLoader", () => {
 }`
             );
         });
+    });
 
-        test("LoadFileSyncUndefinedFileName", () => {
-            expect.assertions(1);
+    test("LoadFileAsyncDefault", () => {
+        expect.assertions(1);
 
-            var loader = LoaderFactory();
+        var loader = LoaderFactory();
 
-            var content = loader.loadFile(undefined, {sync: true});
-            expect(!content).toBeTruthy();
-        });
-
-        test("LoadFileSyncEmptyFileName", () => {
-            expect.assertions(1);
-
-            var loader = LoaderFactory();
-
-            var content = loader.loadFile("", {sync: true});
-            expect(!content).toBeTruthy();
-        });
-
-        test("LoadFileSyncUnknownFileName", () => {
-            expect.assertions(1);
-
-            var loader = LoaderFactory();
-
-            var content = loader.loadFile("unknown.json", {sync: true});
-            expect(!content).toBeTruthy();
-        });
-
-        test("LoadFileAsync", () => {
-            expect.assertions(1);
-
-            var loader = LoaderFactory();
-
-            var promise = loader.loadFile("./test/files/test.json", {sync: false});
-            return promise.then((content) => {
-                expect(content).toBe(`{
+        // have to set async mode to test this because the factory sends you back a
+        // singleton and the other tests have messed with the mode already
+        loader.setAsyncMode();
+        var promise = loader.loadFile("./test/files/test.json");
+        return promise.then((content) => {
+            expect(content).toBe(`{
     "test": "this is a test",
     "test2": {
         "test3": "this is only a test"
     }
 }`
-                );
-            });
+            );
         });
+    });
 
-        test("LoadFileAsyncDefault", () => {
-            expect.assertions(1);
+    test("LoadFilesSync", () => {
+        expect.assertions(1);
 
-            var loader = LoaderFactory();
+        var loader = LoaderFactory();
 
-            var promise = loader.loadFile("./test/files/test.json");
-            return promise.then((content) => {
-                expect(content).toBe(`{
+        loader.setSyncMode();
+        var content = loader.loadFiles([
+            "./test/files/test.json",
+            "./test/files/a/asdf.json"
+        ], {sync: true});
+        expect(content).toEqual([
+`{
     "test": "this is a test",
     "test2": {
         "test3": "this is only a test"
     }
+}`,
+`{
+    "name": "foo",
+    "value": "asdf"
 }`
-                );
-            });
-        });
+        ]);
+    });
 
-        test("LoadFilesSync", () => {
-            expect.assertions(1);
+    test("LoadFilesAsync", () => {
+        expect.assertions(1);
 
-            var loader = LoaderFactory();
+        var loader = LoaderFactory();
 
-            var content = loader.loadFiles([
-                "./test/files/test.json",
-                "./test/files/a/asdf.json"
-            ], {sync: true});
+        var promise = loader.loadFiles([
+            "./test/files/test.json",
+            "./test/files/a/asdf.json"
+        ], {sync: false});
+        return promise.then((content) => {
             expect(content).toEqual([
 `{
     "test": "this is a test",
@@ -134,43 +177,19 @@ describe("testNodeLoader", () => {
 }`
             ]);
         });
+    });
 
-        test("LoadFilesAsync", () => {
-            expect.assertions(1);
+    test("LoadFilesSyncUndefinedFileName", () => {
+        expect.assertions(1);
 
-            var loader = LoaderFactory();
+        var loader = LoaderFactory();
 
-            var promise = loader.loadFiles([
-                "./test/files/test.json",
-                "./test/files/a/asdf.json"
-            ], {sync: false});
-            return promise.then((content) => {
-                expect(content).toEqual([
-`{
-    "test": "this is a test",
-    "test2": {
-        "test3": "this is only a test"
-    }
-}`,
-`{
-    "name": "foo",
-    "value": "asdf"
-}`
-                ]);
-            });
-        });
-
-        test("LoadFilesSyncUndefinedFileName", () => {
-            expect.assertions(1);
-
-            var loader = LoaderFactory();
-
-            var content = loader.loadFiles([
-                "./test/files/test.json",
-                undefined,
-                "./test/files/a/asdf.json"
-            ], {sync: true});
-            expect(content).toEqual([
+        var content = loader.loadFiles([
+            "./test/files/test.json",
+            undefined,
+            "./test/files/a/asdf.json"
+        ], {sync: true});
+        expect(content).toEqual([
 `{
     "test": "this is a test",
     "test2": {
@@ -182,19 +201,45 @@ describe("testNodeLoader", () => {
     "name": "foo",
     "value": "asdf"
 }`
-            ]);
-        });
+        ]);
+    });
 
-        test("LoadFilesSyncEmptyFileName", () => {
-            expect.assertions(1);
+    test("LoadFilesSyncEmptyFileName", () => {
+        expect.assertions(1);
 
-            var loader = LoaderFactory();
+        var loader = LoaderFactory();
 
-            var content = loader.loadFiles([
-                "./test/files/test.json",
-                "",
-                "./test/files/a/asdf.json"
-            ], {sync: true});
+        var content = loader.loadFiles([
+            "./test/files/test.json",
+            "",
+            "./test/files/a/asdf.json"
+        ], {sync: true});
+        expect(content).toEqual([
+`{
+    "test": "this is a test",
+    "test2": {
+        "test3": "this is only a test"
+    }
+}`,
+                undefined,
+`{
+    "name": "foo",
+    "value": "asdf"
+}`
+        ]);
+    });
+
+    test("LoadFilesAsyncUndefinedFileName", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+
+        var promise = loader.loadFiles([
+            "./test/files/test.json",
+            undefined,
+            "./test/files/a/asdf.json"
+        ], {sync: false});
+        return promise.then((content) => {
             expect(content).toEqual([
 `{
     "test": "this is a test",
@@ -209,71 +254,19 @@ describe("testNodeLoader", () => {
 }`
             ]);
         });
+    });
 
-        test("LoadFilesAsyncUndefinedFileName", () => {
-            expect.assertions(1);
+    test("LoadFilesAsyncEmptyFileName", () => {
+        expect.assertions(1);
 
-            var loader = LoaderFactory();
+        var loader = LoaderFactory();
 
-            var promise = loader.loadFiles([
-                "./test/files/test.json",
-                undefined,
-                "./test/files/a/asdf.json"
-            ], {sync: false});
-            return promise.then((content) => {
-                expect(content).toEqual([
-`{
-    "test": "this is a test",
-    "test2": {
-        "test3": "this is only a test"
-    }
-}`,
-                undefined,
-`{
-    "name": "foo",
-    "value": "asdf"
-}`
-                ]);
-            });
-        });
-
-        test("LoadFilesAsyncEmptyFileName", () => {
-            expect.assertions(1);
-
-            var loader = LoaderFactory();
-
-            var promise = loader.loadFiles([
-                "./test/files/test.json",
-                "",
-                "./test/files/a/asdf.json"
-            ], {sync: false});
-            return promise.then((content) => {
-                expect(content).toEqual([
-`{
-    "test": "this is a test",
-    "test2": {
-        "test3": "this is only a test"
-    }
-}`,
-                undefined,
-`{
-    "name": "foo",
-    "value": "asdf"
-}`
-                ]);
-            });
-        });
-
-        test("LoadFilesSyncUnknownFileName", () => {
-            expect.assertions(1);
-
-            var loader = LoaderFactory();
-
-            var content = loader.loadFiles([
-                "./test/files/test.json",
-                "./test/files/asdf.test.json",
-                "./test/files/a/asdf.json"
-            ], {sync: true});
+        var promise = loader.loadFiles([
+            "./test/files/test.json",
+            "",
+            "./test/files/a/asdf.json"
+        ], {sync: false});
+        return promise.then((content) => {
             expect(content).toEqual([
 `{
     "test": "this is a test",
@@ -288,19 +281,19 @@ describe("testNodeLoader", () => {
 }`
             ]);
         });
+    });
 
-        test("LoadFilesAsyncUnknownFileName", () => {
-            expect.assertions(1);
+    test("LoadFilesSyncUnknownFileName", () => {
+        expect.assertions(1);
 
-            var loader = LoaderFactory();
+        var loader = LoaderFactory();
 
-            var promise = loader.loadFiles([
-                "./test/files/test.json",
-                "./test/files/asdf.test.json",
-                "./test/files/a/asdf.json"
-            ], {sync: false});
-            return promise.then((content) => {
-                expect(content).toEqual([
+        var content = loader.loadFiles([
+            "./test/files/test.json",
+            "./test/files/asdf.test.json",
+            "./test/files/a/asdf.json"
+        ], {sync: true});
+        expect(content).toEqual([
 `{
     "test": "this is a test",
     "test2": {
@@ -312,21 +305,20 @@ describe("testNodeLoader", () => {
     "name": "foo",
     "value": "asdf"
 }`
-                ]);
-            });
-        });
+        ]);
+    });
 
-        test("LoadFilesSyncMode", () => {
-            expect.assertions(1);
+    test("LoadFilesAsyncUnknownFileName", () => {
+        expect.assertions(1);
 
-            var loader = LoaderFactory();
-            loader.setSyncMode();
+        var loader = LoaderFactory();
 
-            var content = loader.loadFiles([
-                "./test/files/test.json",
-                "./test/files/asdf.test.json",
-                "./test/files/a/asdf.json"
-            ]);
+        var promise = loader.loadFiles([
+            "./test/files/test.json",
+            "./test/files/asdf.test.json",
+            "./test/files/a/asdf.json"
+        ], {sync: false});
+        return promise.then((content) => {
             expect(content).toEqual([
 `{
     "test": "this is a test",
@@ -341,20 +333,47 @@ describe("testNodeLoader", () => {
 }`
             ]);
         });
+    });
 
-        test("LoadFilesAsync", () => {
-            expect.assertions(1);
+    test("LoadFilesSyncMode", () => {
+        expect.assertions(1);
 
-            var loader = LoaderFactory();
-            loader.setAsyncMode();
+        var loader = LoaderFactory();
+        loader.setSyncMode();
 
-            var promise = loader.loadFiles([
-                "./test/files/test.json",
-                "./test/files/asdf.test.json",
-                "./test/files/a/asdf.json"
-            ]);
-            return promise.then((content) => {
-                expect(content).toEqual([
+        var content = loader.loadFiles([
+            "./test/files/test.json",
+            "./test/files/asdf.test.json",
+            "./test/files/a/asdf.json"
+        ]);
+        expect(content).toEqual([
+`{
+    "test": "this is a test",
+    "test2": {
+        "test3": "this is only a test"
+    }
+}`,
+                undefined,
+`{
+    "name": "foo",
+    "value": "asdf"
+}`
+        ]);
+    });
+
+    test("LoadFilesAsync", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+        loader.setAsyncMode();
+
+        var promise = loader.loadFiles([
+            "./test/files/test.json",
+            "./test/files/asdf.test.json",
+            "./test/files/a/asdf.json"
+        ]);
+        return promise.then((content) => {
+            expect(content).toEqual([
 `{
     "test": "this is a test",
     "test2": {
@@ -366,131 +385,202 @@ describe("testNodeLoader", () => {
     "name": "foo",
     "value": "asdf"
 }`
-                ]);
-            });
-        });
-
-        test("LoadFilesJsSyncModeRightTypeCommonJs", () => {
-            expect.assertions(2);
-
-            var loader = LoaderFactory();
-            loader.setSyncMode();
-
-            var content = loader.loadFiles([
-                "./test/files/testcommon.js"
             ]);
-            expect(content.length).toBe(1);
-            expect(typeof(content[0])).toBe('function');
         });
+    });
 
-        test("LoadFilesJsSyncModeRightTypeESModule", () => {
-            expect.assertions(2);
+    test("LoadFilesJsSyncModeRightTypeCommonJs", () => {
+        expect.assertions(2);
 
-            var loader = LoaderFactory();
-            loader.setSyncMode();
+        var loader = LoaderFactory();
+        loader.setSyncMode();
 
-            var content = loader.loadFiles([
-                "./test/files/a/asdf.mjs"
-            ]);
-            expect(content.length).toBe(1);
+        var content = loader.loadFiles([
+            "./test/files/testcommon.js"
+        ]);
+        expect(content.length).toBe(1);
+        expect(typeof(content[0])).toBe('function');
+    });
 
-            // cannot load ES modules synchronously
-            expect(typeof(content[0])).toBe('undefined');
+    test("LoadFilesJsSyncModeRightTypeESModule", () => {
+        expect.assertions(2);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFiles([
+            "./test/files/a/asdf.mjs"
+        ]);
+        expect(content.length).toBe(1);
+
+        // cannot load ES modules synchronously
+        expect(typeof(content[0])).toBe('undefined');
+    });
+
+    test("LoadFilesJsSyncModeNonExistantFile", () => {
+        expect.assertions(2);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFiles([
+            "./test/files/asdf.test.js"
+        ]);
+        expect(content.length).toBe(1);
+        expect(typeof(content[0])).toBe('undefined');
+    });
+
+    test("LoadFilesJsSyncModeRightTypesMultiple", () => {
+        expect.assertions(4);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFiles([
+            "./test/files/testcommon.js",
+            "./test/files/test.cjs",
+            "./test/files/a/asdf.mjs"
+        ]);
+        expect(content.length).toBe(3);
+        expect(typeof(content[0])).toBe('function');
+        expect(typeof(content[1])).toBe('function');
+        expect(typeof(content[2])).toBe('undefined');
+    });
+
+    test("LoadFilesJsSyncModeRightContent", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFiles([
+            "./test/files/testcommon.js",
+            "./test/files/asdf.test.js"
+        ]);
+        expect(content[0]()).toStrictEqual({
+            "test": "this is a test",
+            "test2": {
+                "test3": "this is only a test"
+            }
         });
+    });
 
-        test("LoadFilesJsSyncModeNonExistantFile", () => {
-            expect.assertions(2);
+    test("LoadFilesJsAsyncRightTypesMultiple", () => {
+        expect.assertions(3);
 
-            var loader = LoaderFactory();
-            loader.setSyncMode();
+        var loader = LoaderFactory();
+        loader.setAsyncMode();
 
-            var content = loader.loadFiles([
-                "./test/files/asdf.test.js"
-            ]);
-            expect(content.length).toBe(1);
-            expect(typeof(content[0])).toBe('undefined');
+        return loader.loadFiles([
+            "./test/files/testcommon.js",
+            "./test/files/a/asdf.mjs"
+        ]).then(content => {
+            expect(content.length).toBe(2);
+            expect(typeof(content[0])).toBe('object');
+
+            // ES modules can be loaded asynchronously
+            expect(typeof(content[1])).toBe('object');
         });
+    });
 
-        test("LoadFilesJsSyncModeRightTypesMultiple", () => {
-            expect.assertions(4);
+    test("LoadFilesJsAsyncRightContent", () => {
+        expect.assertions(2);
 
-            var loader = LoaderFactory();
-            loader.setSyncMode();
+        var loader = LoaderFactory();
+        loader.setAsyncMode();
 
-            var content = loader.loadFiles([
-                "./test/files/testcommon.js",
-                "./test/files/test.cjs",
-                "./test/files/a/asdf.mjs"
-            ]);
-            expect(content.length).toBe(3);
-            expect(typeof(content[0])).toBe('function');
-            expect(typeof(content[1])).toBe('function');
-            expect(typeof(content[2])).toBe('undefined');
-        });
-
-        test("LoadFilesJsSyncModeRightContent", () => {
-            expect.assertions(1);
-
-            var loader = LoaderFactory();
-            loader.setSyncMode();
-
-            var content = loader.loadFiles([
-                "./test/files/testcommon.js",
-                "./test/files/asdf.test.js"
-            ]);
-            expect(content[0]()).toStrictEqual({
+        return loader.loadFiles([
+            "./test/files/testcommon.js",
+            "./test/files/asdf.test.js",
+            "./test/files/a/asdf.mjs"
+        ]).then(content => {
+            expect(content[0].default()).toStrictEqual({
                 "test": "this is a test",
                 "test2": {
                     "test3": "this is only a test"
                 }
             });
-        });
-
-        test("LoadFilesJsAsyncRightTypesMultiple", () => {
-            expect.assertions(3);
-
-            var loader = LoaderFactory();
-            loader.setAsyncMode();
-
-            return loader.loadFiles([
-                "./test/files/testcommon.js",
-                "./test/files/a/asdf.mjs"
-            ]).then(content => {
-                expect(content.length).toBe(2);
-                expect(typeof(content[0])).toBe('object');
-
-                // ES modules can be loaded asynchronously
-                expect(typeof(content[1])).toBe('object');
+            // ES modules can be loaded asynchronously
+            expect(content[2].default()).toStrictEqual({
+                "name": "foo",
+                "value": "asdf"
             });
         });
+    });
 
-        test("LoadFilesJsAsyncRightContent", () => {
-            expect.assertions(2);
+    test("LoadFilesJsAsyncRightTypesMultiple", () => {
+        expect.assertions(3);
 
-            var loader = LoaderFactory();
-            loader.setAsyncMode();
+        var loader = LoaderFactory();
+        loader.setAsyncMode();
 
-            return loader.loadFiles([
-                "./test/files/testcommon.js",
-                "./test/files/asdf.test.js",
-                "./test/files/a/asdf.mjs"
-            ]).then(content => {
-                expect(content[0].default()).toStrictEqual({
-                    "test": "this is a test",
-                    "test2": {
-                        "test3": "this is only a test"
-                    }
-                });
-                // ES modules can be loaded asynchronously
-                expect(content[2].default()).toStrictEqual({
-                    "name": "foo",
-                    "value": "asdf"
-                });
+        return loader.loadFiles([
+            "./test/files/testcommon.js",
+            "./test/files/a/asdf.mjs"
+        ]).then(content => {
+            expect(content.length).toBe(2);
+            expect(typeof(content[0])).toBe('object');
+
+            // ES modules can be loaded asynchronously
+            expect(typeof(content[1])).toBe('object');
+        });
+    });
+
+    test("LoadFilesJsAsyncRightContent", () => {
+        expect.assertions(2);
+
+        var loader = LoaderFactory();
+        loader.setAsyncMode();
+
+        return loader.loadFiles([
+            "./test/files/testcommon.js",
+            "./test/files/asdf.test.js",
+            "./test/files/a/asdf.mjs"
+        ]).then(content => {
+            expect(content[0].default()).toStrictEqual({
+                "test": "this is a test",
+                "test2": {
+                    "test3": "this is only a test"
+                }
+            });
+            // ES modules can be loaded asynchronously
+            expect(content[2].default()).toStrictEqual({
+                "name": "foo",
+                "value": "asdf"
             });
         });
-    } else {
-        test("fake", () => {
-            expect(1+1).toBe(2);
-        });
-    }
+    });
+
+    test("loading a commonjs file synchronously which does not exist", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFile("./test/files/asdf.cjs", {sync: true});
+        // should not throw an exception
+        expect(content).toBeUndefined();
+    });
+
+    test("loading an ES module file synchronously which does not exist", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+        loader.setAsyncMode();
+
+        expect(() => {
+            return loader.loadFile("./test/files/asdf.mjs", {sync: true});
+        }).toThrow("This loader does not support synchronous loading of data.");
+    });
+
+    test("loading a unknown type of js file synchronously which does not exist", () => {
+        expect.assertions(1);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFile("./test/files/asdf.js", {sync: true});
+        // should not throw an exception
+        expect(content).toBeUndefined();
+    });
 });

--- a/packages/ilib-loader/test/WebpackLoader.test.js
+++ b/packages/ilib-loader/test/WebpackLoader.test.js
@@ -1,7 +1,7 @@
 /*
  * Webpackloader.test.js - test the loader under webpack
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2023, 2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import { getPlatform } from 'ilib-env';
 import LoaderFactory, { registerLoader } from '../src/index.js';
 
 describe("testWebpackLoader", () => {
-    if (getPlatform() === "browser") {
         test("LoaderGetName", () => {
             expect.assertions(1);
             var loader = LoaderFactory();
@@ -34,14 +33,26 @@ describe("testWebpackLoader", () => {
             expect(!loader.supportsSync()).toBeTruthy();
         });
 
-        test("LoadFileSync", () => {
-            expect.assertions(1);
+        test("LoadFileSync should throw because sync is not supported", () => {
+            expect.assertions(3);
 
             var loader = LoaderFactory();
+            expect(loader.getSyncMode()).toBe(false);
+            expect(loader.supportsSync()).toBe(false);
 
             expect(() => {
                 return loader.loadFile("root.js", {sync: true});
-            }).toThrow();
+            }).toThrow(new Error("This loader does not support synchronous loading of data."));
+        });
+
+        test("Loader set sync mode should not work", () => {
+            expect.assertions(2);
+            var loader = LoaderFactory();
+
+            // should not be able to set sync mode
+            loader.setSyncMode();
+            expect(loader.getSyncMode()).toBe(false);
+            expect(loader.supportsSync()).toBe(false);
         });
 
         test("LoadFileAsync", () => {
@@ -544,9 +555,4 @@ describe("testWebpackLoader", () => {
                 });
             });
         });
-    } else {
-        test("fake", () => {
-            expect(1+1).toBe(2);
-        });
-    }
 });

--- a/packages/ilib-localedata/src/LocaleData.js
+++ b/packages/ilib-localedata/src/LocaleData.js
@@ -302,6 +302,11 @@ class LocaleData {
 
         this.loader = LoaderFactory();
         this.sync = typeof(sync) === "boolean" && sync && (!this.loader || this.loader.supportsSync());
+        if (this.sync && this.loader) {
+            this.loader.setSyncMode();
+        } else if (this.loader) {
+            this.loader.setAsyncMode();
+        }
         this.cache = DataCache.getDataCache();
         this.logger = log4js.getLogger("ilib-localedata");
         this.path = path;
@@ -415,6 +420,14 @@ class LocaleData {
             }
         }
 
+        if (this.loader) {
+            if (sync && this.loader.supportsSync()) {
+                this.loader.setSyncMode();
+            } else {
+                this.loader.setAsyncMode();
+            }
+        }
+
         function mergeData(files) {
             if (mostSpecific) {
                 return files.reduce((previous, current) => {
@@ -449,6 +462,18 @@ class LocaleData {
             }, {});
         }
 
+        const isFileLoaded = (file) => {
+            if (file.data || this.cache.isLoaded(file.name)) {
+                return true;
+            }
+            if (!sync || this.loader.supportsSync()) {
+                return false;
+            }
+            const spec = file.locale.getSpec();
+            return this.cache.isLoaded(Path.join(file.root, `${spec}.js`)) ||
+                this.cache.isLoaded(Path.join(file.root, `${spec}.json`));
+        };
+
         // for async operation, try loading the assembled locale data file first
         // so that we don't have to load a bunch of individual files
         let promise = (!sync && !this.cache.isLoaded(`${loc.getSpec()}.js`)) ?
@@ -466,19 +491,21 @@ class LocaleData {
             const count = files.filter(file => !file.data).length;
             if (count) {
                 const fileNames = files.map((file) => {
-                    return (file.data || this.cache.isLoaded(file.name)) ? undefined : file.name;
+                    return isFileLoaded(file) ? undefined : file.name;
                 });
-                const data = this.loader.loadFiles(fileNames, {sync});
-                data.forEach((datum, i) => {
-                    if (!files[i].data) {
-                        // null indicates we attempted to load the file, but
-                        // there was no data or the file did not exist
-                        this.cache.markFileAsLoaded(fileNames[i]);
-                        const parsed = datum ? parseData(datum, fileNames[i]) : null;
-                        this.cache.storeData(files[i].root, basename, files[i].locale, parsed);
-                        files[i].data = parsed;
-                    }
-                });
+                if (fileNames.some(fileName => fileName)) {
+                    const data = this.loader.loadFiles(fileNames, {sync});
+                    data.forEach((datum, i) => {
+                        if (!files[i].data) {
+                            // null indicates we attempted to load the file, but
+                            // there was no data or the file did not exist
+                            this.cache.markFileAsLoaded(fileNames[i]);
+                            const parsed = datum ? parseData(datum, fileNames[i]) : null;
+                            this.cache.storeData(files[i].root, basename, files[i].locale, parsed);
+                            files[i].data = parsed;
+                        }
+                    });
+                }
             }
 
             return mergeData(files);
@@ -488,21 +515,23 @@ class LocaleData {
                 const count = files.filter(file => !file.data).length;
                 if (count) {
                     const fileNames = files.map((file) => {
-                        return (file.data || this.cache.isLoaded(file)) ? undefined : file.name;
+                        return isFileLoaded(file) ? undefined : file.name;
                     });
-                    return this.loader.loadFiles(fileNames, {sync}).then((data) => {
-                        data.forEach((datum, i) => {
-                            // record that we already attempted to load this
-                            this.cache.markFileAsLoaded(fileNames[i]);
-                            if (!files[i].data) {
-                                // null indicates we attempted to load the file, but
-                                // there was no data or the file did not exist
-                                const parsed = datum ? parseData(datum, fileNames[i]) : null;
-                                this.cache.storeData(files[i].root, basename, files[i].locale, parsed);
-                                files[i].data = parsed;
-                            }
+                    if (fileNames.some(fileName => fileName)) {
+                        return this.loader.loadFiles(fileNames, {sync}).then((data) => {
+                            data.forEach((datum, i) => {
+                                // record that we already attempted to load this
+                                this.cache.markFileAsLoaded(fileNames[i]);
+                                if (!files[i].data) {
+                                    // null indicates we attempted to load the file, but
+                                    // there was no data or the file did not exist
+                                    const parsed = datum ? parseData(datum, fileNames[i]) : null;
+                                    this.cache.storeData(files[i].root, basename, files[i].locale, parsed);
+                                    files[i].data = parsed;
+                                }
+                            });
                         });
-                    });
+                    }
                 }
             });
             return promise.then(() => mergeData(files));
@@ -694,6 +723,9 @@ class LocaleData {
         const spec = loc.getSpec();
 
         const loader = LoaderFactory();
+        if (loader) {
+            loader.setAsyncMode();
+        }
         const cache = DataCache.getDataCache();
         const subLocales = Utils.getSublocales(locale);
         let files = [];

--- a/packages/ilib-localedata/test/testLocaleData.js
+++ b/packages/ilib-localedata/test/testLocaleData.js
@@ -458,7 +458,7 @@ export const testLocaleData = {
             test.ok(result);
 
             const locData = new LocaleData({
-                path: "./test/files",
+                path: "./test/files3",
                 sync: false
             });
 
@@ -517,7 +517,7 @@ export const testLocaleData = {
             test.ok(result);
 
             const locData = new LocaleData({
-                path: "./test/files",
+                path: "./test/files3",
                 sync: false
             });
 


### PR DESCRIPTION
- Browsers can specify to use the webpack loader automatically by putting `"ilib-loader": "ilib-loader/browser"` in the webpack.resolve.alias in the karma configuration.
- This will avoid dragging in the NodeLoader to the webpack bundle, and all of its dependencies making for a clean webpack build
- Loaders now check if the mode is async but the caller requests a sync call. In this case, it now throws because sync calls are not supported.