### PR TITLE
loctool: Add unique selection criteria to loctool select.

### DIFF
--- a/.changeset/loctool-select-unique-criteria.md
+++ b/.changeset/loctool-select-unique-criteria.md
@@ -1,0 +1,5 @@
+---
+"loctool": minor
+---
+
+Add `unique` and `unique:field+field+...` selection criteria to the select command so callers can control which fields identify already-seen translation units (for example `unique:key+source` when Mojito drop ids are stored in `original`/`product-name`).

--- a/packages/ilib-localedata/src/LocaleData.js
+++ b/packages/ilib-localedata/src/LocaleData.js
@@ -445,6 +445,12 @@ class LocaleData {
      * called and completed successfully, then the data will be returned immediately. If the data is not in the cache,
      * then this method will throw an error because synchronous loading is not supported.
      *
+     * If no data at all could be found for the requested locale and basename, this method does
+     * not throw. Instead it returns the result of merging nothing, which is an empty object for
+     * all of the merge modes except `returnOne`, which returns undefined because there is no
+     * single file to return. This lets callers treat missing data for a particular locale or
+     * basename as "no strings available" rather than as an error.
+     *
      * @param {Object} params parameters controlling the data loading
      * @param {string|Locale} params.locale the locale to load data for
      * @param {string} params.basename the basename of the data to load
@@ -455,7 +461,8 @@ class LocaleData {
      * @returns {Object|Promise.<Object>} the locale data if sync is true, or a promise to the locale data
      * if sync is false. When no data exists for the requested locale and basename, an empty object
      * is returned (or the promise resolves to one) so callers can treat missing data as an
-     * empty map.
+     * empty map. The exception is `returnOne`, which returns undefined because there is no
+     * single file to return.
      * @throws {Error} if synchronous loading is requested but the loader does not support it and the
      * data is not already in the cache
      */
@@ -524,19 +531,22 @@ class LocaleData {
                 this.cache.isLoaded(Path.join(file.root, `${spec}.json`));
         };
 
+        // The merged data caches signal "nothing found at all" with undefined, but
+        // callers expect the result of merging zero files instead: an empty object
+        // for every merge mode except returnOne, which has nothing to return.
+        const noData = () => returnOne ? undefined : {};
+
         if (sync) {
             // A loader that cannot load synchronously can only give us what is already
             // in the cache, which may be under the root that ensureLocale loaded it from
             // rather than one of this instance's own roots.
             const syncRoots = this.loader.supportsSync() ? roots : this.getCachedRoots();
 
-            // Missing data used to merge down to {} before the cache rewrite; keep that
-            // contract so callers can treat "no data" as an empty map.
             const result = mergedDataCache.loadMergedDataSync(loc.getSpec(), syncRoots, basename);
-            return result === undefined ? {} : result;
+            return (result === undefined) ? noData() : result;
         } else {
             return mergedDataCache.loadMergedData(loc.getSpec(), roots, basename).then((result) => {
-                return result === undefined ? {} : result;
+                return (result === undefined) ? noData() : result;
             });
         }
     }
@@ -758,23 +768,10 @@ class LocaleData {
             throw new Error("No loader available for this platform");
         }
 
-        try {
-            // Use MergedDataCache to load all locale-specific data for the locale
-            // This will look for [locale].js and [locale].json files and cache all the data
-            const result = await mergedDataCache.loadLocaleData(loc.getSpec(), roots);
-
-            // Return true if any data was loaded and cached
-            return result;
-        } catch (error) {
-            // If MergedDataCache failed to load the data, return false
-            // MergedDataCache should handle the case where no locale-specific files are found
-            if (error.message && error.message.includes("No locale data found")) {
-                return false;
-            }
-
-            // Re-throw unexpected errors
-            throw error;
-        }
+        // Use MergedDataCache to load all locale-specific data for the locale.
+        // This will look for [locale].js and [locale].json files and cache all the data.
+        // It reports a locale with no data by returning false rather than throwing.
+        return mergedDataCache.loadLocaleData(loc.getSpec(), roots);
     }
 
     /**

--- a/packages/ilib-localedata/test/LocaleDataNode.test.js
+++ b/packages/ilib-localedata/test/LocaleDataNode.test.js
@@ -876,6 +876,146 @@ describe("LocaleDataNode", () => {
         });
     });
 
+    test("should load sync empty object when there is no data at all", () => {
+        expect.assertions(2);
+        setPlatform();
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+
+        const locData = new LocaleData({
+            path: "./test/testfiles/files",
+            sync: true
+        });
+
+        expect(locData).toBeTruthy();
+
+        // merging zero files gives an empty object. Missing data for a basename is
+        // not an error, because the caller may have data for other locales only.
+        const actual = locData.loadData({
+            basename: "nonexistentbasename",
+            locale: "en-US"
+        });
+
+        expect(actual).toEqual({});
+    });
+
+    test("should load sync empty object when there is no data at all with crossRoots", () => {
+        expect.assertions(2);
+        setPlatform();
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+
+        const locData = new LocaleData({
+            path: "./test/testfiles/files",
+            sync: true
+        });
+
+        expect(locData).toBeTruthy();
+
+        const actual = locData.loadData({
+            basename: "nonexistentbasename",
+            locale: "en-US",
+            crossRoots: true
+        });
+
+        expect(actual).toEqual({});
+    });
+
+    test("should load sync empty object when there is no data at all with mostSpecific", () => {
+        expect.assertions(2);
+        setPlatform();
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+
+        const locData = new LocaleData({
+            path: "./test/testfiles/files",
+            sync: true
+        });
+
+        expect(locData).toBeTruthy();
+
+        const actual = locData.loadData({
+            basename: "nonexistentbasename",
+            locale: "en-US",
+            mostSpecific: true
+        });
+
+        expect(actual).toEqual({});
+    });
+
+    test("should load sync undefined when there is no data at all with returnOne", () => {
+        expect.assertions(2);
+        setPlatform();
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+
+        const locData = new LocaleData({
+            path: "./test/testfiles/files",
+            sync: true
+        });
+
+        expect(locData).toBeTruthy();
+
+        // returnOne returns a single file's data, so with no files found there is
+        // nothing to return at all
+        const actual = locData.loadData({
+            basename: "nonexistentbasename",
+            locale: "en-US",
+            returnOne: true
+        });
+
+        expect(actual).toBeUndefined();
+    });
+
+    test("should load async empty object when there is no data at all", async () => {
+        expect.assertions(2);
+        setPlatform();
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+
+        const locData = new LocaleData({
+            path: "./test/testfiles/files",
+            sync: false
+        });
+
+        expect(locData).toBeTruthy();
+
+        const actual = await locData.loadData({
+            basename: "nonexistentbasename",
+            locale: "en-US"
+        });
+
+        expect(actual).toEqual({});
+    });
+
+    test("should load async undefined when there is no data at all with returnOne", async () => {
+        expect.assertions(2);
+        setPlatform();
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+
+        const locData = new LocaleData({
+            path: "./test/testfiles/files",
+            sync: false
+        });
+
+        expect(locData).toBeTruthy();
+
+        const actual = await locData.loadData({
+            basename: "nonexistentbasename",
+            locale: "en-US",
+            returnOne: true
+        });
+
+        expect(actual).toBeUndefined();
+    });
+
     test("should ensure locale bad root", async () => {
         expect.assertions(1);
         setPlatform();

--- a/packages/ilib-localedata/test/LocaleDataNode.test.js
+++ b/packages/ilib-localedata/test/LocaleDataNode.test.js
@@ -1016,6 +1016,119 @@ describe("LocaleDataNode", () => {
         expect(actual).toBeUndefined();
     });
 
+    test("should not duplicate array data for the root locale", () => {
+        expect.assertions(2);
+        setPlatform();
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+
+        const locData = new LocaleData({
+            path: "./test/testfiles/files",
+            sync: true
+        });
+
+        expect(locData).toBeTruthy();
+
+        const actual = locData.loadData({
+            basename: "arrays",
+            locale: "root"
+        });
+
+        // arrays are concatenated when data is merged, so merging the same
+        // sublocale's data twice would give ["root1", "root2", "root1", "root2"]
+        expect(actual).toEqual({
+            "list": ["root1", "root2"],
+            "nested": {
+                "inner": ["rootinner"]
+            }
+        });
+    });
+
+    test("should not duplicate array data when merging sublocales", () => {
+        expect.assertions(2);
+        setPlatform();
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+
+        const locData = new LocaleData({
+            path: "./test/testfiles/files",
+            sync: true
+        });
+
+        expect(locData).toBeTruthy();
+
+        const actual = locData.loadData({
+            basename: "arrays",
+            locale: "en-US"
+        });
+
+        // the root array followed by the und-US array, each appearing exactly once
+        expect(actual).toEqual({
+            "list": ["root1", "root2", "undUS"],
+            "nested": {
+                "inner": ["rootinner", "undUSinner"]
+            }
+        });
+    });
+
+    test("should not duplicate array data for a locale with a repeated sublocale", () => {
+        expect.assertions(2);
+        setPlatform();
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+
+        const locData = new LocaleData({
+            path: "./test/testfiles/files",
+            sync: true
+        });
+
+        expect(locData).toBeTruthy();
+
+        // getSublocales("und-US") names "und-US" twice, so this locale is the one
+        // that duplicated array data even when the root data had no arrays
+        const actual = locData.loadData({
+            basename: "arrays",
+            locale: "und-US"
+        });
+
+        expect(actual).toEqual({
+            "list": ["root1", "root2", "undUS"],
+            "nested": {
+                "inner": ["rootinner", "undUSinner"]
+            }
+        });
+    });
+
+    test("should not duplicate array data when merging sublocales async", async () => {
+        expect.assertions(2);
+        setPlatform();
+
+        LocaleData.clearCache();
+        LocaleData.clearGlobalRoots();
+
+        const locData = new LocaleData({
+            path: "./test/testfiles/files",
+            sync: false
+        });
+
+        expect(locData).toBeTruthy();
+
+        const actual = await locData.loadData({
+            basename: "arrays",
+            locale: "en-US"
+        });
+
+        expect(actual).toEqual({
+            "list": ["root1", "root2", "undUS"],
+            "nested": {
+                "inner": ["rootinner", "undUSinner"]
+            }
+        });
+    });
+
     test("should ensure locale bad root", async () => {
         expect.assertions(1);
         setPlatform();

--- a/packages/ilib-localedata/test/testfiles/files/arrays.json
+++ b/packages/ilib-localedata/test/testfiles/files/arrays.json
@@ -1,0 +1,6 @@
+{
+    "list": ["root1", "root2"],
+    "nested": {
+        "inner": ["rootinner"]
+    }
+}

--- a/packages/ilib-localedata/test/testfiles/files/und/US/arrays.json
+++ b/packages/ilib-localedata/test/testfiles/files/und/US/arrays.json
@@ -1,0 +1,6 @@
+{
+    "list": ["undUS"],
+    "nested": {
+        "inner": ["undUSinner"]
+    }
+}

--- a/packages/loctool/README.md
+++ b/packages/loctool/README.md
@@ -8,6 +8,10 @@ resource file formats needed by each project.
 See the [release notes](https://github.com/iLib-js/ilib-mono/blob/main/packages/loctool/CHANGELOG.md) for details on what is
 new and what has changed.
 
+Documentation for individual commands and topics lives under
+[docs/](docs/index.md). Many pages are still planned; finished guides
+are linked from that index.
+
 Installation
 ------------
 
@@ -839,7 +843,13 @@ These are the actions which are available:
   of specific fields. Also, you can limit the output by specifying the
   maximum number of units, or the maximum number of source or target words.
   It also allows you to randomize the selection so you can create a sample
-  of the input translations units.
+  of the input translations units. Use `unique` to skip units whose default
+  identity (project, targetLocale, key, datatype, flavor, context, and
+  source) was already selected, or `unique:field+field+...` to define that
+  identity yourself (for example `unique:key+source` when drop ids are
+  stored in the project field). Criteria can be combined with commas. See
+  [The select Command](docs/SelectCommand.md) for a full guide with
+  examples, or `loctool select --help` for the option list.
 - compare - Compare two xliff files (from and to) and write the
   differences to an output directory. The files are compared
   logically by translation units instead of lexically by characters

--- a/packages/loctool/docs/SelectCommand.md
+++ b/packages/loctool/docs/SelectCommand.md
@@ -1,0 +1,311 @@
+# The `select` Command
+
+The `select` command reads one or more XLIFF files, filters their
+translation units according to selection criteria, and writes the
+matching units to a single output XLIFF file.
+
+Typical uses include building a random sample for linguistic review,
+pulling only the units for one locale or project, removing units that
+match unwanted patterns, or collapsing duplicate strings that appear
+across multiple translation drops.
+
+## Synopsis
+
+```
+loctool select <criteria> <outfile> <infile> [<infile> ...]
+```
+
+All input and output files must be XLIFF. You may list as many input
+files as you need; their units are loaded, merged, and then filtered
+before writing.
+
+For the full command-line help:
+
+```
+loctool select --help
+```
+
+## How Selection Works
+
+Selection happens in three stages:
+
+1. **Load and merge.** Each input file is read. Exact duplicates are
+   collapsed using the default identity fields (see
+   [Uniqueness](#uniqueness) below). Unless `--prune` is set, each unit
+   also receives an `original-file` extended attribute naming the
+   input file it came from.
+2. **Filter.** Units are kept or discarded according to the criteria
+   string. Criteria are combined with commas and form a conjunction:
+   a unit must satisfy every part to be selected (or, with `--prune`,
+   to be excluded).
+3. **Write.** Matching units are serialized to the output file.
+
+Within the filter stage, criteria are applied in this order:
+
+1. Field matches (`field=regexp` / `field!=regexp`), including plural
+   category and array index forms
+2. Uniqueness (`unique` / `unique:…`)
+3. Size budgets (`maxunits`, `maxsource`, `maxtarget`)
+
+`random` is special: when present, the unit list is shuffled *before*
+the filters run, so that later budgets such as `maxunits` sample from
+a random order.
+
+Uniqueness is applied before size budgets so that
+`unique:key+source,maxunits:100` counts only units that survived the
+uniqueness filter.
+
+## Selection Criteria
+
+Criteria are a comma-separated list of parts. Each part is one of the
+forms below.
+
+### Field matches
+
+```
+<field>=<regexp>
+<field>!=<regexp>
+```
+
+Keep units where `<field>` matches the regular expression, or (with
+`!=`) where it does **not** match. The first `=` (or `!=`) separates
+the field name from the pattern, so the pattern itself may contain
+`=` signs.
+
+Supported fields:
+
+| Field | Meaning |
+|-------|---------|
+| `project` | Project / product name |
+| `context` | Context string |
+| `sourceLocale` | Source locale |
+| `targetLocale` | Target locale |
+| `key` | Resource key (`resname`) |
+| `pathName` | Path of the source file |
+| `state` | Translation state |
+| `comment` | Translator / developer comment |
+| `dnt` | Do-not-translate flag |
+| `datatype` | Datatype (for example `javascript`, `x-json`) |
+| `resType` | Resource type (`string`, `plural`, `array`, …) |
+| `flavor` | Flavor |
+| `source` | Source text |
+| `target` | Target text |
+
+For plurals and arrays you can narrow the match further:
+
+| Form | Meaning |
+|------|---------|
+| `source.<category>` / `target.<category>` | Match only the given plural category (`zero`, `one`, `two`, `few`, `many`, `other`) |
+| `source.<index>` / `target.<index>` | Match only the array element at that zero-based index |
+
+Bare `source=` / `target=` still match across string, plural, and array
+resources as appropriate.
+
+### Random sampling
+
+```
+random
+```
+
+Shuffle the candidate units before applying the remaining criteria.
+Combine with a size budget to draw a sample:
+
+```
+loctool select 'random,maxunits:100' sample.xliff translations.xliff
+```
+
+### Uniqueness
+
+```
+unique
+unique:<field>+<field>+...
+```
+
+Do not select a unit if another unit with the same identity was already
+selected (first match wins).
+
+Bare `unique` uses this default identity:
+
+- `project`
+- `targetLocale`
+- `key`
+- `datatype`
+- `flavor`
+- `context`
+- `source`
+
+`unique:<field>+…` builds the identity from only the listed fields.
+Fields are separated by `+`. `resname` is accepted as an alias for
+`key`.
+
+This is useful when the same logical string appears under different
+project values — for example when Mojito drop ids are stored in the
+project / `product-name` field. In that case the default identity
+treats each drop’s copy as distinct, while `unique:key+source`
+collapses them:
+
+```
+loctool select 'unique:key+source' merged.xliff drop1.xliff drop2.xliff
+```
+
+Note that loading already collapses exact duplicates under the *default*
+identity. Narrower uniqueness such as `unique:key+source` is applied
+only as a selection filter afterwards.
+
+### Size budgets
+
+| Criterion | Meaning |
+|-----------|---------|
+| `maxunits:<n>` | Stop after selecting `<n>` units |
+| `maxsource:<n>` | Stop when the cumulative source word count would reach `<n>` |
+| `maxtarget:<n>` | Stop when the cumulative target word count would reach `<n>` |
+
+Word counts are a simple whitespace split of the source or target
+string. That is a rough estimate and is less meaningful for languages
+that do not separate words with spaces.
+
+## Command Options
+
+These options are specific to `select` (global loctool flags such as
+`-2` for XLIFF 2.0 still apply):
+
+| Option | Meaning |
+|--------|---------|
+| `--projectId <name>` | Set the project name on selected units when writing the output |
+| `--extendedAttr <name>=<value>` | Add an extended attribute to every selected unit. Repeatable. |
+| `--prune` | Invert the filter: write units that do *not* match the criteria, and skip adding `original-file` |
+
+## Examples
+
+### Select everything from several files
+
+The CLI always requires a criteria argument. After load-time
+deduplication of exact duplicates, any criterion that does not discard
+units will keep the rest. The simplest options are bare `unique`
+(default identity, already applied at load) or `random` (keeps
+everything, but shuffled):
+
+```
+loctool select unique all.xliff a.xliff b.xliff c.xliff
+loctool select random all.xliff a.xliff b.xliff c.xliff
+```
+
+When calling the `XliffSelect` API directly, omitting `criteria`
+likewise keeps every unit that survived the load-time merge.
+
+### Filter by locale
+
+```
+loctool select 'targetLocale=^fr' french.xliff translations.xliff
+```
+
+### Filter by project and state
+
+```
+loctool select 'project=^webapp$,state=translated' ready.xliff translations.xliff
+```
+
+### Exclude do-not-translate units
+
+```
+loctool select 'dnt!=^true$' translatable.xliff translations.xliff
+```
+
+### Find untranslated units
+
+```
+loctool select 'target=^$' missing.xliff translations.xliff
+```
+
+(Exact emptiness depends on how empty targets are represented in your
+files; adjust the pattern if needed.)
+
+### Take a random sample for LQA
+
+Draw 50 random units, or about 200 source words:
+
+```
+loctool select 'random,maxunits:50' lqa-sample.xliff translations.xliff
+loctool select 'random,maxsource:200' lqa-sample.xliff translations.xliff
+```
+
+### Sample only one project
+
+```
+loctool select 'project=^checkout$,random,maxunits:100' \
+    checkout-sample.xliff translations.xliff
+```
+
+### Deduplicate across Mojito drops
+
+When each drop stores its id as the project name, overlapping strings
+are kept by default. Collapse them by key and source, keeping the
+first-seen translation:
+
+```
+loctool select 'unique:key+source' \
+    deduped.xliff drop-2025-01.xliff drop-2025-02.xliff
+```
+
+Combine with a budget when you only want a unique sample:
+
+```
+loctool select 'unique:key+source,random,maxunits:100' \
+    sample.xliff drop-2025-01.xliff drop-2025-02.xliff
+```
+
+### Match a plural category
+
+```
+loctool select 'source.one=file' plurals.xliff translations.xliff
+```
+
+### Match an array element
+
+```
+loctool select 'source.0=Monday' weekdays.xliff translations.xliff
+```
+
+### Prune unwanted units out of a file
+
+`--prune` inverts the match. This writes everything *except* units
+whose source looks like a debug string:
+
+```
+loctool select --prune 'source=^DEBUG:' cleaned.xliff translations.xliff
+```
+
+### Annotate selected units
+
+Add metadata that survives in the output XLIFF:
+
+```
+loctool select \
+    --extendedAttr 'review-batch=2026-08' \
+    --projectId myapp \
+    'random,maxunits:100' \
+    batch.xliff translations.xliff
+```
+
+Selected units also get `original-file` pointing at the input file they
+came from (unless `--prune` is used).
+
+### XLIFF 2.0 output
+
+```
+loctool -2 select 'targetLocale=^de' german.xliff translations.xliff
+```
+
+## Tips
+
+- Quote the criteria string so the shell does not interpret `|`, `*`,
+  or other regexp characters.
+- Criteria are a conjunction: every part must match. There is no `or`
+  operator; run `select` more than once (or use `--prune`) if you need
+  the complement of a filter.
+- Prefer `unique:…` when you need a custom identity. Bare `unique` is
+  equivalent to the same identity already used to collapse duplicates
+  at load time, so it mainly matters after other filters have changed
+  which units remain candidates.
+- See also `loctool select --help` for the authoritative option list
+  shipped with your installed version.

--- a/packages/loctool/docs/index.md
+++ b/packages/loctool/docs/index.md
@@ -1,0 +1,61 @@
+# Loctool Documentation
+
+Guides for using and extending [loctool](../README.md). Many sections
+are still to be written; links below go to finished pages where they
+exist.
+
+## Getting started
+
+- [ ] Installing loctool
+- [ ] Setting up a project for localization
+- [ ] The basic localize workflow (extract → translate → generate)
+- [ ] Running loctool from npm scripts and CI
+
+## Configuration
+
+- [ ] Project config files (`loctool-config.json` / `project.json`)
+- [ ] Locales, pseudo-locales, and locale mapping
+- [ ] Resource file locations and naming
+- [ ] Intermediate formats (XLIFF, PO)
+- [ ] XLIFF versions and styles
+- [ ] Common configuration examples
+
+## Commands
+
+Each loctool command has (or will have) its own guide. Use
+`loctool <command> --help` for the option list shipped with your
+install.
+
+- [ ] `init` — create a new project config file
+- [ ] `localize` — extract strings and generate localized resources
+  (default command)
+- [ ] `merge` — merge multiple XLIFF files into one
+- [ ] `split` — split XLIFF files by language or project
+- [ ] `generate` — generate localized files without re-extracting
+- [ ] `convert` — convert between resource file formats (and to TMX)
+- [x] [`select`](SelectCommand.md) — select translation units from
+  XLIFF files by criteria
+- [ ] `compare` — compare two XLIFF files by translation unit
+
+## Plugins
+
+- [x] [Writing a loctool plugin](Plugins.md) — SPI, file / file-type
+  classes, and how plugins plug into localize
+- [ ] Using existing plugins in a project
+- [ ] Configuring plugins (file types, paths, options)
+- [ ] Listing and choosing plugins for common project types
+
+## Resources and translation memory
+
+- [ ] XLIFF as the translation interchange format
+- [ ] Working with translation directories
+- [ ] Do-not-translate (DNT) strings
+- [ ] Plurals, arrays, and ICU-style strings
+- [ ] Pseudo-localization
+
+## Troubleshooting and reference
+
+- [ ] Common errors and how to fix them
+- [ ] Logging and quiet / silent modes
+- [ ] Command cheat sheet
+- [ ] Glossary of loctool terms

--- a/packages/loctool/lib/XliffSelect.js
+++ b/packages/loctool/lib/XliffSelect.js
@@ -27,6 +27,22 @@ var XliffFactory = require("./XliffFactory.js");
 
 var logger = log4js.getLogger("loctool.lib.XliffSelect");
 
+/**
+ * Default fields used to decide whether a translation unit has already
+ * been seen. Used for load-time deduplication and for the bare "unique"
+ * selection criterion.
+ * @private
+ */
+var defaultUniqueFields = [
+    "project",
+    "targetLocale",
+    "key",
+    "datatype",
+    "flavor",
+    "context",
+    "source"
+];
+
 // very simple tokenizer that only tokenizes by whitespace. This, of
 // course, does not work so well in languages that do not use spaces
 // between the words.
