### PR TITLE
Fix ilib-loctool-json double-templating a path supplied by a delegating caller

### DIFF
--- a/.changeset/lxp-2111-fix-double-templated-path.md
+++ b/.changeset/lxp-2111-fix-double-templated-path.md
@@ -1,0 +1,5 @@
+---
+"ilib-loctool-json": patch
+---
+
+Fixed `getResourceFile` re-templating an already-final path when a caller (such as `ilib-loctool-regex` delegating output via `resourceFileTypes`) supplied one, producing incorrect nested paths like `resources/ja/JP/ja.json` instead of `resources/ja.json`. A path passed explicitly is now used as-is; the path is only computed from this plugin's own mapping when none is given. `JsonFile.localize()` now passes its own computed localized path to the delegate instead of the raw source path.

--- a/packages/ilib-loctool-json/JsonFile.js
+++ b/packages/ilib-loctool-json/JsonFile.js
@@ -1037,9 +1037,11 @@ JsonFile.prototype.localize = function (translations, locales) {
                 continue;
             }
 
-            // Don't pass pathName - let the resource file type use its own template
+            // Pass this file's own localized path (computed from this plugin's mapping),
+            // not the raw source pathName - the delegate resource file type uses
+            // whatever path it is given as-is rather than re-templating it.
             this.logger.debug("Delegating output to resourceFileType for locale " + locale);
