### PR TITLE
ilib-assemble: resolve assemble.mjs from package root in mergeJson

### DIFF
--- a/.changeset/smart-cycles-lie.md
+++ b/.changeset/smart-cycles-lie.md
@@ -1,0 +1,7 @@
+---
+"ilib-assemble": patch
+---
+
+Fix `--mergeJson` to also resolve `assemble.mjs` from the package root
+(`<ilibPath>/assemble.mjs`), so it works against installed ilib packages and
+not just the source-tree layout (`<ilibPath>/js/assembleData/assemble.mjs`).

--- a/packages/ilib-assemble/src/mergeJson.js
+++ b/packages/ilib-assemble/src/mergeJson.js
@@ -18,6 +18,7 @@
  */
 
 import { pathToFileURL } from 'url';
+import { existsSync } from 'node:fs';
 import path from 'path';
 import readLines from './readLines.js';
 import write from './write.js';
@@ -57,7 +58,18 @@ function mergeJson(options) {
     }
 
     const ilibPath = path.resolve(options.opt.ilibPath || "./");
-    const assemblePath = path.resolve(ilibPath, "js/assembleData", "assemble.mjs");
+    // In the source tree assemble.mjs lives at js/assembleData/; in a published
+    // package it is copied to the package root next to the lib/ and locale/ dirs.
+    const candidates = [
+        path.resolve(ilibPath, "js/assembleData", "assemble.mjs"),
+        path.resolve(ilibPath, "assemble.mjs"),
+    ];
+    const assemblePath = candidates.find(existsSync);
+    if (!assemblePath) {
+        return Promise.reject(new Error(
+            `Could not find assemble.mjs under ilib path "${ilibPath}" (looked in: ${candidates.join(", ")})`
+        ));
+    }
     return import(pathToFileURL(assemblePath).href)
         .then(({ assemble }) => {
             const result_data = assemble([...ilibModules], options);

--- a/packages/ilib-assemble/test/mergeJson.test.js
+++ b/packages/ilib-assemble/test/mergeJson.test.js
@@ -202,6 +202,25 @@ describe("testMergeJson", () => {
         expect(fs.existsSync(path.join(OUTPUT_DIR, "en.json"))).toBeTruthy();
     });
 
+    test("MergeJsonResolvesPackageRootAssemble", async () => {
+        expect.assertions(2);
+        // ilibPath points at a package-root layout where assemble.mjs sits at
+        // the root rather than under js/assembleData/ (the published-package case).
+        const options = {
+            args: [OUTPUT_DIR],
+            opt: {
+                ilibincPath: "test/testfiles/ilib-all-inc.js",
+                ilibPath: "test/pkg-root",
+                locales: ["en"]
+            }
+        };
+        await mergeJson(options);
+        const content = fs.readFileSync(path.join(OUTPUT_DIR, "en.json"), "utf-8");
+        const parsed = JSON.parse(content);
+        expect(parsed.locale).toBe("en");
+        expect(parsed.layout).toBe("package-root");
+    });
+
     test("MergeJsonInvalidIlibPathRejects", async () => {
         expect.assertions(1);
         const options = {
@@ -212,7 +231,7 @@ describe("testMergeJson", () => {
                 locales: ["en"]
             }
         };
-        await expect(mergeJson(options)).rejects.toThrow("mergeJson failed:");
+        await expect(mergeJson(options)).rejects.toThrow("Could not find assemble.mjs");
     });
 
     test("MergeJsonRejectsEmptyAssembleResult", async () => {

--- a/packages/ilib-assemble/test/pkg-root/assemble.mjs
+++ b/packages/ilib-assemble/test/pkg-root/assemble.mjs
@@ -26,7 +26,7 @@
  * @returns {object} locale-keyed merged data map
  */
 export function assemble(modules, options) {
-    const locales = (options && options.opt && options.opt.locales) || ["en", "de"];
+    const locales = (options?.opt?.locales) || ["en", "de"];
     const result = {};
     locales.forEach(locale => {
         result[locale] = {

--- a/packages/ilib-assemble/test/pkg-root/assemble.mjs
+++ b/packages/ilib-assemble/test/pkg-root/assemble.mjs
@@ -1,0 +1,39 @@
+/*
+ * assemble.mjs - mock assembler at the package root for testing mergeJson
+ *
+ * Copyright © 2026 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Mock assemble function living at the package root (published-package layout),
+ * as opposed to test/js/assembleData/assemble.mjs (source-tree layout).
+ *
+ * @param {string[]} modules - list of ilib module names
+ * @param {object} options - ilib-assemble options object
+ * @returns {object} locale-keyed merged data map
+ */
+export function assemble(modules, options) {
+    const locales = (options && options.opt && options.opt.locales) || ["en", "de"];
+    const result = {};
+    locales.forEach(locale => {
+        result[locale] = {
+            modules: modules,
+            locale: locale,
+            layout: "package-root"
+        };
+    });
+    return result;
+}


### PR DESCRIPTION
## Summary

`--mergeJson` previously only looked for `assemble.mjs` at the source-tree
location `<ilibPath>/js/assembleData/assemble.mjs`. When `--ilibPath` points at
an **installed ilib package** — where `assemble.mjs` sits at the package root
next to `lib/` and `locale/` — the file was not found and the command failed.

## Changes

- Resolve `assemble.mjs` from a list of candidate paths: source-tree location
  first, then the package root (`<ilibPath>/assemble.mjs`).
- Reject early with a clear error listing the paths tried when neither exists.
- Add `MergeJsonResolvesPackageRootAssemble` test plus a `test/pkg-root/` fixture.

## Testing

- `pnpm test` in `packages/ilib-assemble` — all 18 tests pass.