@@ -37,22 +53,48 @@ function wordCount(string) {
 }
 
 /**
+ * Normalize a field name used in a unique: criterion.
+ * @private
+ * @param {string} field the field name from the criteria
+ * @returns {string} normalized field name
+ */
+function normalizeUniqueField(field) {
+    if (field === "resname") return "key";
+    return field;
+}
+
+/**
+ * Return the value of a field on a translation unit for uniqueness hashing.
+ * @private
+ * @param {TranslationUnit} unit the translation unit
+ * @param {string} field the field name
+ * @returns {string} the value to include in the hash
+ */
+function uniqueFieldValue(unit, field) {
+    if (field === "pathName") {
+        return unit.pathName || unit.file || "";
+    }
+    if (field === "source" || field === "target") {
+        return utils.hashKey(unit[field] || "");
+    }
+    return unit[field] || "";
+}
+
+/**
  * Return a hash for the translation unit. This is used to identify
- * translation units in the cache so we can avoid adding duplicates.
+ * translation units that have already been seen so they are not
+ * selected again.
  * @private
  * @param {TranslationUnit} unit the translation unit to hash
+ * @param {Array.<string>} [fields] fields to include in the hash;
+ *        defaults to the full uniqueness field set
  * @returns {string} the hash for the translation unit
  */