-            var resFile = resFileType.getResourceFile(locale, this.pathName);
+            var resFile = resFileType.getResourceFile(locale, this.getLocalizedPath(locale));
 
             // For each extracted resource, look up its translation and add to the resource file
             for (var j = 0; j < resources.length; j++) {

--- a/packages/ilib-loctool-json/JsonFileType.js
+++ b/packages/ilib-loctool-json/JsonFileType.js
@@ -373,7 +373,11 @@ JsonFileType.prototype.newFile = function(pathName, options) {
  *
  * @param {String} locale the name of the locale in which the resource
  * file will reside
- * @param {String} pathName path to the resource file, if known, or undefined otherwise
+ * @param {String} pathName path to the resource file, if known, or undefined otherwise.
+ * When given, it is used as-is because the caller (e.g. another plugin
+ * delegating output to this one, such as ilib-loctool-regex) has already
+ * computed the final localized path using its own mapping/template. When
+ * not given, this type computes the path itself from its own mapping.
  * @return {JavaScriptResourceFile} the Android resource file that serves the
  * given project, context, and locale.
  */
@@ -383,9 +387,12 @@ JsonFileType.prototype.getResourceFile = function(locale, pathName) {
     var resfile = this.resourceFiles && this.resourceFiles[key];
 
     if (!resfile) {
-        var mapping = this.getMapping(pathName);
-        var localizedPath = this.getLocalizedPath(mapping, pathName, key);
-        resfile = this.resourceFiles[key] = this.newFile(localizedPath, {
+        var newPathName = pathName;
+        if (!newPathName) {
+            var mapping = this.getMapping(pathName);
+            newPathName = this.getLocalizedPath(mapping, pathName, key);
+        }
+        resfile = this.resourceFiles[key] = this.newFile(newPathName, {
             project: this.project,
             locale: key
         });

--- a/packages/ilib-loctool-json/test/JsonFileType.test.js
+++ b/packages/ilib-loctool-json/test/JsonFileType.test.js
@@ -494,43 +494,53 @@ describe("jsonfiletype", function() {
         expect(jft.handles("resources/en/US/messages.json")).toBeTruthy();
     });
 
-    test("JsonFileTypeGetResourceFileUsesLocalizedPath", function() {
+    test("JsonFileTypeGetResourceFileUsesGivenPathAsIs", function() {
+        // When a pathName is given, it is used verbatim because the caller (e.g. a
+        // delegating plugin like ilib-loctool-regex, or JsonFile itself which computes
+        // its own localized path before delegating) has already computed the final path.
         expect.assertions(2);
 
         var jft = new JsonFileType(p);
-        var rf = jft.getResourceFile("de-DE", "x/y/z/messages.json");
+        var rf = jft.getResourceFile("de-DE", "resources/de/DE/messages.json");
 
         expect(rf.pathName).toBe(path.normalize("resources/de/DE/messages.json"));
         expect(rf.localeSpec).toBe("de-DE");
     });
 
-    test("JsonFileTypeGetResourceFileUsesLocalizedPathAlternateExtension", function() {
+    test("JsonFileTypeGetResourceFileComputesLocalizedPathWhenPathOmitted", function() {
+        // With no pathName given, getMapping(undefined) falls back to this type's
+        // own default mapping ("**/*.json" -> "resources/[localeDir]/[filename]"),
+        // and there is no source filename to plug into [filename] since none was given.
         expect.assertions(1);
 
         var jft = new JsonFileType(p);
-        var rf = jft.getResourceFile("de-DE", "x/y/z/test/str.jsn");
+        var rf = jft.getResourceFile("de-DE");
 
-        expect(rf.pathName).toBe(path.normalize("x/y/z/test/de/DE/str.json"));
+        expect(rf.pathName).toBe(path.normalize("resources/de/DE/"));
     });
 
     test("JsonFileTypeGetResourceFileCachesPerLocale", function() {
         expect.assertions(2);
 
         var jft = new JsonFileType(p);
-        var rf1 = jft.getResourceFile("de-DE", "x/y/z/messages.json");
-        var rf2 = jft.getResourceFile("de-DE", "a/b/messages.json");
+        var rf1 = jft.getResourceFile("de-DE", "resources/de/DE/messages.json");
+        var rf2 = jft.getResourceFile("de-DE", "resources/de/DE/other.json");
 
         expect(rf1).toBe(rf2);
         expect(rf1.pathName).toBe(path.normalize("resources/de/DE/messages.json"));
     });
 
     test("JsonFileTypeGetResourceFileUsesSourceLocaleWhenLocaleOmitted", function() {
+        // Locale defaults to the project's source locale, which is used when computing
+        // the localized path. Path is also omitted here so that path computation
+        // actually happens (an explicit path is otherwise used as-is - see
+        // JsonFileTypeGetResourceFileUsesGivenPathAsIs).
         expect.assertions(1);
 
         var jft = new JsonFileType(p);
-        var rf = jft.getResourceFile(undefined, "x/y/z/messages.json");
+        var rf = jft.getResourceFile(undefined);
 
-        expect(rf.pathName).toBe(path.normalize("resources/en/US/messages.json"));
+        expect(rf.pathName).toBe(path.normalize("resources/en/US/"));
     });
 
     test("JsonFileTypeRejectInvalidSchema", function() {


### PR DESCRIPTION
## Summary
- `JsonFileType.getResourceFile(locale, pathName)` unconditionally re-templated `pathName` using this plugin's own `getMapping`/`getLocalizedPath`, even when the caller had already computed a final localized path with a different plugin's mapping config.
- This breaks the `ilib-loctool-regex` + `resourceFileTypes` delegation flow: `RegexFileType.write()` computes e.g. `resources/ja.json` from its own `regex.mappings` config, then calls `resFileType.getResourceFile(locale, "resources/ja.json")` on the delegate JSON plugin — which re-templated that already-final path against its own default mapping (`resources/[localeDir]/[filename]`), producing `resources/ja/JP/ja.json` instead. Any consumer that scans `resources/*.json` (non-recursively) then finds nothing.
- `getResourceFile` now uses a given `pathName` as-is (matching the convention already used by sibling delegate plugins like `ilib-loctool-javascript-resource`), and only computes the path itself when no `pathName` is given.
- `JsonFile.localize()` is updated to pass its own already-computed localized path (`this.getLocalizedPath(locale)`) to the delegate instead of the raw source `pathName`, preserving the anyOf/oneOf schema fix from 604565d2b that this delegation call site depends on.

## Root cause history
The regression was introduced in 604565d2b ("Fix json plugin to localize anyOf or oneOf properly"), which added the re-templating call to `getResourceFile` to make `JsonFile.localize()`'s no-`pathName` delegation call work, but didn't account for the other call site (`RegexFileType.write()`) that already passes a final computed path.

## Test plan
- [x] Added/updated unit tests in `test/JsonFileType.test.js` covering: explicit path used as-is, path computed when omitted, locale defaulting when omitted.
- [x] `packages/ilib-loctool-json`: 124/124 tests pass (`JsonFile.test.js` + `JsonFileType.test.js`).
- [x] `packages/ilib-loctool-regex`: 46/46 tests pass (unaffected, verifying no regression).
- [x] End-to-end repro: ran `loctool localize` against a minimal project mirroring the real-world DevDocsGuides config (`ilib-loctool-regex` delegating to `ilib-loctool-json` via `resourceFileTypes`) with the exact package versions (`loctool@2.33.1`, `ilib-loctool-regex@1.1.1`, `ilib-loctool-json@2.2.0`). Before the fix: wrote `resources/ja/JP/ja.json`. After the fix: correctly writes `resources/ja.json`.