### PR TITLE
ilib-assemble: Fix legacy assemble to handle minified/compiled ilib sources

### DIFF
--- a/.changeset/nine-eggs-judge.md
+++ b/.changeset/nine-eggs-judge.md
@@ -1,0 +1,5 @@
+---
+"ilib-assemble": patch
+---
+
+Fixed legacy assemble to strip require imports and non-ilib module.exports from minified/compiled ilib sources, so the assembled bundle is valid JS.

--- a/packages/ilib-assemble/src/legacyilibassemble.js
+++ b/packages/ilib-assemble/src/legacyilibassemble.js
@@ -118,12 +118,29 @@ function readJSFiles() {
 }
 
 function deletePatterns(data) {
-    const deletePattern1 = /var\s*[^;]*=[^;]require[^;]*;/g;
-    const deletePattern2 = /module\.exports\s*=\s*\b(?:(?!ilib)\w)+\b\;/g;
+    // Strip CommonJS `require(...)` imports and `module.exports`. This must work
+    // for BOTH un-minified source (`var X = require("y");`, one statement per
+    // line) and minified/compiled sources (`var A=require("x"),B=require("y"),
+    // Real=function(){...};` and `...,X.prototype={...},module.exports=X;`).
+    // Only string-literal requires are stripped; dynamic requires such as
+    // `require(fnc(entry))` are intentionally left untouched.
+    //
+    // 1) comma-separated require binding inside a multi-declarator `var`
+    const deleteFrag = /[A-Za-z_$][\w$]*\s*=\s*require\(\s*(["'])(?:(?!\1).)*\1\s*\)\s*,/g;
+    // 2) standalone / last require declarator: `var X = require("...");`
+    const deleteStmt = /var\s+[A-Za-z_$][\w$]*\s*=\s*require\(\s*(["'])(?:(?!\1).)*\1\s*\)\s*;/g;
+    // 3) module.exports, possibly as the tail of a comma-expression. Emitting a
+    //    `;` keeps the enclosing statement terminated. The core
+    //    `module.exports = ilib;` is preserved via the (?!ilib) lookahead.
+    const deleteExport = /,?\s*module\.exports\s*=\s*\b(?:(?!ilib)\w)+\b\s*;/g;
     const macroPattern = /\/\/\s*\!macro\s*ilibVersion/g;
     const readPkg = readFile(path.join(ilibPath, "package.json"));
     const ilibVersion = JSON.parse(readPkg).version;
-    data = data.replaceAll(deletePattern1, "").replaceAll(deletePattern2, "").replaceAll(macroPattern, '"' +ilibVersion+ '"');
+    data = data
+        .replaceAll(deleteFrag, "")
+        .replaceAll(deleteStmt, "")
+        .replaceAll(deleteExport, ";")
+        .replaceAll(macroPattern, '"' + ilibVersion + '"');
 
     return data;
 }

--- a/packages/ilib-assemble/test/legacyAssemble.test.js
+++ b/packages/ilib-assemble/test/legacyAssemble.test.js
@@ -19,6 +19,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import vm from 'vm';
 import assembleilib from '../src/legacyilibassemble.js';
 
 const OUTPUT_DIR = "test/testfiles/output/legacy";
@@ -28,6 +29,10 @@ const CUSTOM_PATH = "test/testfiles/legacy-custom";
 
 const FLAT_OUTPUT_DIR = "test/testfiles/output/legacy-flat";
 const FLAT_ILIB_PATH = "test/testfiles/legacy-ilib-flat";
+
+const MIN_OUTPUT_DIR = "test/testfiles/output/legacy-minified";
+const MIN_ILIB_PATH = "test/testfiles/legacy-ilib-minified";
+const MIN_INC_PATH = "test/testfiles/legacy-ilib-minified-inc.js";
 
 describe("legacyAssemble with customPath", () => {
     afterEach(() => {
@@ -127,5 +132,68 @@ describe("legacyAssemble with flat directory layout (lib/ and locale/)", () => {
         expect(koOutput).toContain("ilib.data.currency_ko");
         expect(koOutput).toContain('"KRW"');
         expect(koOutput).toContain("South Korean Won");
+    });
+});
+
+describe("legacyAssemble with minified/compiled ilib sources", () => {
+    afterEach(() => {
+        if (fs.existsSync(MIN_OUTPUT_DIR)) {
+            fs.rmSync(MIN_OUTPUT_DIR, { recursive: true, force: true });
+        }
+    });
+
+    function assembleMinified() {
+        if (!fs.existsSync(MIN_OUTPUT_DIR)) {
+            fs.mkdirSync(MIN_OUTPUT_DIR, { recursive: true });
+        }
+        assembleilib({
+            opt: {
+                ilibPath: MIN_ILIB_PATH,
+                ilibincPath: MIN_INC_PATH,
+                locales: ["en-US"],
+                outjsFileName: "ilib-all.js"
+            },
+            args: [MIN_OUTPUT_DIR]
+        });
+        return fs.readFileSync(path.join(MIN_OUTPUT_DIR, "ilib-all.js"), "utf-8");
+    }
+
+    test("produces syntactically valid JS from minified sources", () => {
+        const output = assembleMinified();
+
+        // The whole point of the fix: minified modules must assemble into a
+        // bundle that actually parses. Prior to the fix, stripping the require
+        // imports and the comma-tail module.exports left dangling commas and
+        // raw require() calls, producing invalid JS.
+        expect(() => new vm.Script(output)).not.toThrow();
+    });
+
+    test("strips string-literal require() imports (minified and un-minified)", () => {
+        const output = assembleMinified();
+
+        // No leftover `= require("...")` bindings from either the minified
+        // (MinFmt: `var A=require("x"),B=require("y"),...`) or the un-minified
+        // (PlainFmt: `var A = require("x");`) module.
+        expect(output).not.toMatch(/=\s*require\(\s*["']/);
+    });
+
+    test("keeps the real definitions that shared a var with require imports", () => {
+        const output = assembleMinified();
+
+        // MinFmt was declared in the same minified `var` as the require imports;
+        // it must survive after the imports are stripped.
+        expect(output).toContain("MinFmt=function");
+        expect(output).toContain("PlainFmt = function");
+    });
+
+    test("removes non-ilib module.exports but preserves the ilib global export", () => {
+        const output = assembleMinified();
+
+        // module.exports that is the tail of a comma-expression must be removed
+        // without breaking the statement...
+        expect(output).not.toMatch(/module\.exports\s*=\s*MinFmt/);
+        expect(output).not.toMatch(/module\.exports\s*=\s*PlainFmt/);
+        // ...but the core `module.exports = ilib;` must be kept.
+        expect(output).toMatch(/module\.exports\s*=\s*ilib/);
     });
 });

--- a/packages/ilib-assemble/test/testfiles/legacy-ilib-minified-inc.js
+++ b/packages/ilib-assemble/test/testfiles/legacy-ilib-minified-inc.js
@@ -1,0 +1,3 @@
+ilibcore.js
+MinFmt.js
+PlainFmt.js

--- a/packages/ilib-assemble/test/testfiles/legacy-ilib-minified/lib/MinFmt.js
+++ b/packages/ilib-assemble/test/testfiles/legacy-ilib-minified/lib/MinFmt.js
@@ -1,0 +1,1 @@
+var ilib=require("./ilibcore.js"),Locale=require("./Locale.js"),MinFmt=function(options){this.locale=options&&options.locale||"en"};MinFmt.prototype={format:function(num){return String(num)},getLocale:function(){return this.locale}},module.exports=MinFmt;

--- a/packages/ilib-assemble/test/testfiles/legacy-ilib-minified/lib/PlainFmt.js
+++ b/packages/ilib-assemble/test/testfiles/legacy-ilib-minified/lib/PlainFmt.js
@@ -1,0 +1,4 @@
+var ilib = require("./ilibcore.js");
+var Locale = require("./Locale.js");
+var PlainFmt = function() {};
+module.exports = PlainFmt;

--- a/packages/ilib-assemble/test/testfiles/legacy-ilib-minified/lib/ilibcore.js
+++ b/packages/ilib-assemble/test/testfiles/legacy-ilib-minified/lib/ilibcore.js
@@ -1,0 +1,1 @@
+var ilib=ilib||{};ilib.data={},module.exports=ilib;

--- a/packages/ilib-assemble/test/testfiles/legacy-ilib-minified/package.json
+++ b/packages/ilib-assemble/test/testfiles/legacy-ilib-minified/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "legacy-ilib-minified",
+    "version": "14.99.0"
+}


### PR DESCRIPTION
## Summary

Fixes `legacyilibassemble.js` so **minified/compiled ilib sources** assemble into valid JS.
`deletePatterns` assumed one declaration per line. Minified modules pack multiple `require` imports into one comma-separated `var` and append `module.exports` as a comma-tail, which the old logic couldn't strip cleanly — leaving dangling commas and raw `require()` calls (invalid JS).

## Before / After
**As-Is** (invalid — raw require + dangling comma)

​```js
var ilib=require("./ilibcore.js"),Locale=require("./Locale.js"),MinFmt=function(){...},;
​```
**To-Be** (valid — imports stripped, definition kept, export terminated)
​```js
var MinFmt=function(){...};
​```
`module.exports = ilib;` is still preserved (via `(?!ilib)` lookahead).

## Tests
Added minified + un-minified fixtures and tests asserting the bundle parses via `vm.Script`, requires are removed, real definitions survive, and the ilib export is kept.