-function tuHash(unit) {
-    return [
-        unit.project,
-        unit.targetLocale,
-        unit.key,
-        unit.datatype,
-        unit.flavor,
-        unit.context,
-        utils.hashKey(unit.source)
-    ].join("_");
+function tuHash(unit, fields) {
+    var hashFields = fields || defaultUniqueFields;
+    return hashFields.map(function(field) {
+        return uniqueFieldValue(unit, field);
+    }).join("_");
 }
 
 
@@ -110,6 +152,9 @@ var XliffSelect = function XliffSelect(settings) {
                 if (!settings.prune) {
                     unit.extended["original-file"] = file;
                 }
+                // Always collapse exact duplicates using the default field set
+                // while loading. Narrower uniqueness (e.g. unique:key+source) is
+                // applied later as a selection filter.
                 var hash = tuHash(unit);
                 unitCache[hash] = unit;
             });
@@ -134,6 +179,7 @@ var XliffSelect = function XliffSelect(settings) {
             var totalunits = 0;
             var sourcewords = 0;
             var targetwords = 0;
+            var seen = new ISet();
 
             if (criteria.random) {
                 // Mix up the units first and then perform the normal criteria below.
@@ -156,28 +202,6 @@ var XliffSelect = function XliffSelect(settings) {
 
             units = units.filter(function(unit) {
                 var match = true;
-                if (criteria.maxunits) {
-                    if (totalunits >= criteria.maxunits) {
-                        match = false;
-                    }
-                    totalunits++;
-                }
-
-                if (criteria.maxsource) {
-                    var count = wordCount(unit.source);
-                    if (sourcewords + count >= criteria.maxsource) {
-                        match = false;
-                    }
-                    sourcewords += count;
-                }
-
-                if (criteria.maxtarget) {
-                    var count = wordCount(unit.target);
-                    if (targetwords + count >= criteria.maxtarget) {
-                        match = false;
-                    }
-                    targetwords += count;
-                }
 
                 if (criteria.category && (!unit.quantity || unit.quantity !== criteria.category)) {
                     // units that are part of a plural have a quantity field
@@ -210,6 +234,45 @@ var XliffSelect = function XliffSelect(settings) {
                         if (unit[nfield] && unit[nfield].match(nre) !== null) {
                             match = false;
                         }
+                    }
+                }
+
+                // Uniqueness is "do not select this unit again if one with the
+                // same identity was already selected". Applied after field filters
+                // and before size budgets so that maxunits/maxsource count selected
+                // units only.
+                if (match && criteria.uniqueFields) {
+                    var id = tuHash(unit, criteria.uniqueFields);
+                    if (seen.has(id)) {
+                        match = false;
+                    } else {
+                        seen.add(id);
+                    }
+                }
+
+                if (match && criteria.maxunits) {
+                    if (totalunits >= criteria.maxunits) {
+                        match = false;
+                    } else {
+                        totalunits++;
+                    }
+                }
+
+                if (match && criteria.maxsource) {
+                    var sourceCount = wordCount(unit.source);
+                    if (sourcewords + sourceCount >= criteria.maxsource) {
+                        match = false;
+                    } else {
+                        sourcewords += sourceCount;
+                    }
+                }
+
+                if (match && criteria.maxtarget) {
+                    var targetCount = wordCount(unit.target);
+                    if (targetwords + targetCount >= criteria.maxtarget) {
+                        match = false;
+                    } else {
+                        targetwords += targetCount;
                     }
                 }
 
@@ -295,6 +358,29 @@ XliffSelect.parseCriteria = function (criteria) {
             criteriaObj.maxtarget = parseInt(part.substring(10));
         } else if (lowerPart === "random") {
             criteriaObj.random = true;
+        } else if (lowerPart === "unique") {
+            criteriaObj.uniqueFields = defaultUniqueFields.slice();
+        } else if (lowerPart.startsWith("unique:")) {
+            var fieldList = part.substring(7);
+            if (!fieldList) {
+                throw new Error("Incorrect syntax for criteria: " + part);
+            }
+            var fields = fieldList.split("+").map(function(f) {
+                return f.trim();
+            }).filter(function(f) {
+                return f.length > 0;
+            });
+            if (fields.length === 0) {
+                throw new Error("Incorrect syntax for criteria: " + part);
+            }
+            criteriaObj.uniqueFields = fields.map(function(field) {
+                // resname is accepted as an alias for key in unique: criteria only
+                var normalized = normalizeUniqueField(field);
+                if (!knownFields[normalized]) {
+                    throw new Error("Unknown field name in criteria: " + part);
+                }
+                return normalized;
+            });
         } else {
             // get the first equals sign only, as there may be equals signs in the regex
             var equals = part.indexOf("=");

--- a/packages/loctool/loctool.js
+++ b/packages/loctool/loctool.js
@@ -187,6 +187,13 @@ var commandOptionHelp = {
         "      of resources and will search the string, category strings, or array values as appropriate.\n" +
         "    random\n" +
         "      Select a random set of translation units.\n" +
+        "    unique\n" +
+        "      Do not select a translation unit if another unit with the same identity was already\n" +
+        "      selected. The default identity uses project, targetLocale, key, datatype, flavor,\n" +
+        "      context, and source.\n" +
+        "    unique:[field]+[field]+...\n" +
+        "      Same as unique, but only the listed fields form the identity. Fields are separated by\n" +
+        "      plus signs. eg. unique:key+source  (resname is accepted as an alias for key)\n" +
         "    maxunits:[number]\n" +
         "      Select a the given maximum number of translation units.\n" +
         "    maxsource:[number]\n" +
@@ -194,7 +201,7 @@ var commandOptionHelp = {
         "    maxtarget:[number]\n" +
         "      Select translation units until the given number of target words is reached.\n" +
         "  Selection criteria can be combined with a comma. All criteria must match, making the selection a\n" +
-        "  conjunction. eg. loctool select 'random,maxsource:100,project=myproject' outfile.xliff infile.xliff\n" +
+        "  conjunction. eg. loctool select 'unique:key+source,random,maxunits:100' outfile.xliff infile.xliff\n" +
         "outfile\n" +
         "  the path to the file where the selected translation units are written to\n" +
         "filename\n" +

--- a/packages/loctool/test/XliffSelect.test.js
+++ b/packages/loctool/test/XliffSelect.test.js
@@ -195,6 +195,72 @@ describe("xliff select criteria parser", function() {
         };
         expect(actual).toStrictEqual(expected);
     });
+
+    test("unique criteria with default fields", function() {
+        expect.assertions(1);
+
+        var actual = XliffSelect.parseCriteria("unique");
+        var expected = {
+            uniqueFields: [
+                "project",
+                "targetLocale",
+                "key",
+                "datatype",
+                "flavor",
+                "context",
+                "source"
+            ]
+        };
+        expect(actual).toStrictEqual(expected);
+    });
+
+    test("unique criteria with field list", function() {
+        expect.assertions(1);
+
+        var actual = XliffSelect.parseCriteria("unique:key+source");
+        var expected = {
+            uniqueFields: ["key", "source"]
+        };
+        expect(actual).toStrictEqual(expected);
+    });
+
+    test("unique criteria with resname alias", function() {
+        expect.assertions(1);
+
+        var actual = XliffSelect.parseCriteria("unique:resname+source");
+        var expected = {
+            uniqueFields: ["key", "source"]
+        };
+        expect(actual).toStrictEqual(expected);
+    });
+
+    test("unique criteria combined with other criteria", function() {
+        expect.assertions(1);
+
+        var actual = XliffSelect.parseCriteria("unique:key+source,random,maxunits:100");
+        var expected = {
+            uniqueFields: ["key", "source"],
+            random: true,
+            maxunits: 100
+        };
+        expect(actual).toStrictEqual(expected);
+    });
+
+    test("unique criteria with unknown field", function() {
+        expect.assertions(1);
+
+        expect(function() {
+            XliffSelect.parseCriteria("unique:key+bogus");
+        }).toThrow();
+    });
+
+    test("unique criteria with empty field list", function() {
+        expect.assertions(1);
+
+        expect(function() {
+            XliffSelect.parseCriteria("unique:");
+        }).toThrow();
+    });
 });
 
 describe("xliff select test edge cases", function() {
@@ -627,6 +693,72 @@ describe("xliff select translation units in xliff v1", function() {
         '</xliff>';
 
         expect(actual).toBe(expected);
+    });
+
+    test("Select keeps same key+source from different projects by default", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff_select/drop1.xliff",
+                "test/testfiles/xliff_select/drop2.xliff"
+            ]
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var units = target.getTranslationUnits();
+        // different product-name/original values mean different projects, so both
+        // copies of got.it.key / hello.key are kept, plus bye.key from drop2
+        expect(units.length).toBe(5);
+    });
+
+    test("Select with unique:key+source collapses across projects", function() {
+        expect.assertions(4);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff_select/drop1.xliff",
+                "test/testfiles/xliff_select/drop2.xliff"
+            ],
+            criteria: "unique:key+source"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var units = target.getTranslationUnits();
+        expect(units.length).toBe(3);
+        expect(units.map(function(u) { return u.key; }).sort()).toEqual([
+            "bye.key",
+            "got.it.key",
+            "hello.key"
+        ]);
+        // first-seen wins, so targets come from drop1 for the overlapping keys
+        var gotIt = units.filter(function(u) { return u.key === "got.it.key"; })[0];
+        expect(gotIt.target).toBe("one");
+    });
+
+    test("Select with unique:key+source and maxunits counts only unique units", function() {
+        expect.assertions(2);
+
+        var settings = {
+            xliffVersion: 1,
+            infiles: [
+                "test/testfiles/xliff_select/drop1.xliff",
+                "test/testfiles/xliff_select/drop2.xliff"
+            ],
+            criteria: "unique:key+source,maxunits:2"
+        };
+
+        var target = XliffSelect(settings);
+        expect(target).toBeTruthy();
+
+        var units = target.getTranslationUnits();
+        expect(units.length).toBe(2);
     });
 });
 

--- a/packages/loctool/test/testfiles/xliff_select/drop1.xliff
+++ b/packages/loctool/test/testfiles/xliff_select/drop1.xliff
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="111111" source-language="en" target-language="bn-IN" product-name="111111">
+    <body>
+      <trans-unit id="1" resname="got.it.key" restype="string">
+        <source>Got it</source>
+        <target>one</target>
+      </trans-unit>
+      <trans-unit id="2" resname="hello.key" restype="string">
+        <source>Hello</source>
+        <target>two</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/packages/loctool/test/testfiles/xliff_select/drop2.xliff
+++ b/packages/loctool/test/testfiles/xliff_select/drop2.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2">
+  <file original="222222" source-language="en" target-language="bn-IN" product-name="222222">
+    <body>
+      <trans-unit id="1" resname="got.it.key" restype="string">
+        <source>Got it</source>
+        <target>one-b</target>
+      </trans-unit>
+      <trans-unit id="2" resname="hello.key" restype="string">
+        <source>Hello</source>
+        <target>two-b</target>
+      </trans-unit>
+      <trans-unit id="3" resname="bye.key" restype="string">
+        <source>Goodbye</source>
+        <target>three</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
- During the "select" command, this change allows callers to control which fields identify already-seen translation units.
- For example if you would like to tell the selection command to view any two resources as unique if their key and their source string match, then you would use the selection criteria: 'unique:key+source'
- Without this new selection criteria, all of the fields in a resource are used to determine uniqueness.
    - That means that if you have two strings with the key "shared.cancel", the source string "Cancel", but in two separate projects, it will consider them unique because the project differentiates them.
    - On some occasions, you want to select only by key and source and ignore the project.
    - Or you might only want to differentiate by source only if you want to ensure that the selection produces a variety of resources as a sample of your overall set of translations.

Example usage:

```
loctool select unique:source,random,maxsource:100 target.xliff source1.xliff source2.xliff
```

This will randomly select resources from source1.xliff and source2.xliff where the source tags are unique (ignoring all other fields), and the output should have a maximum of 100 source words in it across all selected resources.