### PR TITLE
ilib-loctool-mdx: Fixed a problem where it would not localize a path that looked like a language code

### DIFF
--- a/.changeset/curvy-flies-brush.md
+++ b/.changeset/curvy-flies-brush.md
@@ -1,0 +1,9 @@
+---
+"ilib-loctool-mdx": patch
+---
+
+- Fixed a problem where 2-letter lower-case directories are skipped
+  for localization because they look like they might be language
+  codes.
+- Fix was to actually check if the 2 letters are an actual ISO 639
+  language code.

--- a/packages/ilib-loctool-mdx/MdxFileType.js
+++ b/packages/ilib-loctool-mdx/MdxFileType.js
@@ -20,6 +20,7 @@
 var fs = require("fs");
 var path = require("path");
 var mm = require("micromatch");
+var Locale = require("ilib/lib/Locale.js");
 var MdxFile = require("./MdxFile.js");
 var YamlFileType = require('ilib-loctool-yaml');
 
@@ -165,8 +166,13 @@ MdxFileType.prototype.handles = function(pathName) {
                 // source locale, then we don't need to extract those strings
                 if (ret) {
                     for (var i = 0; i < patterns.length; i++) {
+                        if (!mm.isMatch(pathName, patterns[i]) && !mm.isMatch(normalized, patterns[i])) {
+                            continue;
+                        }
                         var locale = this.API.utils.getLocaleFromPath(mappings[patterns[i]].template, pathName);
-                        if (locale && locale !== this.project.sourceLocale) {
+                        var language = locale && new Locale(locale).getLanguage();
+                        if (locale && locale !== this.project.sourceLocale &&
+                            this.API.utils.iso639[language]) {
                             ret = false;
                             break;
                         }

--- a/packages/ilib-loctool-mdx/test/MdxFileType.test.js
+++ b/packages/ilib-loctool-mdx/test/MdxFileType.test.js
@@ -290,4 +290,32 @@ describe("mdxfiletype", function() {
         expect(mdft).toBeTruthy();
         expect(mdft.handles("foo.mdoc")).toBeFalsy();
     });
+
+    test("should handle source paths that look like locale prefixes", function() {
+        expect.assertions(4);
+        var devDocsProject = new CustomProject({
+            sourceLocale: "en-US",
+            plugins: ["../."]
+        }, "./test/testfiles", {
+            locales: ["ja-JP"],
+            mdx: {
+                mappings: {
+                    "ai/**/*.mdx": {
+                        "template": "[language]/[dir]/[filename]"
+                    },
+                    "guides/**/*.mdx": {
+                        "template": "[language]/[dir]/[filename]"
+                    },
+                    "*.mdx": {
+                        "template": "[language]/[filename]"
+                    }
+                }
+            }
+        });
+        var mdft = new MdxFileType(devDocsProject);
+        expect(mdft.handles("ai/agent-skills.mdx")).toBeTruthy();
+        expect(mdft.handles("ai/vector-databases/pinecone.mdx")).toBeTruthy();
+        expect(mdft.handles("guides/getting-started/index.mdx")).toBeTruthy();
+        expect(!mdft.handles("ja/guides/getting-started/index.mdx")).toBeTruthy();
+    });
 });


### PR DESCRIPTION
- "ai" looked like a language code, even though it is not, because it is 2 lower case letters. Anything within that path was not localized.
- The fix is to check if the 2 letters are an actual language code in ISO 639 before skipping the directory