### PR TITLE
ilib-localedata: Fix flaky browser tests from mixed sync/async FileCache

### DIFF
--- a/.changeset/olive-jars-tickle.md
+++ b/.changeset/olive-jars-tickle.md
@@ -1,0 +1,13 @@
+---
+"ilib-localedata": patch
+---
+
+Fixed two inconsistencies in FileCache between synchronous and asynchronous loading causing flaky tests
+
+- A file loaded with loadFileSync was not counted by size(), so the same cached file
+  reported a different count depending on whether it was first loaded synchronously or
+  asynchronously. Synchronous loads now record the same promise marker in the cache
+  that asynchronous loads do.
+- Once a failed load was cached, both loadFile and loadFileSync returned null for it
+  instead of the documented undefined. A failure that is already in the cache now
+  looks the same to callers as one that was just attempted.

--- a/packages/ilib-localedata/src/FileCache.js
+++ b/packages/ilib-localedata/src/FileCache.js
@@ -2,7 +2,7 @@
  * FileCache.js - class to handle file loading and caching to prevent race conditions
  * and avoid re-attempting failed file loads
  *
- * Copyright © 2025 JEDLSoft
+ * Copyright © 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,8 +93,9 @@ class FileCache {
         // Check if we already have the data in DataCache
         const existingData = this.dataCache.getFileData(filePath);
         if (existingData !== undefined) {
-            // Return resolved promise with existing data
-            const promise = Promise.resolve(existingData);
+            // a null entry records a load that already happened and found nothing.
+            // Callers see that the same way as a first-time failure, as undefined
+            const promise = Promise.resolve(existingData === null ? undefined : existingData);
             this.dataCache.setFilePromise(filePath, promise);
             return promise;
         }
@@ -142,7 +143,9 @@ class FileCache {
         // Check if we already have the data in DataCache
         const existingData = this.dataCache.getFileData(filePath);
         if (existingData !== undefined) {
-            return existingData;
+            // a null entry records a load that already happened and found nothing.
+            // Callers see that the same way as a first-time failure, as undefined
+            return existingData === null ? undefined : existingData;
         }
 
         // Check if the loader supports sync operations. Nothing is attempted in that
@@ -157,20 +160,32 @@ class FileCache {
             // Attempt to load the file synchronously
             const data = this.loader.loadFile(filePath, { sync: true });
 
-            if (data) {
-                // Store successful load in DataCache
-                this.dataCache.setFileData(filePath, data);
-                return data;
-            } else {
-                // Store no-data result in DataCache
-                this.dataCache.setFileData(filePath, null);
-                return undefined;
-            }
+            this.recordLoad(filePath, data || null);
+            return data || undefined;
         } catch (error) {
             // Store failed load in DataCache
-            this.dataCache.setFileData(filePath, null);
+            this.recordLoad(filePath, null);
             this.logger.warn(`Failed to load file ${filePath} synchronously: ${error.message}`);
             throw error;
+        }
+    }
+
+    /**
+     * Record the result of a synchronous load. The cached promise doubles as the
+     * marker that a file has already been loaded, so a synchronous load has to
+     * record one as well. Without it, the same cached file would be counted
+     * differently depending on which method happened to load it first.
+     *
+     * @private
+     * @param {string} filePath - The path to the file that was loaded
+     * @param {Object|null} data - The file data, or null if there was none
+     */
+    recordLoad(filePath, data) {
+        this.dataCache.setFileData(filePath, data);
+        // an asynchronous load of the same file may already be in flight, and its
+        // promise is the one that its callers are waiting on, so leave it alone
+        if (!this.dataCache.getFilePromise(filePath)) {
+            this.dataCache.setFilePromise(filePath, Promise.resolve(data === null ? undefined : data));
         }
     }
 
@@ -206,9 +221,11 @@ class FileCache {
     }
 
     /**
-     * Return the number of files currently being loaded (promises in flight).
+     * Return the number of files that this cache has loaded or is loading. Files
+     * loaded synchronously count the same as files loaded asynchronously, so this
+     * does not depend on which method a caller used.
      *
-     * @returns {number} The number of files currently being loaded
+     * @returns {number} The number of files loaded or loading
      */
     size() {
         return this.dataCache.getFilePromiseCount();

--- a/packages/ilib-localedata/test/FileCache.sync.test.js
+++ b/packages/ilib-localedata/test/FileCache.sync.test.js
@@ -1,7 +1,7 @@
 /*
  * FileCache.sync.test.js - sync unit tests for the FileCache class (Node only)
  *
- * Copyright © 2025 JEDLSoft
+ * Copyright © 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,6 +167,62 @@ describe('FileCache Sync Tests (Node Only)', () => {
             const result2 = fileCache.loadFileSync(filePath);
             expect(result2).toBe(result);
         });
+
+        test('should not count a file twice when it is loaded synchronously and then asynchronously', async () => {
+            expect.assertions(4);
+
+            const filePath = 'test/testfiles/files/fr/localeinfo.json';
+            fileCache.loadFileSync(filePath);
+
+            // the synchronous load counts the same as an asynchronous one would
+            expect(fileCache.size()).toBe(1);
+            expect(fileCache.attemptCount()).toBe(1);
+
+            await fileCache.loadFile(filePath);
+
+            // the asynchronous load found the cached data rather than loading again
+            expect(fileCache.size()).toBe(1);
+            expect(fileCache.attemptCount()).toBe(1);
+        });
+
+        test('should not count a file twice when it is loaded asynchronously and then synchronously', async () => {
+            expect.assertions(4);
+
+            const filePath = 'test/testfiles/files/fr/localeinfo.json';
+            await fileCache.loadFile(filePath);
+
+            expect(fileCache.size()).toBe(1);
+            expect(fileCache.attemptCount()).toBe(1);
+
+            fileCache.loadFileSync(filePath);
+
+            // the synchronous load found the cached data rather than loading again
+            expect(fileCache.size()).toBe(1);
+            expect(fileCache.attemptCount()).toBe(1);
+        });
+
+        test('should report a failed load as undefined to both methods no matter which one attempted it', async () => {
+            expect.assertions(4);
+
+            const filePath = 'test/testfiles/files/nonexistent/file.json';
+            expect(fileCache.loadFileSync(filePath)).toBeUndefined();
+
+            // the cache records the failure as null, but callers see undefined the
+            // same way they would for a load that was never attempted before
+            expect(fileCache.loadFileSync(filePath)).toBeUndefined();
+            expect(await fileCache.loadFile(filePath)).toBeUndefined();
+            expect(fileCache.getCachedData(filePath)).toBeNull();
+        });
+
+        test('should report a failed asynchronous load as undefined to a later synchronous caller', async () => {
+            expect.assertions(3);
+
+            const filePath = 'test/testfiles/files/nonexistent/file.json';
+            expect(await fileCache.loadFile(filePath)).toBeUndefined();
+
+            expect(await fileCache.loadFile(filePath)).toBeUndefined();
+            expect(fileCache.loadFileSync(filePath)).toBeUndefined();
+        });
     });
 
     describe('removeFileFromCache', () => {
@@ -174,14 +230,14 @@ describe('FileCache Sync Tests (Node Only)', () => {
             expect.assertions(3);
 
             const filePath = 'test/testfiles/files/fr/localeinfo.json';
-            fileCache.loadFile(filePath);
+            fileCache.loadFileSync(filePath);
             expect(fileCache.size()).toBe(1);
 
             fileCache.removeFileFromCache(filePath);
             expect(fileCache.size()).toBe(0);
 
             // Should be able to load again
-            fileCache.loadFile(filePath);
+            fileCache.loadFileSync(filePath);
             expect(fileCache.size()).toBe(1);
         });
 
@@ -195,12 +251,13 @@ describe('FileCache Sync Tests (Node Only)', () => {
     });
 
     describe('clearCache', () => {
-        test('should clear all cached file promises', () => {
-            expect.assertions(3);
+        test('should clear all cached files', () => {
+            expect.assertions(4);
 
-            fileCache.loadFile('test/testfiles/files/fr/localeinfo.json');
-            fileCache.loadFile('test/testfiles/files/und/FR/localeinfo.json');
+            fileCache.loadFileSync('test/testfiles/files/fr/localeinfo.json');
+            fileCache.loadFileSync('test/testfiles/files/und/FR/localeinfo.json');
             expect(fileCache.size()).toBe(2);
+            expect(fileCache.attemptCount()).toBe(2);
 
             fileCache.clearCache();
             expect(fileCache.size()).toBe(0);
@@ -219,17 +276,25 @@ describe('FileCache Sync Tests (Node Only)', () => {
             expect.assertions(3);
 
             expect(fileCache.size()).toBe(0);
-            fileCache.loadFile('test/testfiles/files/fr/localeinfo.json');
+            fileCache.loadFileSync('test/testfiles/files/fr/localeinfo.json');
             expect(fileCache.size()).toBe(1);
-            fileCache.loadFile('test/testfiles/files/und/FR/localeinfo.json');
+            fileCache.loadFileSync('test/testfiles/files/und/FR/localeinfo.json');
             expect(fileCache.size()).toBe(2);
+        });
+
+        test('should count files that were attempted but had no data', () => {
+            expect.assertions(2);
+
+            fileCache.loadFileSync('nonexistent/file.json');
+            expect(fileCache.size()).toBe(1);
+            expect(fileCache.attemptCount()).toBe(1);
         });
 
         test('should update count when files are removed', () => {
             expect.assertions(4);
 
-            fileCache.loadFile('test/testfiles/files/fr/localeinfo.json');
-            fileCache.loadFile('test/testfiles/files/und/FR/localeinfo.json');
+            fileCache.loadFileSync('test/testfiles/files/fr/localeinfo.json');
+            fileCache.loadFileSync('test/testfiles/files/und/FR/localeinfo.json');
             expect(fileCache.size()).toBe(2);
 
             fileCache.removeFileFromCache('test/testfiles/files/fr/localeinfo.json');

--- a/packages/ilib-localedata/test/LocaleDataWeb.test.js
+++ b/packages/ilib-localedata/test/LocaleDataWeb.test.js
@@ -2,7 +2,7 @@
  * LocaleDataWeb.test.js - test the locale data class synchronously
  * on a browser
  *
- * Copyright © 2022, 2025 JEDLSoft
+ * Copyright © 2022, 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ describe("LocaleDataWeb", () => {
         expect(locData.isSync()).toBe(false);
     });
 
-    test("should create LocaleData in async mode by default", () => {
+    test("should create LocaleData in async mode by default", async () => {
         expect.assertions(2);
 
         const locData = new LocaleData({
@@ -53,6 +53,10 @@ describe("LocaleDataWeb", () => {
         });
 
         expect(actual instanceof Promise).toBe(true);
+
+        // the load writes into the globally shared cache when it settles, so it
+        // must finish inside this test instead of landing in a later one
+        await actual;
     });
 
     test("should throw error when sync loading not supported", () => {

--- a/packages/ilib-localedata/test/MergedDataCache.async.test.js
+++ b/packages/ilib-localedata/test/MergedDataCache.async.test.js
@@ -1,7 +1,7 @@
 /*
  * MergedDataCache.async.test.js - async unit tests for the MergedDataCache class (Node and Browser)
  *
- * Copyright © 2025 JEDLSoft
+ * Copyright © 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -541,6 +541,10 @@ describe('MergedDataCache Async Tests (Node and Browser)', () => {
 
             const result = mergedDataCache.loadMergedData(null, ["./test/testfiles/files3"], "info")
             expect(result).toBeDefined();
+
+            // the load writes into the globally shared cache when it settles, so it
+            // must finish inside this test instead of landing in a later one
+            await result;
         });
 
 


### PR DESCRIPTION
## Summary
- Unawaited async loads in the Karma suite were writing into the shared `DataCache` after the spec that started them had finished, which made **Test Web All** flake on Firefox (`ParsedDataCache` "Expected 1 to be 0").
- `FileCache.loadFileSync` did not record the marker that `size()` counts, so the same cached file reported a different size depending on which method loaded it first. A cached failure also leaked as `null` instead of the documented `undefined`.
- Sync tests now use `loadFileSync`, mixed-order coverage was added, and the two abandoned promises in the web/async suites are awaited.

Fixes [LXP-2236](https://jira.inside-box.net/browse/LXP-2236).

## Test plan
- [x] `pnpm --filter ilib-localedata test` (380 Jest tests)
- [x] `pnpm --filter ilib-localedata test:web` (Chrome + Firefox, 426 total)
- [ ] CI Test Web All / Test All on this PR

Made with [Cursor](https://cursor.com)